### PR TITLE
virtcontainers: Fix paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
    - go list ./... | xargs go list -f '{{.Dir}}' | xargs -L 1 ineffassign
    - go list ./... | xargs go list -f '{{.Dir}}' | xargs gofmt -s -l | wc -l | xargs -I % bash -c "test % -eq 0"
    - go build ./...
-   - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -short -coverprofile /tmp/cover.out github.com/sameo/virtcontainers
+   - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -short -coverprofile /tmp/cover.out github.com/containers/virtcontainers
 
 after_success:
    - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=/tmp/cover.out

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![Build Status](https://travis-ci.org/sameo/virtcontainers.svg?branch=master)](https://travis-ci.org/sameo/virtcontainers)
-[![Go Report Card](https://goreportcard.com/badge/github.com/sameo/virtcontainers)](https://goreportcard.com/report/github.com/sameo/virtcontainers)
+[![Build Status](https://travis-ci.org/containers/virtcontainers.svg?branch=master)](https://travis-ci.org/containers/virtcontainers)
+[![Go Report Card](https://goreportcard.com/badge/github.com/containers/virtcontainers)](https://goreportcard.com/report/github.com/containers/virtcontainers)
 [![Coverage Status](https://coveralls.io/repos/github/sameo/virtcontainers/badge.svg?branch=master)](https://coveralls.io/github/sameo/virtcontainers?branch=master)
-[![GoDoc](https://godoc.org/github.com/sameo/virtcontainers?status.svg)](https://godoc.org/github.com/sameo/virtcontainers)
+[![GoDoc](https://godoc.org/github.com/containers/virtcontainers?status.svg)](https://godoc.org/github.com/containers/virtcontainers)
 
 # virtcontainers
 

--- a/api_test.go
+++ b/api_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sameo/virtcontainers/hyperstart/mock"
+	"github.com/containers/virtcontainers/hyperstart/mock"
 )
 
 const (

--- a/example_pod_run_test.go
+++ b/example_pod_run_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	vc "github.com/sameo/virtcontainers"
+	vc "github.com/containers/virtcontainers"
 )
 
 const containerRootfs = "/var/lib/container/bundle/"

--- a/hack/virtc/README.md
+++ b/hack/virtc/README.md
@@ -38,12 +38,12 @@ $ sudo cp clear-11130-containers.img /usr/share/clear-containers/clear-container
 
 _Download virtc_
 ```
-$ go get github.com/sameo/virtcontainers
+$ go get github.com/containers/virtcontainers
 ```
 
 _Build virtc_
 ```
-$ cd $GOPATH/src/github.com/sameo/virtcontainers
+$ cd $GOPATH/src/github.com/containers/virtcontainers
 $ cd virtc && go build
 ```
 

--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -26,7 +26,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/urfave/cli"
 
-	vc "github.com/sameo/virtcontainers"
+	vc "github.com/containers/virtcontainers"
 )
 
 var podConfigFlags = []cli.Flag{

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/golang/glog"
 
+	"github.com/containers/virtcontainers/hyperstart"
 	hyperJson "github.com/hyperhq/runv/hyperstart/api/json"
-	"github.com/sameo/virtcontainers/hyperstart"
 )
 
 var defaultSockPathTemplates = []string{"/tmp/hyper-pod-%s.sock", "/tmp/tty-pod%s.sock"}

--- a/hyperstart/hyperstart_test.go
+++ b/hyperstart/hyperstart_test.go
@@ -23,8 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containers/virtcontainers/hyperstart/mock"
 	hyper "github.com/hyperhq/runv/hyperstart/api/json"
-	"github.com/sameo/virtcontainers/hyperstart/mock"
 )
 
 const (


### PR DESCRIPTION
Moving to github.com/containers broke a few imports and URLs.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>