### PR TITLE
hyperstart: Don't special-case destroypod

### DIFF
--- a/hyperstart/hyperstart.go
+++ b/hyperstart/hyperstart.go
@@ -402,10 +402,6 @@ func (h *Hyperstart) SendCtlMessage(cmd string, data []byte) (*hyper.DecodedMess
 		return nil, err
 	}
 
-	if code == hyper.INIT_DESTROYPOD {
-		return nil, nil
-	}
-
 	// Wait for answer
 	resp, err := h.expectReadingCmd(hyper.INIT_ACK)
 	if err != nil {

--- a/hyperstart/hyperstart_test.go
+++ b/hyperstart/hyperstart_test.go
@@ -602,7 +602,7 @@ func testSendCtlMessage(t *testing.T, cmd string) {
 		t.Fatal()
 	}
 
-	if cmd != DestroyPod && msg.Code != hyper.INIT_ACK {
+	if msg.Code != hyper.INIT_ACK {
 		t.Fatal()
 	}
 }

--- a/hyperstart/mock/hyperstart.go
+++ b/hyperstart/mock/hyperstart.go
@@ -260,9 +260,7 @@ func (h *Hyperstart) handleCtl() {
 		// hyperstart to fail and test the reaction of proxy/clients
 		h.logf("ctl: <-- command %s executed successfully\n", cmdName)
 
-		if cmdName != DestroyPod {
-			h.SendMessage(hyper.INIT_ACK, nil)
-		}
+		h.SendMessage(hyper.INIT_ACK, nil)
 
 	}
 


### PR DESCRIPTION
We're supposed to be able to receive an ack message after a destroypod.
The fact that we didn't was caused by our use of hyperstart as a daemon
(vs an init process) and some bugs introduced by that.

With those fixed, we have the destroypod ack message back.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>