### PR TITLE
Make the hyperstart package follow upstream changes and fix ctl panic

### DIFF
--- a/hyperstart/hyperstart.go
+++ b/hyperstart/hyperstart.go
@@ -43,7 +43,6 @@ const (
 	Error            = "error"
 	WinSize          = "winsize"
 	Ping             = "ping"
-	FinishPod        = "finishpod"
 	Next             = "next"
 	WriteFile        = "writefile"
 	ReadFile         = "readfile"

--- a/hyperstart/hyperstart.go
+++ b/hyperstart/hyperstart.go
@@ -133,8 +133,6 @@ func (h *Hyperstart) CloseSockets() error {
 		if err != nil {
 			return err
 		}
-
-		h.ctl = nil
 	}
 
 	if h.io != nil {
@@ -142,8 +140,6 @@ func (h *Hyperstart) CloseSockets() error {
 		if err != nil {
 			return err
 		}
-
-		h.io = nil
 	}
 
 	return nil

--- a/hyperstart/mock/hyperstart.go
+++ b/hyperstart/mock/hyperstart.go
@@ -42,7 +42,6 @@ const (
 	Error            = "error"
 	WinSize          = "winsize"
 	Ping             = "ping"
-	FinishPod        = "finishpod"
 	Next             = "next"
 	WriteFile        = "writefile"
 	ReadFile         = "readfile"


### PR DESCRIPTION
The first commit is to fix the hyperstart package as upstream has renamed a payload name, breaking the compilation.

More importantly, the second commit fixes a panic that can occur when killing the shim.

Note that travis fails because it got gets the current hyperstart package, which doesn't have the fix.