### PR TITLE
hyperstart: Don't reset the connections to nil in CloseSockets()

### DIFF
--- a/hyperstart/hyperstart.go
+++ b/hyperstart/hyperstart.go
@@ -134,8 +134,6 @@ func (h *Hyperstart) CloseSockets() error {
 		if err != nil {
 			return err
 		}
-
-		h.ctl = nil
 	}
 
 	if h.io != nil {
@@ -143,8 +141,6 @@ func (h *Hyperstart) CloseSockets() error {
 		if err != nil {
 			return err
 		}
-
-		h.io = nil
 	}
 
 	return nil


### PR DESCRIPTION
There's a problem in reseting those sockets to nil when
CloseSockets() is called but other hyperstart methods are
being run in go routines. The methods in the goroutines
end up trying to dereference nil.

It's safer to just close the socket so the goroutines in
flight can still can Read() or Write() on them, which is
exit with io.EOF.

This trace is from killing the cc-shim process trying to
send a CTL message in the middle of tearing down the VM
(so CTL socket is closed):

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x58 pc=0x4e0044]

    goroutine 56 [running]:
    panic(0x540220, 0xc4200100f0)
    	/home/damien/go-1.7/src/runtime/panic.go:500 +0x1a1
    github.com/containers/virtcontainers/hyperstart.(*Hyperstart).writeCtlMessage(0xc4200ce600, 0xc4201d3d08, 0xc400000012, 0x0)
    	github.com/containers/virtcontainers/hyperstart/hyperstart.go:255 +0x1f4
    github.com/containers/virtcontainers/hyperstart.(*Hyperstart).SendCtlMessage(0xc4200ce600, 0xc42012f830, 0xd, 0xc4200ce720, 0x5d, 0x60, 0x0, 0x0, 0x0)
    	github.com/containers/virtcontainers/hyperstart/hyperstart.go:400 +0x139
    main.(*vm).SendMessage(0xc4200ce660, 0xc42012f830, 0xd, 0xc4200ce720, 0x5d, 0x60, 0x4, 0x5)
    	github.com/01org/cc-oci-runtime/proxy/vm.go:203 +0x64
    main.hyperHandler(0xc42012a360, 0x82, 0x90, 0x540820, 0xc4201bc5a0, 0xc4201de060)
    	github.com/01org/cc-oci-runtime/proxy/proxy.go:243 +0x248
    main.(*protocol).handleRequest(0xc420026040, 0xc4201d3ee0, 0xc4201bc8d0, 0xc4201de060, 0x0)
    	github.com/01org/cc-oci-runtime/proxy/protocol.go:95 +0xca
    main.(*protocol).Serve(0xc420026040, 0x60bcc0, 0xc4201120b0, 0x540820, 0xc4201bc5a0, 0x0, 0x0)
    	github.com/01org/cc-oci-runtime/proxy/protocol.go:129 +0x181
    main.(*proxy).serveNewClient(0xc42000c6c0, 0xc420026040, 0x60bcc0, 0xc4201120b0)
    	github.com/01org/cc-oci-runtime/proxy/proxy.go:314 +0x137
    created by main.(*proxy).serve
    	github.com/01org/cc-oci-runtime/proxy/proxy.go:341 +0x4a5

Not that I had a similar fix before we moved to virtconainers, but it
got lost.  See cc-oci-runtime commit:

    commit 617fb27b489a0e893f9aad87218cd4e19a27f569
    Author: Damien Lespiau <damien.lespiau@intel.com>
    Date:   Fri Oct 14 12:38:16 2016 +0100

      proxy/vm: Set ctl/io sockets to nil after goroutine have finished

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>
Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>