### PR TITLE
unit: Log errors when they're not nil

### DIFF
--- a/agent_test.go
+++ b/agent_test.go
@@ -26,11 +26,11 @@ func testSetAgentType(t *testing.T, value string, expected AgentType) {
 
 	err := (&agentType).Set(value)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	if agentType != expected {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 

--- a/api_test.go
+++ b/api_test.go
@@ -115,13 +115,13 @@ func TestCreatePodNoopAgentSuccessful(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -130,13 +130,13 @@ func TestCreatePodHyperstartAgentSuccessful(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatalf("%s", err)
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -154,18 +154,18 @@ func TestDeletePodNoopAgentSuccessful(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	p, err = DeletePod(p.id)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	_, err = os.Stat(podDir)
@@ -179,23 +179,23 @@ func TestDeletePodHyperstartAgentSuccessful(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	p, err = DeletePod(p.id)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	_, err = os.Stat(podDir)
 	if err == nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -214,18 +214,18 @@ func TestStartPodNoopAgentSuccessful(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	p, err = StartPod(p.id)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -252,18 +252,18 @@ func TestStartPodHyperstartAgentSuccessful(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	p, err = StartPod(p.id)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -282,23 +282,23 @@ func TestStopPodNoopAgentSuccessful(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	p, err = StartPod(p.id)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	p, err = StopPod(p.id)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -315,20 +315,20 @@ func TestStopPodHyperstartAgentSuccessful(t *testing.T) {
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
 		mock.Stop()
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
 		mock.Stop()
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	p, err = StartPod(p.id)
 	if p == nil || err != nil {
 		mock.Stop()
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	mock.Stop()
@@ -337,7 +337,7 @@ func TestStopPodHyperstartAgentSuccessful(t *testing.T) {
 
 	p, err = StopPod(p.id)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -356,13 +356,13 @@ func TestRunPodNoopAgentSuccessful(t *testing.T) {
 
 	p, err := RunPod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -379,13 +379,13 @@ func TestRunPodHyperstartAgentSuccessful(t *testing.T) {
 
 	p, err := RunPod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -405,12 +405,12 @@ func TestListPodSuccessful(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	err = ListPod()
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -428,12 +428,12 @@ func TestStatusPodSuccessful(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	err = StatusPod(p.id)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -442,7 +442,7 @@ func TestListPodFailingFetchPodConfig(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	path := filepath.Join(configStoragePath, p.id)
@@ -459,7 +459,7 @@ func TestListPodFailingFetchPodState(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	path := filepath.Join(runStoragePath, p.id)
@@ -488,26 +488,26 @@ func TestCreateContainerSuccessful(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	contConfig := newTestContainerConfigNoop(contID)
 
 	c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	contDir := filepath.Join(podDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -517,12 +517,12 @@ func TestCreateContainerFailingNoPod(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	p, err = DeletePod(p.id)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
@@ -535,7 +535,7 @@ func TestCreateContainerFailingNoPod(t *testing.T) {
 
 	c, err := CreateContainer(p.id, contConfig)
 	if c != nil || err == nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -545,31 +545,31 @@ func TestDeleteContainerSuccessful(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	contConfig := newTestContainerConfigNoop(contID)
 
 	c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	contDir := filepath.Join(podDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	c, err = DeleteContainer(p.id, contID)
 	if c == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	_, err = os.Stat(contDir)
@@ -595,13 +595,13 @@ func TestDeleteContainerFailingNoContainer(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	c, err := DeleteContainer(p.id, contID)
@@ -616,36 +616,36 @@ func TestStartContainerNoopAgentSuccessful(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	p, err = StartPod(p.id)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	contConfig := newTestContainerConfigNoop(contID)
 
 	c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	contDir := filepath.Join(podDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	c, err = StartContainer(p.id, contID)
 	if c == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -663,20 +663,20 @@ func TestStartContainerHyperstartAgentSuccessful(t *testing.T) {
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
 		mock.Stop()
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
 		mock.Stop()
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	p, err = StartPod(p.id)
 	if p == nil || err != nil {
 		mock.Stop()
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	mock.Stop()
@@ -685,13 +685,13 @@ func TestStartContainerHyperstartAgentSuccessful(t *testing.T) {
 
 	c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	contDir := filepath.Join(podDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	mock.Start()
@@ -699,7 +699,7 @@ func TestStartContainerHyperstartAgentSuccessful(t *testing.T) {
 
 	c, err = StartContainer(p.id, contID)
 	if c == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -720,13 +720,13 @@ func TestStartContainerFailingNoContainer(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	c, err := StartContainer(p.id, contID)
@@ -741,26 +741,26 @@ func TestStartContainerFailingPodNotStarted(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	contConfig := newTestContainerConfigNoop(contID)
 
 	c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	contDir := filepath.Join(podDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	c, err = StartContainer(p.id, contID)
@@ -775,41 +775,41 @@ func TestStopContainerNoopAgentSuccessful(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	p, err = StartPod(p.id)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	contConfig := newTestContainerConfigNoop(contID)
 
 	c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	contDir := filepath.Join(podDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	c, err = StartContainer(p.id, contID)
 	if c == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	c, err = StopContainer(p.id, contID)
 	if c == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -827,20 +827,20 @@ func TestStopContainerHyperstartAgentSuccessful(t *testing.T) {
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
 		mock.Stop()
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
 		mock.Stop()
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	p, err = StartPod(p.id)
 	if p == nil || err != nil {
 		mock.Stop()
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	mock.Stop()
@@ -849,13 +849,13 @@ func TestStopContainerHyperstartAgentSuccessful(t *testing.T) {
 
 	c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	contDir := filepath.Join(podDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	mock.Start()
@@ -863,7 +863,7 @@ func TestStopContainerHyperstartAgentSuccessful(t *testing.T) {
 	c, err = StartContainer(p.id, contID)
 	if c == nil || err != nil {
 		mock.Stop()
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	mock.Stop()
@@ -872,7 +872,7 @@ func TestStopContainerHyperstartAgentSuccessful(t *testing.T) {
 
 	c, err = StopContainer(p.id, contID)
 	if c == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -893,13 +893,13 @@ func TestStopContainerFailingNoContainer(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	c, err := StopContainer(p.id, contID)
@@ -914,31 +914,31 @@ func TestStopContainerFailingContNotStarted(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	p, err = StartPod(p.id)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	contConfig := newTestContainerConfigNoop(contID)
 
 	c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	contDir := filepath.Join(podDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	c, err = StopContainer(p.id, contID)
@@ -953,43 +953,43 @@ func TestEnterContainerNoopAgentSuccessful(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	p, err = StartPod(p.id)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	contConfig := newTestContainerConfigNoop(contID)
 
 	c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	contDir := filepath.Join(podDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	c, err = StartContainer(p.id, contID)
 	if c == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	cmd := newBasicTestCmd()
 
 	c, err = EnterContainer(p.id, contID, cmd)
 	if c == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -1007,20 +1007,20 @@ func TestEnterContainerHyperstartAgentSuccessful(t *testing.T) {
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
 		mock.Stop()
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
 		mock.Stop()
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	p, err = StartPod(p.id)
 	if p == nil || err != nil {
 		mock.Stop()
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	mock.Stop()
@@ -1029,13 +1029,13 @@ func TestEnterContainerHyperstartAgentSuccessful(t *testing.T) {
 
 	c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	contDir := filepath.Join(podDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	mock.Start()
@@ -1043,7 +1043,7 @@ func TestEnterContainerHyperstartAgentSuccessful(t *testing.T) {
 	c, err = StartContainer(p.id, contID)
 	if c == nil || err != nil {
 		mock.Stop()
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	mock.Stop()
@@ -1055,7 +1055,7 @@ func TestEnterContainerHyperstartAgentSuccessful(t *testing.T) {
 
 	c, err = EnterContainer(p.id, contID, cmd)
 	if c == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -1078,13 +1078,13 @@ func TestEnterContainerFailingNoContainer(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	cmd := newBasicTestCmd()
@@ -1101,31 +1101,31 @@ func TestEnterContainerFailingContNotStarted(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	p, err = StartPod(p.id)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	contConfig := newTestContainerConfigNoop(contID)
 
 	c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	contDir := filepath.Join(podDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	cmd := newBasicTestCmd()
@@ -1142,31 +1142,31 @@ func TestStatusContainerSuccessful(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	contConfig := newTestContainerConfigNoop(contID)
 
 	c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	contDir := filepath.Join(podDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	err = StatusContainer(p.id, contID)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -1176,13 +1176,13 @@ func TestStatusContainerFailing(t *testing.T) {
 
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	podDir := filepath.Join(configStoragePath, p.id)
 	_, err = os.Stat(podDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	err = StatusContainer(p.id, contID)

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -55,31 +55,31 @@ func TestFilesystemCreateAllResourcesSuccessful(t *testing.T) {
 
 	err := fs.createAllResources(pod)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	// Check resources
 	_, err = os.Stat(podConfigPath)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	_, err = os.Stat(podRunPath)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	for _, container := range containers {
 		configPath := filepath.Join(configStoragePath, testPodID, container.ID)
 		_, err = os.Stat(configPath)
 		if err != nil {
-			t.Fatal()
+			t.Fatal(err)
 		}
 
 		runPath := filepath.Join(runStoragePath, testPodID, container.ID)
 		_, err = os.Stat(runPath)
 		if err != nil {
-			t.Fatal()
+			t.Fatal(err)
 		}
 	}
 }
@@ -133,12 +133,12 @@ func TestFilesystemStoreFileSuccessfulNotExisting(t *testing.T) {
 
 	err := fs.storeFile(path, data)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	fileData, err := ioutil.ReadFile(path)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	if string(fileData) != expected {
@@ -154,7 +154,7 @@ func TestFilesystemStoreFileSuccessfulExisting(t *testing.T) {
 
 	f, err := os.Create(path)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 	f.Close()
 
@@ -167,12 +167,12 @@ func TestFilesystemStoreFileSuccessfulExisting(t *testing.T) {
 
 	err = fs.storeFile(path, data)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	fileData, err := ioutil.ReadFile(path)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	if string(fileData) != expected {
@@ -203,20 +203,20 @@ func TestFilesystemFetchFileSuccessful(t *testing.T) {
 
 	f, err := os.Create(path)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	dataToWrite := "{\"Field1\":\"value1\",\"Field2\":\"value2\"}"
 	n, err := f.WriteString(dataToWrite)
 	if err != nil || n != len(dataToWrite) {
 		f.Close()
-		t.Fatal()
+		t.Fatal(err)
 	}
 	f.Close()
 
 	err = fs.fetchFile(path, &data)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	expected := TestNoopStructure{
@@ -251,7 +251,7 @@ func TestFilesystemFetchFileFailingUnMarshalling(t *testing.T) {
 
 	f, err := os.Create(path)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 	f.Close()
 
@@ -274,20 +274,20 @@ func TestFilesystemFetchContainerConfigSuccessful(t *testing.T) {
 
 	f, err := os.Create(path)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	configData := fmt.Sprintf("{\"ID\":\"%s\",\"RootFs\":\"%s\"}", contID, rootFs)
 	n, err := f.WriteString(configData)
 	if err != nil || n != len(configData) {
 		f.Close()
-		t.Fatal()
+		t.Fatal(err)
 	}
 	f.Close()
 
 	data, err := fs.fetchContainerConfig(testPodID, contID)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	expected := ContainerConfig{

--- a/hypervisor_test.go
+++ b/hypervisor_test.go
@@ -27,7 +27,7 @@ func testSetHypervisorType(t *testing.T, value string, expected HypervisorType) 
 
 	err := (&hypervisorType).Set(value)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	if hypervisorType != expected {
@@ -82,7 +82,7 @@ func TestStringFromUnknownHypervisorType(t *testing.T) {
 func testNewHypervisorFromHypervisorType(t *testing.T, hypervisorType HypervisorType, expected hypervisor) {
 	hy, err := newHypervisor(hypervisorType)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	if reflect.DeepEqual(hy, expected) == false {

--- a/mock_hypervisor_test.go
+++ b/mock_hypervisor_test.go
@@ -44,7 +44,7 @@ func TestMockHypervisorInit(t *testing.T) {
 
 	err = m.init(rightConfig)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -55,7 +55,7 @@ func TestMockHypervisorCreatePod(t *testing.T) {
 
 	err := m.createPod(config)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -71,7 +71,7 @@ func TestMockHypervisorStartPod(t *testing.T) {
 	case <-startCh:
 		break
 	case <-time.After(time.Second):
-		t.Fatal()
+		t.Fatal("Timeout waiting for start notification")
 	}
 }
 
@@ -80,7 +80,7 @@ func TestMockHypervisorStopPod(t *testing.T) {
 
 	err := m.stopPod()
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -89,6 +89,6 @@ func TestMockHypervisorAddDevice(t *testing.T) {
 
 	err := m.addDevice(nil, imgDev)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }

--- a/noop_agent_test.go
+++ b/noop_agent_test.go
@@ -26,7 +26,7 @@ func TestNoopAgentInit(t *testing.T) {
 
 	err := n.init(pod, nil)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -35,7 +35,7 @@ func TestNoopAgentStartAgent(t *testing.T) {
 
 	err := n.startAgent()
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -47,7 +47,7 @@ func TestNoopAgentExec(t *testing.T) {
 
 	err := n.exec(pod, container, cmd)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -57,7 +57,7 @@ func TestNoopAgentStartPod(t *testing.T) {
 
 	err := n.startPod(podConfig)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -67,7 +67,7 @@ func TestNoopAgentStopPod(t *testing.T) {
 
 	err := n.stopPod(pod)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -76,7 +76,7 @@ func TestNoopAgentStopAgent(t *testing.T) {
 
 	err := n.stopAgent()
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -87,7 +87,7 @@ func TestNoopAgentStartContainer(t *testing.T) {
 
 	err := n.startContainer(pod, contConfig)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -98,6 +98,6 @@ func TestNoopAgentStopContainer(t *testing.T) {
 
 	err := n.stopContainer(pod, container)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }

--- a/nsenter_test.go
+++ b/nsenter_test.go
@@ -26,7 +26,7 @@ func testNsEnterFormatArgs(t *testing.T, args []string, expected string) {
 
 	cmd, err := nsenter.formatArgs(args)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	if strings.Join(cmd, " ") != expected {

--- a/pod_test.go
+++ b/pod_test.go
@@ -310,7 +310,7 @@ func TestVolumesSetSuccessful(t *testing.T) {
 
 	err := volumes.Set(volStr)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	if reflect.DeepEqual(*volumes, expected) == false {
@@ -393,7 +393,7 @@ func TestSocketsSetSuccessful(t *testing.T) {
 
 	err := sockets.Set(sockStr)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	if reflect.DeepEqual(*sockets, expected) == false {
@@ -461,7 +461,7 @@ func TestPodEnterSuccessful(t *testing.T) {
 
 	err := pod.enter([]string{})
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -524,7 +524,7 @@ func TestPodDeleteContainerStateSuccessful(t *testing.T) {
 	path := filepath.Join(runStoragePath, testPodID, contID)
 	err := os.MkdirAll(path, os.ModeDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	stateFilePath := filepath.Join(path, stateFile)
@@ -533,17 +533,17 @@ func TestPodDeleteContainerStateSuccessful(t *testing.T) {
 
 	_, err = os.Create(stateFilePath)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	_, err = os.Stat(stateFilePath)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	err = pod.deleteContainerState(contID)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	_, err = os.Stat(stateFilePath)
@@ -593,7 +593,7 @@ func TestPodDeleteContainersStateSuccessful(t *testing.T) {
 		path := filepath.Join(runStoragePath, testPodID, c.ID)
 		err = os.MkdirAll(path, os.ModeDir)
 		if err != nil {
-			t.Fatal()
+			t.Fatal(err)
 		}
 
 		stateFilePath := filepath.Join(path, stateFile)
@@ -602,18 +602,18 @@ func TestPodDeleteContainersStateSuccessful(t *testing.T) {
 
 		_, err = os.Create(stateFilePath)
 		if err != nil {
-			t.Fatal()
+			t.Fatal(err)
 		}
 
 		_, err = os.Stat(stateFilePath)
 		if err != nil {
-			t.Fatal()
+			t.Fatal(err)
 		}
 	}
 
 	err = pod.deleteContainersState()
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	for _, c := range containers {
@@ -673,7 +673,7 @@ func TestPodCheckContainerStateFailingNotExpectedState(t *testing.T) {
 	path := filepath.Join(runStoragePath, testPodID, contID)
 	err := os.MkdirAll(path, os.ModeDir)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	stateFilePath := filepath.Join(path, stateFile)
@@ -682,7 +682,7 @@ func TestPodCheckContainerStateFailingNotExpectedState(t *testing.T) {
 
 	f, err := os.Create(stateFilePath)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	stateData := "{\"state\":\"ready\"}"
@@ -695,7 +695,7 @@ func TestPodCheckContainerStateFailingNotExpectedState(t *testing.T) {
 
 	_, err = os.Stat(stateFilePath)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	err = pod.checkContainerState(contID, statePaused)

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -48,7 +48,7 @@ func testQemuBuildKernelParams(t *testing.T, kernelParams []Param, expected stri
 
 	err := q.buildKernelParams(qemuConfig)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	if strings.Join(q.kernelParams, " ") != expected {
@@ -285,13 +285,13 @@ func TestQemuAppendImage(t *testing.T) {
 
 	imageFile, err := os.Open(q.config.ImagePath)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 	defer imageFile.Close()
 
 	imageStat, err := imageFile.Stat()
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	expectedOut := []ciaoQemu.Device{
@@ -309,7 +309,7 @@ func TestQemuAppendImage(t *testing.T) {
 
 	devices, err = q.appendImage(devices, podConfig)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	if reflect.DeepEqual(devices, expectedOut) == false {
@@ -323,7 +323,7 @@ func TestQemuInit(t *testing.T) {
 
 	err := q.init(qemuConfig)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	if reflect.DeepEqual(qemuConfig, q.config) == false {
@@ -397,7 +397,7 @@ func testQemuAddDevice(t *testing.T, devInfo interface{}, devType deviceType, ex
 
 	err := q.addDevice(devInfo, devType)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	if reflect.DeepEqual(q.qemuConfig.Devices, expected) == false {

--- a/spawner_test.go
+++ b/spawner_test.go
@@ -32,7 +32,7 @@ func TestSpawnerTypeSet(t *testing.T) {
 	for _, sType := range testSpawnerTypeList {
 		err = (&s).Set(string(sType))
 		if err != nil {
-			t.Fatal()
+			t.Fatal(err)
 		}
 
 		if s != sType {

--- a/syscall_test.go
+++ b/syscall_test.go
@@ -42,12 +42,12 @@ func TestBindMountFailingMount(t *testing.T) {
 
 	_, err := os.OpenFile(fakeSource, os.O_CREATE, mountPerm)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	err = os.Symlink(fakeSource, source)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	err = bindMount(source, "")
@@ -65,17 +65,17 @@ func TestBindMountSuccessful(t *testing.T) {
 
 	err := os.MkdirAll(source, mountPerm)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	err = os.MkdirAll(dest, mountPerm)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	err = bindMount(source, dest)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	syscall.Unmount(dest, 0)
@@ -96,7 +96,7 @@ func TestEnsureDestinationExistsWrongParentDir(t *testing.T) {
 
 	_, err := os.OpenFile(source, os.O_CREATE, mountPerm)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	err = ensureDestinationExists(source, dest)
@@ -113,12 +113,12 @@ func TestEnsureDestinationExistsSuccessfulSrcDir(t *testing.T) {
 
 	err := os.MkdirAll(source, mountPerm)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	err = ensureDestinationExists(source, dest)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }
 
@@ -130,11 +130,11 @@ func TestEnsureDestinationExistsSuccessfulSrcFile(t *testing.T) {
 
 	_, err := os.OpenFile(source, os.O_CREATE, mountPerm)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	err = ensureDestinationExists(source, dest)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
We should pass non nil errors to Fatal().

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>