### PR TITLE
network: cni: Add unit testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,22 @@ before_install:
   - go get github.com/golang/lint/golint
   - go get github.com/client9/misspell/cmd/misspell
   - go get github.com/01org/ciao/test-cases
+  - go get github.com/containernetworking/cni/libcni
+  - go get github.com/containernetworking/cni/pkg/types
+  - go get github.com/containernetworking/cni/pkg/ns
+
+install:
+  - mkdir -p $HOME/build
+  - pushd $HOME/build
+  - git clone https://github.com/containernetworking/cni.git
+  - cd cni
+  - ./build
+  - sudo mkdir -p /tmp/cni/bin
+  - sudo cp ./bin/bridge /tmp/cni/bin/cni-bridge
+  - sudo cp ./bin/loopback /tmp/cni/bin/loopback
+  - sudo cp ./bin/host-local /tmp/cni/bin/host-local
+  - popd
+  - go get -t -v ./...
 
 script:
    - go env
@@ -28,7 +44,7 @@ script:
    - go list ./... | xargs go list -f '{{.Dir}}' | xargs -L 1 ineffassign
    - go list ./... | xargs go list -f '{{.Dir}}' | xargs gofmt -s -l | wc -l | xargs -I % bash -c "test % -eq 0"
    - go build ./...
-   - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -short -coverprofile /tmp/cover.out github.com/containers/virtcontainers/...
+   - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin:/tmp/cni/bin $GOPATH/bin/test-cases -v -timeout 9 -short -coverprofile /tmp/cover.out github.com/containers/virtcontainers/...
 
 after_success:
    - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=/tmp/cover.out

--- a/network/cni/cni_test.go
+++ b/network/cni/cni_test.go
@@ -1,0 +1,395 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cni
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/containernetworking/cni/libcni"
+	"github.com/containernetworking/cni/pkg/ns"
+)
+
+var testConfDir = "/tmp/cni/net.d"
+var testBinDir = "/tmp/cni/bin"
+var testWrongConfDir = "/tmp/cni/wrong"
+var testDefFile = "10-test_network.conf"
+var testLoFile = "99-test_loopback.conf"
+var testWrongFile = "100-test_error.conf"
+
+var testLoFileContent = []byte(`{
+    "cniVersion": "0.2.0",
+    "name": "testlonetwork",
+    "type": "loopback"
+}`)
+
+var testLoFileContentNoName = []byte(`{
+    "cniVersion": "0.2.0",
+    "type": "loopback"
+}`)
+
+var testDefFileContent = []byte(`{
+    "cniVersion": "0.2.0",
+    "name": "testdefnetwork",
+    "type": "cni-bridge",
+    "bridge": "cni0",
+    "isGateway": true,
+    "ipMasq": true,
+    "ipam": {
+        "type": "host-local",
+        "subnet": "10.88.0.0/16",
+        "routes": [
+            { "dst": "0.0.0.0/0" }
+        ]
+    }
+}`)
+
+var testDefFileContentNoName = []byte(`{
+    "cniVersion": "0.2.0",
+    "type": "cni-bridge",
+    "bridge": "cni0",
+    "isGateway": true,
+    "ipMasq": true,
+    "ipam": {
+        "type": "host-local",
+        "subnet": "10.88.0.0/16",
+        "routes": [
+            { "dst": "0.0.0.0/0" }
+        ]
+    }
+}`)
+
+var testWrongFileContent = []byte(`{
+    "cniVersion "0.2.0",
+    "type": "loopback"
+}`)
+
+func createLoNetwork(t *testing.T) {
+	loFile := filepath.Join(testConfDir, testLoFile)
+
+	f, err := os.Create(loFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	_, err = f.Write(testLoFileContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createLoNetworkNoName(t *testing.T) {
+	loFile := filepath.Join(testConfDir, testLoFile)
+
+	f, err := os.Create(loFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	_, err = f.Write(testLoFileContentNoName)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createDefNetwork(t *testing.T) {
+	defFile := filepath.Join(testConfDir, testDefFile)
+
+	f, err := os.Create(defFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	_, err = f.Write(testDefFileContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createDefNetworkNoName(t *testing.T) {
+	defFile := filepath.Join(testConfDir, testDefFile)
+
+	f, err := os.Create(defFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	_, err = f.Write(testDefFileContentNoName)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createWrongNetwork(t *testing.T) {
+	wrongFile := filepath.Join(testConfDir, testWrongFile)
+
+	f, err := os.Create(wrongFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	_, err = f.Write(testWrongFileContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func removeLoNetwork(t *testing.T) {
+	loFile := filepath.Join(testConfDir, testLoFile)
+	err := os.Remove(loFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func removeDefNetwork(t *testing.T) {
+	defFile := filepath.Join(testConfDir, testDefFile)
+	err := os.Remove(defFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func removeWrongNetwork(t *testing.T) {
+	wrongFile := filepath.Join(testConfDir, testWrongFile)
+	err := os.Remove(wrongFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNewNetworkPluginSuccessful(t *testing.T) {
+	createLoNetwork(t)
+	defer removeLoNetwork(t)
+	createDefNetwork(t)
+	defer removeDefNetwork(t)
+
+	netPlugin, err := NewNetworkPluginWithArgs(testConfDir, testBinDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if netPlugin.loNetwork == nil {
+		t.Fatal("Invalid local network")
+	}
+
+	if netPlugin.defNetwork == nil {
+		t.Fatal("Invalid default network")
+	}
+
+	if netPlugin.loNetwork.name != "testlonetwork" {
+		t.Fatal("Invalid local network name")
+	}
+
+	if netPlugin.defNetwork.name != "testdefnetwork" {
+		t.Fatal("Invalid default network name")
+	}
+}
+
+func TestNewNetworkPluginSuccessfulNoName(t *testing.T) {
+	createLoNetworkNoName(t)
+	defer removeLoNetwork(t)
+	createDefNetworkNoName(t)
+	defer removeDefNetwork(t)
+
+	netPlugin, err := NewNetworkPluginWithArgs(testConfDir, testBinDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if netPlugin.loNetwork == nil {
+		t.Fatal("Invalid local network")
+	}
+
+	if netPlugin.defNetwork == nil {
+		t.Fatal("Invalid default network")
+	}
+
+	if netPlugin.loNetwork.name != "lo" {
+		t.Fatal("Invalid local network name")
+	}
+
+	if netPlugin.defNetwork.name != "net" {
+		t.Fatal("Invalid default network name")
+	}
+}
+
+func TestNewNetworkPluginFailureNoNetwork(t *testing.T) {
+	netPlugin, err := NewNetworkPluginWithArgs(testConfDir, testBinDir)
+	if err == nil || netPlugin != nil {
+		t.Fatal("Should fail because no available network")
+	}
+}
+
+func TestNewNetworkPluginFailureNoConfDir(t *testing.T) {
+	netPlugin, err := NewNetworkPluginWithArgs(testWrongConfDir, testBinDir)
+	if err == nil || netPlugin != nil {
+		t.Fatal("Should fail because configuration directory does not exist")
+	}
+}
+
+func TestNewNetworkPluginFailureWrongNetwork(t *testing.T) {
+	createWrongNetwork(t)
+	defer removeWrongNetwork(t)
+
+	netPlugin, err := NewNetworkPluginWithArgs(testConfDir, testBinDir)
+	if err == nil || netPlugin != nil {
+		t.Fatal("Should fail because of wrong network definition")
+	}
+}
+
+func TestBuildRuntimeConf(t *testing.T) {
+	expected := libcni.RuntimeConf{
+		ContainerID: "testPodID",
+		NetNS:       "testPodNetNSPath",
+		IfName:      "testIfName",
+	}
+
+	runtimeConf := buildRuntimeConf("testPodID", "testPodNetNSPath", "testIfName")
+
+	if reflect.DeepEqual(*runtimeConf, expected) == false {
+		t.Fatal("Runtime configuration different from expected one")
+	}
+}
+
+func TestAddNetworkSuccessful(t *testing.T) {
+	createLoNetworkNoName(t)
+	defer removeLoNetwork(t)
+	createDefNetworkNoName(t)
+	defer removeDefNetwork(t)
+
+	netNsHandle, err := ns.NewNS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer netNsHandle.Close()
+
+	testNetNsPath := netNsHandle.Path()
+
+	netPlugin, err := NewNetworkPluginWithArgs(testConfDir, testBinDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = netPlugin.AddNetwork("testPodID", testNetNsPath, "testIfName")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAddNetworkFailureUnknownNetNs(t *testing.T) {
+	createLoNetworkNoName(t)
+	defer removeLoNetwork(t)
+	createDefNetworkNoName(t)
+	defer removeDefNetwork(t)
+
+	testNetNsPath := "/var/run/netns/testNetNs"
+
+	netPlugin, err := NewNetworkPluginWithArgs(testConfDir, testBinDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = netPlugin.AddNetwork("testPodID", testNetNsPath, "testIfName")
+	if err == nil {
+		t.Fatalf("Should fail because netns %s does not exist", testNetNsPath)
+	}
+}
+
+func TestRemoveNetworkSuccessful(t *testing.T) {
+	createLoNetworkNoName(t)
+	defer removeLoNetwork(t)
+	createDefNetworkNoName(t)
+	defer removeDefNetwork(t)
+
+	netNsHandle, err := ns.NewNS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer netNsHandle.Close()
+
+	testNetNsPath := netNsHandle.Path()
+
+	netPlugin, err := NewNetworkPluginWithArgs(testConfDir, testBinDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = netPlugin.AddNetwork("testPodID", testNetNsPath, "testIfName")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = netPlugin.RemoveNetwork("testPodID", testNetNsPath, "testIfName")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRemoveNetworkFailureNetworkDoesNotExist(t *testing.T) {
+	createLoNetworkNoName(t)
+	defer removeLoNetwork(t)
+	createDefNetworkNoName(t)
+	defer removeDefNetwork(t)
+
+	netNsHandle, err := ns.NewNS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer netNsHandle.Close()
+
+	testNetNsPath := netNsHandle.Path()
+
+	netPlugin, err := NewNetworkPluginWithArgs(testConfDir, testBinDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = netPlugin.RemoveNetwork("testPodID", testNetNsPath, "testIfName")
+	if err == nil {
+		t.Fatal("Should fail because network not previously added")
+	}
+}
+
+func TestMain(m *testing.M) {
+	err := os.MkdirAll(testConfDir, os.ModeDir)
+	if err != nil {
+		fmt.Printf("Could not create test configuration directory\n")
+		os.Exit(1)
+	}
+
+	_, err = os.Stat(testBinDir)
+	if err != nil {
+		fmt.Printf("Test binary directory should exist\n")
+		os.RemoveAll(testConfDir)
+		os.Exit(1)
+	}
+
+	ret := m.Run()
+
+	os.RemoveAll(testConfDir)
+
+	os.Exit(ret)
+}


### PR DESCRIPTION
CNI package handling the usage of the CNI plugin was not covered by
any unit test until now. This patch aims to cover as much as possible
the unit testing of this cni package.

Furthermore, some minor changes have been brought to the cni package
itself in order to be able to test the package more easily.

Notice that we need to modify travis.yml to properly setup the
test environment.