### PR TITLE
Update hyperstart in virtcontainers to follow recent changes from hyperstart project

### DIFF
--- a/hyperstart/hyperstart.go
+++ b/hyperstart/hyperstart.go
@@ -121,6 +121,8 @@ type Hyperstart struct {
 	// ctl access is arbitrated by ctlMutex. We can only allow a single
 	// "transaction" (write command + read answer) at a time
 	ctlMutex sync.Mutex
+
+	ctlMulticast *multicast
 }
 
 // NewHyperstart returns a new hyperstart structure.
@@ -149,6 +151,8 @@ func (h *Hyperstart) OpenSockets() error {
 	}
 	h.ioState.open()
 
+	h.ctlMulticast = startCtlMonitor(h.ctl)
+
 	return nil
 }
 
@@ -171,6 +175,8 @@ func (h *Hyperstart) CloseSockets() error {
 
 		h.ioState.close()
 	}
+
+	h.ctlMulticast = nil
 
 	return nil
 }
@@ -371,42 +377,32 @@ func codeFromCmd(cmd string) (uint32, error) {
 	return codeList[cmd], nil
 }
 
-func (h *Hyperstart) expectReadingCmd(conn net.Conn, code uint32) (*hyper.DecodedMessage, error) {
-	var msg *hyper.DecodedMessage
-	var err error
-
-	for {
-		msg, err = ReadCtlMessage(conn)
-		if err != nil {
-			return nil, nil
+func (h *Hyperstart) checkReturnedCode(recvCode, expectedCode uint32) error {
+	if recvCode != expectedCode {
+		if recvCode == hyper.INIT_ERROR {
+			return fmt.Errorf("ERROR received from Hyperstart")
 		}
 
-		if msg.Code == code {
-			break
-		}
-
-		if msg.Code == hyper.INIT_NEXT || msg.Code == hyper.INIT_READY {
-			continue
-		}
-
-		if msg.Code != code {
-			if msg.Code == hyper.INIT_ERROR {
-				return nil, fmt.Errorf("ERROR received from Hyperstart")
-			}
-
-			return nil, fmt.Errorf("CMD ID received %d not matching expected %d", msg.Code, code)
-		}
+		return fmt.Errorf("CMD ID received %d not matching expected %d", recvCode, expectedCode)
 	}
 
-	return msg, nil
+	return nil
 }
 
 // WaitForReady waits for a READY message on CTL channel.
 func (h *Hyperstart) WaitForReady() error {
-	h.ctlMutex.Lock()
-	defer h.ctlMutex.Unlock()
+	if h.ctlMulticast == nil {
+		return fmt.Errorf("No multicast available for CTL channel")
+	}
 
-	_, err := h.expectReadingCmd(h.ctl, hyper.INIT_READY)
+	channel, err := h.ctlMulticast.listen("", "", replyType)
+	if err != nil {
+		return err
+	}
+
+	msg := <-channel
+
+	err = h.checkReturnedCode(msg.Code, hyper.INIT_READY)
 	if err != nil {
 		return err
 	}
@@ -414,37 +410,75 @@ func (h *Hyperstart) WaitForReady() error {
 	return nil
 }
 
+// WaitForPAE waits for a PROCESSASYNCEVENT message on CTL channel.
+func (h *Hyperstart) WaitForPAE(containerID, processID string) (*hyper.ProcessAsyncEvent, error) {
+	if h.ctlMulticast == nil {
+		return nil, fmt.Errorf("No multicast available for CTL channel")
+	}
+
+	channel, err := h.ctlMulticast.listen(containerID, processID, eventType)
+	if err != nil {
+		return nil, err
+	}
+
+	msg := <-channel
+
+	var paeData hyper.ProcessAsyncEvent
+	err = json.Unmarshal(msg.Message, paeData)
+	if err != nil {
+		return nil, err
+	}
+
+	return &paeData, nil
+}
+
 // SendCtlMessage sends a message to the CTL channel.
 //
-// This function does a full transaction over the CTL channel: it will write a
-// command and wait for hyperstart's answer before returning. Several
-// concurrent calls to SendCtlMessage is allowed, the function ensuring proper
-// serialization of the communication over the underlying hyperstart serial
-// link.
+// This function does a full transaction over the CTL channel: it will rely on the
+// multicaster to register a listener reading over the CTL channel. Then it writes
+// a command and waits for the multicaster to send hyperstart's answer back before
+// it can return.
+// Several concurrent calls to SendCtlMessage are allowed, the function ensuring
+// proper serialization of the communication by making the listener registration
+// and the command writing an atomic operation protected by a mutex.
+// Waiting for the reply from multicaster doesn't need to be protected by this mutex.
 func (h *Hyperstart) SendCtlMessage(cmd string, data []byte) (*hyper.DecodedMessage, error) {
+	if h.ctlMulticast == nil {
+		return nil, fmt.Errorf("No multicast available for CTL channel")
+	}
+
 	h.ctlMutex.Lock()
-	defer h.ctlMutex.Unlock()
+
+	channel, err := h.ctlMulticast.listen("", "", replyType)
+	if err != nil {
+		h.ctlMutex.Unlock()
+		return nil, err
+	}
 
 	code, err := codeFromCmd(cmd)
 	if err != nil {
+		h.ctlMutex.Unlock()
 		return nil, err
 	}
 
-	// Write message
-	msg := &hyper.DecodedMessage{
+	msgSend := &hyper.DecodedMessage{
 		Code:    code,
 		Message: data,
 	}
-	err = h.WriteCtlMessage(h.ctl, msg)
+	err = h.WriteCtlMessage(h.ctl, msgSend)
+	if err != nil {
+		h.ctlMutex.Unlock()
+		return nil, err
+	}
+
+	h.ctlMutex.Unlock()
+
+	msgRecv := <-channel
+
+	err = h.checkReturnedCode(msgRecv.Code, hyper.INIT_ACK)
 	if err != nil {
 		return nil, err
 	}
 
-	// Wait for answer
-	resp, err := h.expectReadingCmd(h.ctl, hyper.INIT_ACK)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+	return msgRecv, nil
 }

--- a/hyperstart/hyperstart.go
+++ b/hyperstart/hyperstart.go
@@ -234,7 +234,7 @@ func FormatMessage(payload interface{}) ([]byte, error) {
 //
 // This is a low level function, for a full and safe transaction on the
 // hyperstart control serial link, use SendCtlMessage.
-func (h *Hyperstart) ReadCtlMessage(conn net.Conn) (*hyper.DecodedMessage, error) {
+func ReadCtlMessage(conn net.Conn) (*hyper.DecodedMessage, error) {
 	needRead := ctlHdrSize
 	length := 0
 	read := 0
@@ -376,7 +376,7 @@ func (h *Hyperstart) expectReadingCmd(conn net.Conn, code uint32) (*hyper.Decode
 	var err error
 
 	for {
-		msg, err = h.ReadCtlMessage(conn)
+		msg, err = ReadCtlMessage(conn)
 		if err != nil {
 			return nil, nil
 		}

--- a/hyperstart/hyperstart_test.go
+++ b/hyperstart/hyperstart_test.go
@@ -223,7 +223,7 @@ func TestReadCtlMessage(t *testing.T) {
 
 	mockHyper.SendMessage(int(expected.Code), expected.Message)
 
-	reply, err := h.ReadCtlMessage(h.ctl)
+	reply, err := ReadCtlMessage(h.ctl)
 	if err != nil {
 		t.Fatal()
 	}

--- a/hyperstart/multicast.go
+++ b/hyperstart/multicast.go
@@ -1,0 +1,176 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package hyperstart
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/golang/glog"
+	hyper "github.com/hyperhq/runv/hyperstart/api/json"
+)
+
+type ctlDataType string
+
+const (
+	eventType ctlDataType = "ctlEvent"
+	replyType ctlDataType = "ctlReply"
+)
+
+type multicast struct {
+	bufReplies []*hyper.DecodedMessage
+	reply      []chan *hyper.DecodedMessage
+	event      map[string]chan *hyper.DecodedMessage
+	ctl        net.Conn
+	sync.Mutex
+}
+
+func newMulticast(ctlConn net.Conn) *multicast {
+	return &multicast{
+		bufReplies: []*hyper.DecodedMessage{},
+		reply:      []chan *hyper.DecodedMessage{},
+		event:      make(map[string]chan *hyper.DecodedMessage),
+		ctl:        ctlConn,
+	}
+}
+
+func startCtlMonitor(ctlConn net.Conn) *multicast {
+	ctlMulticast := newMulticast(ctlConn)
+
+	go func() {
+		for {
+			msg, err := ReadCtlMessage(ctlMulticast.ctl)
+			if err != nil {
+				glog.Infof("Read on CTL channel ended: %s\n", err)
+				break
+			}
+
+			err = ctlMulticast.write(msg)
+			if err != nil {
+				glog.Errorf("Multicaster write error: %s\n", err)
+				break
+			}
+		}
+	}()
+
+	return ctlMulticast
+}
+
+func (m *multicast) buildEventID(containerID, processID string) string {
+	return fmt.Sprintf("%s-%s", containerID, processID)
+}
+
+func (m *multicast) sendEvent(msg *hyper.DecodedMessage) error {
+	var paeData hyper.ProcessAsyncEvent
+
+	err := json.Unmarshal(msg.Message, paeData)
+	if err != nil {
+		return err
+	}
+
+	uniqueID := m.buildEventID(paeData.Container, paeData.Process)
+	channel, exist := m.event[uniqueID]
+	if !exist {
+		return nil
+	}
+
+	channel <- msg
+
+	delete(m.event, uniqueID)
+
+	return nil
+}
+
+func (m *multicast) sendReply(msg *hyper.DecodedMessage) error {
+	m.Lock()
+	if len(m.reply) == 0 {
+		m.bufReplies = append(m.bufReplies, msg)
+		m.Unlock()
+		return nil
+	}
+
+	replyChannel := m.reply[0]
+	m.reply = m.reply[1:]
+
+	m.Unlock()
+
+	// The current reply channel has been removed from the list, that's why
+	// we can be out of the mutex to send through that channel. Indeed, there
+	// is no risk that someone else tries to write on this channel.
+	replyChannel <- msg
+
+	return nil
+}
+
+func (m *multicast) processBufferedReply(channel chan *hyper.DecodedMessage) {
+	m.Lock()
+
+	if len(m.bufReplies) == 0 {
+		m.reply = append(m.reply, channel)
+		m.Unlock()
+		return
+	}
+
+	msg := m.bufReplies[0]
+	m.bufReplies = m.bufReplies[1:]
+
+	m.Unlock()
+
+	// The current buffered reply message has been removed from the list, and
+	// the channel have not been added to the reply list, that's why we can be
+	// out of the mutex to send the buffered message through that channel.
+	// There is no risk that someone else tries to write this message on another
+	// channel, or another message on this channel.
+	channel <- msg
+}
+
+func (m *multicast) write(msg *hyper.DecodedMessage) error {
+	switch msg.Code {
+	case hyper.INIT_NEXT:
+		return nil
+	case hyper.INIT_PROCESSASYNCEVENT:
+		return m.sendEvent(msg)
+	default:
+		return m.sendReply(msg)
+	}
+}
+
+func (m *multicast) listen(containerID, processID string, dataType ctlDataType) (chan *hyper.DecodedMessage, error) {
+	switch dataType {
+	case replyType:
+		newChan := make(chan *hyper.DecodedMessage)
+
+		go m.processBufferedReply(newChan)
+
+		return newChan, nil
+	case eventType:
+		uniqueID := m.buildEventID(containerID, processID)
+
+		_, exist := m.event[uniqueID]
+		if exist {
+			return nil, fmt.Errorf("Channel already assigned for ID %s", uniqueID)
+		}
+
+		m.event[uniqueID] = make(chan *hyper.DecodedMessage)
+
+		return m.event[uniqueID], nil
+	default:
+		return nil, fmt.Errorf("Unknown data type: %s", dataType)
+	}
+}


### PR DESCRIPTION
Recent changes in hyperstart project introduced new commands, and particularly PROCESSASYNCEVENT which is returned on the CTL channel to return the exit code of a process running on a container.
This PR handles those changes by fixing "hyperstart" and "mock" packages in virtcontainers, and also by fixing virtcontainers itself.