### PR TITLE
Implement proxy

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -114,7 +114,7 @@ type agent interface {
 	// init().
 	// After init() is called, agent implementations should be initialized and ready
 	// to handle all other Agent interface methods.
-	init(pod Pod, config interface{}) error
+	init(pod *Pod, config interface{}) error
 
 	// startAgent will start the agent.
 	startAgent() error

--- a/cc_proxy.go
+++ b/cc_proxy.go
@@ -16,29 +16,141 @@
 
 package virtcontainers
 
-type ccProxy struct{}
+import (
+	"fmt"
+	"net"
+
+	"github.com/01org/cc-oci-runtime/proxy/api"
+)
+
+var defaultHyperstartProxySock = "/usr/local/var/run/cc-oci-runtime/proxy.sock"
+
+type ccProxy struct {
+	client *api.Client
+}
+
+func (p *ccProxy) connectProxy() (*api.Client, error) {
+	conn, err := net.Dial(unixSocket, defaultHyperstartProxySock)
+	if err != nil {
+		return nil, err
+	}
+
+	return api.NewClient(conn.(*net.UnixConn)), nil
+}
+
+func (p *ccProxy) allocateIOStream() (IOStream, error) {
+	if p.client == nil {
+		return IOStream{}, fmt.Errorf("allocateIOStream: Client is nil, we can't interact with cc-proxy")
+	}
+
+	ioBase, fd, err := p.client.AllocateIo(2)
+	if err != nil {
+		return IOStream{}, err
+	}
+
+	// We have to wait for cc-proxy API to be modified before we
+	// can really assign each fd to the right field.
+	ioStream := IOStream{
+		Stdin:    fd,
+		Stdout:   fd,
+		Stderr:   fd,
+		StdinID:  uint64(0),
+		StdoutID: ioBase,
+		StderrID: ioBase + 1,
+	}
+
+	return ioStream, nil
+}
 
 // register is the proxy register implementation for ccProxy.
 func (p *ccProxy) register(pod Pod) ([]IOStream, error) {
-	return []IOStream{}, nil
+	var err error
+	var ioStreams []IOStream
+
+	p.client, err = p.connectProxy()
+	if err != nil {
+		return []IOStream{}, err
+	}
+
+	hyperConfig, ok := newAgentConfig(*(pod.config)).(HyperConfig)
+	if !ok {
+		return []IOStream{}, fmt.Errorf("Wrong agent config type, should be HyperConfig type")
+	}
+
+	err = p.client.Hello(pod.id, hyperConfig.SockCtlName, hyperConfig.SockTtyName)
+	if err != nil {
+		return []IOStream{}, err
+	}
+
+	for i := 0; i < len(pod.containers); i++ {
+		ioStream, err := p.allocateIOStream()
+		if err != nil {
+			return []IOStream{}, err
+		}
+
+		ioStreams = append(ioStreams, ioStream)
+	}
+
+	return ioStreams, nil
 }
 
 // unregister is the proxy unregister implementation for ccProxy.
 func (p *ccProxy) unregister(pod Pod) error {
-	return nil
+	if p.client == nil {
+		return fmt.Errorf("unregister: Client is nil, we can't interact with cc-proxy")
+	}
+
+	return p.client.Bye(pod.id)
 }
 
 // connect is the proxy connect implementation for ccProxy.
 func (p *ccProxy) connect(pod Pod) (IOStream, error) {
-	return IOStream{}, nil
+	var err error
+
+	p.client, err = p.connectProxy()
+	if err != nil {
+		return IOStream{}, err
+	}
+
+	err = p.client.Attach(pod.id)
+	if err != nil {
+		return IOStream{}, err
+	}
+
+	ioStream, err := p.allocateIOStream()
+	if err != nil {
+		return IOStream{}, err
+	}
+
+	return ioStream, nil
 }
 
 // disconnect is the proxy disconnect implementation for ccProxy.
 func (p *ccProxy) disconnect() error {
+	if p.client == nil {
+		return fmt.Errorf("disconnect: Client is nil, we can't interact with cc-proxy")
+	}
+
+	p.client.Close()
+
 	return nil
 }
 
 // sendCmd is the proxy sendCmd implementation for ccProxy.
 func (p *ccProxy) sendCmd(cmd interface{}) (interface{}, error) {
+	if p.client == nil {
+		return nil, fmt.Errorf("sendCmd: Client is nil, we can't interact with cc-proxy")
+	}
+
+	proxyCmd, ok := cmd.(hyperstartProxyCmd)
+	if !ok {
+		return nil, fmt.Errorf("Wrong command type, should be hyperstartProxyCmd type")
+	}
+
+	err := p.client.Hyper(proxyCmd.cmd, proxyCmd.message)
+	if err != nil {
+		return nil, err
+	}
+
 	return nil, nil
 }

--- a/cc_proxy.go
+++ b/cc_proxy.go
@@ -1,0 +1,44 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+type ccProxy struct{}
+
+// register is the proxy register implementation for ccProxy.
+func (p *ccProxy) register(pod Pod) ([]IOStream, error) {
+	return []IOStream{}, nil
+}
+
+// unregister is the proxy unregister implementation for ccProxy.
+func (p *ccProxy) unregister(pod Pod) error {
+	return nil
+}
+
+// connect is the proxy connect implementation for ccProxy.
+func (p *ccProxy) connect(pod Pod) (IOStream, error) {
+	return IOStream{}, nil
+}
+
+// disconnect is the proxy disconnect implementation for ccProxy.
+func (p *ccProxy) disconnect() error {
+	return nil
+}
+
+// sendCmd is the proxy sendCmd implementation for ccProxy.
+func (p *ccProxy) sendCmd(cmd interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/hack/virtc/README.md
+++ b/hack/virtc/README.md
@@ -73,11 +73,11 @@ $ echo -e 'HOME=/root\nPATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/s
 
 #### Run a new pod (Create + Start)
 ```
-./virtc pod run --agent="hyperstart" --network="CNI"
+./virtc pod run --agent="hyperstart" --network="CNI" --proxy="ccProxy"
 ```
 #### Create a new pod
 ```
-./virtc pod create --agent="hyperstart" --network="CNI"
+./virtc pod create --agent="hyperstart" --network="CNI" --proxy="ccProxy"
 ```
 This should generate that kind of output
 ```

--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -48,6 +48,12 @@ var podConfigFlags = []cli.Flag{
 		Usage: "the network model",
 	},
 
+	cli.GenericFlag{
+		Name:  "proxy",
+		Value: new(vc.ProxyType),
+		Usage: "the agent's proxy",
+	},
+
 	cli.StringFlag{
 		Name:  "sshd-user",
 		Value: "",
@@ -142,6 +148,11 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 		return vc.PodConfig{}, fmt.Errorf("Could not convert network model")
 	}
 
+	proxyType, ok := context.Generic("proxy").(*vc.ProxyType)
+	if ok != true {
+		return vc.PodConfig{}, fmt.Errorf("Could not convert proxy type")
+	}
+
 	volumes, ok := context.Generic("volume").(*vc.Volumes)
 	if ok != true {
 		return vc.PodConfig{}, fmt.Errorf("Could not convert to volume list")
@@ -205,6 +216,8 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 
 		NetworkModel:  *networkModel,
 		NetworkConfig: netConfig,
+
+		ProxyType: *proxyType,
 
 		Containers: []vc.ContainerConfig{},
 	}

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -114,7 +114,7 @@ type hyperstartProxyCmd struct {
 	message interface{}
 }
 
-func (h *hyper) buildHyperContainerProcess(cmd Cmd, stdio uint64, stderr uint64) (*hyperJson.Process, error) {
+func (h *hyper) buildHyperContainerProcess(cmd Cmd, stdio uint64, stderr uint64, terminal bool) (*hyperJson.Process, error) {
 	var envVars []hyperJson.EnvironmentVar
 
 	for _, e := range cmd.Envs {
@@ -127,13 +127,14 @@ func (h *hyper) buildHyperContainerProcess(cmd Cmd, stdio uint64, stderr uint64)
 	}
 
 	process := &hyperJson.Process{
-		User:    cmd.User,
-		Group:   cmd.Group,
-		Stdio:   stdio,
-		Stderr:  stderr,
-		Args:    cmd.Args,
-		Envs:    envVars,
-		Workdir: cmd.WorkDir,
+		User:     cmd.User,
+		Group:    cmd.Group,
+		Terminal: terminal,
+		Stdio:    stdio,
+		Stderr:   stderr,
+		Args:     cmd.Args,
+		Envs:     envVars,
+		Workdir:  cmd.WorkDir,
 	}
 
 	return process, nil
@@ -244,7 +245,7 @@ func (h *hyper) exec(pod Pod, container Container, cmd Cmd) error {
 		return err
 	}
 
-	process, err := h.buildHyperContainerProcess(cmd, ioStream.StdoutID, ioStream.StderrID)
+	process, err := h.buildHyperContainerProcess(cmd, ioStream.StdoutID, ioStream.StderrID, container.config.Interactive)
 	if err != nil {
 		return err
 	}
@@ -348,7 +349,7 @@ func (h *hyper) startPauseContainer(pod Pod, ioStream IOStream) error {
 		WorkDir: "/",
 	}
 
-	process, err := h.buildHyperContainerProcess(cmd, ioStream.StdoutID, ioStream.StderrID)
+	process, err := h.buildHyperContainerProcess(cmd, ioStream.StdoutID, ioStream.StderrID, false)
 	if err != nil {
 		return err
 	}
@@ -379,7 +380,7 @@ func (h *hyper) startPauseContainer(pod Pod, ioStream IOStream) error {
 }
 
 func (h *hyper) startOneContainer(pod Pod, contConfig ContainerConfig, ioStream IOStream) error {
-	process, err := h.buildHyperContainerProcess(contConfig.Cmd, ioStream.StdoutID, ioStream.StderrID)
+	process, err := h.buildHyperContainerProcess(contConfig.Cmd, ioStream.StdoutID, ioStream.StderrID, contConfig.Interactive)
 	if err != nil {
 		return err
 	}

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -314,16 +314,6 @@ func (h *hyper) stopPod(pod Pod) error {
 		return err
 	}
 
-	proxyCmd := hyperstartProxyCmd{
-		cmd:     hyperstart.DestroyPod,
-		message: nil,
-	}
-
-	_, err = h.proxy.sendCmd(proxyCmd)
-	if err != nil {
-		return err
-	}
-
 	err = h.proxy.unregister(pod)
 	if err != nil {
 		return err

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -18,11 +18,9 @@ package virtcontainers
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"syscall"
-	"time"
 
 	"github.com/golang/glog"
 
@@ -93,10 +91,9 @@ func (c *HyperConfig) validate(pod Pod) bool {
 
 // hyper is the Agent interface implementation for hyperstart.
 type hyper struct {
-	pod    Pod
+	pod    *Pod
 	config HyperConfig
-
-	hyperstart *hyperstart.Hyperstart
+	proxy  proxy
 }
 
 // ExecInfo is the structure corresponding to the format
@@ -106,30 +103,18 @@ type ExecInfo struct {
 	Process   hyperJson.Process `json:"process"`
 }
 
+// RemoveContainer is the structure corresponding to the format
+// expected by hyperstart to remove a container on the guest.
+type RemoveContainer struct {
+	Container string `json:"container"`
+}
+
 type hyperstartProxyCmd struct {
 	cmd     string
 	message interface{}
 }
 
-func (h *hyper) retryConnectSocket(retry int) error {
-	var err error
-
-	for i := 0; i < retry; i++ {
-		err = h.hyperstart.OpenSockets()
-		if err == nil {
-			break
-		}
-
-		select {
-		case <-time.After(100 * time.Millisecond):
-			break
-		}
-	}
-
-	return err
-}
-
-func (h *hyper) buildHyperContainerProcess(cmd Cmd) (*hyperJson.Process, error) {
+func (h *hyper) buildHyperContainerProcess(cmd Cmd, stdio uint64, stderr uint64) (*hyperJson.Process, error) {
 	var envVars []hyperJson.EnvironmentVar
 
 	for _, e := range cmd.Envs {
@@ -144,8 +129,8 @@ func (h *hyper) buildHyperContainerProcess(cmd Cmd) (*hyperJson.Process, error) 
 	process := &hyperJson.Process{
 		User:    cmd.User,
 		Group:   cmd.Group,
-		Stdio:   uint64(rand.Int63()),
-		Stderr:  uint64(rand.Int63()),
+		Stdio:   stdio,
+		Stderr:  stderr,
 		Args:    cmd.Args,
 		Envs:    envVars,
 		Workdir: cmd.WorkDir,
@@ -193,10 +178,10 @@ func (h *hyper) bindUnmountAllRootfs() {
 }
 
 // init is the agent initialization implementation for hyperstart.
-func (h *hyper) init(pod Pod, config interface{}) error {
+func (h *hyper) init(pod *Pod, config interface{}) error {
 	switch c := config.(type) {
 	case HyperConfig:
-		if c.validate(pod) == false {
+		if c.validate(*pod) == false {
 			return fmt.Errorf("Invalid configuration")
 		}
 		h.config = c
@@ -204,6 +189,7 @@ func (h *hyper) init(pod Pod, config interface{}) error {
 		return fmt.Errorf("Invalid config type")
 	}
 
+	pod.config.AgentConfig = h.config
 	h.pod = pod
 
 	for _, volume := range h.config.Volumes {
@@ -237,33 +223,28 @@ func (h *hyper) init(pod Pod, config interface{}) error {
 		return err
 	}
 
-	h.hyperstart = hyperstart.NewHyperstart(h.config.SockCtlName, h.config.SockTtyName, unixSocket)
+	h.proxy, err = newProxy(pod.config.ProxyType)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
 
 // start is the agent starting implementation for hyperstart.
+// It does nothing.
 func (h *hyper) startAgent() error {
-	if h.hyperstart.IsStarted() == true {
-		return nil
-	}
-
-	err := h.retryConnectSocket(1000)
-	if err != nil {
-		return err
-	}
-
-	_, err = h.hyperstart.SendCtlMessage(hyperstart.Ping, nil)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
 // exec is the agent command execution implementation for hyperstart.
 func (h *hyper) exec(pod Pod, container Container, cmd Cmd) error {
-	process, err := h.buildHyperContainerProcess(cmd)
+	ioStream, err := h.proxy.connect(pod)
+	if err != nil {
+		return err
+	}
+
+	process, err := h.buildHyperContainerProcess(cmd, ioStream.StdoutID, ioStream.StderrID)
 	if err != nil {
 		return err
 	}
@@ -273,55 +254,82 @@ func (h *hyper) exec(pod Pod, container Container, cmd Cmd) error {
 		Process:   *process,
 	}
 
-	payload, err := hyperstart.FormatMessage(execInfo)
-	if err != nil {
-		return err
+	proxyCmd := hyperstartProxyCmd{
+		cmd:     hyperstart.ExecCmd,
+		message: execInfo,
 	}
 
-	_, err = h.hyperstart.SendCtlMessage(hyperstart.ExecCmd, payload)
+	_, err = h.proxy.sendCmd(proxyCmd)
 	if err != nil {
-		return err
+		return nil
 	}
 
-	return nil
+	return h.proxy.disconnect()
 }
 
 // startPod is the agent Pod starting implementation for hyperstart.
 func (h *hyper) startPod(config PodConfig) error {
+	h.pod.containers = append(h.pod.containers, ContainerConfig{})
+
+	ioStreams, err := h.proxy.register(*(h.pod))
+	if err != nil {
+		return err
+	}
+
 	hyperPod := hyperJson.Pod{
 		Hostname:             config.ID,
 		DeprecatedContainers: []hyperJson.Container{},
 		ShareDir:             mountTag,
 	}
 
-	payload, err := hyperstart.FormatMessage(hyperPod)
+	proxyCmd := hyperstartProxyCmd{
+		cmd:     hyperstart.StartPod,
+		message: hyperPod,
+	}
+
+	_, err = h.proxy.sendCmd(proxyCmd)
 	if err != nil {
 		return err
 	}
 
-	_, err = h.hyperstart.SendCtlMessage(hyperstart.StartPod, payload)
+	err = h.startPauseContainer(*(h.pod), ioStreams[0])
 	if err != nil {
 		return err
 	}
 
-	err = h.startPauseContainer(h.pod)
-	if err != nil {
-		return err
-	}
-
-	for _, c := range config.Containers {
-		err := h.startContainer(h.pod, c)
+	for idx, c := range config.Containers {
+		err := h.startOneContainer(*(h.pod), c, ioStreams[idx+1])
 		if err != nil {
 			return err
 		}
 	}
 
-	return nil
+	return h.proxy.disconnect()
 }
 
 // stopPod is the agent Pod stopping implementation for hyperstart.
 func (h *hyper) stopPod(pod Pod) error {
-	_, err := h.hyperstart.SendCtlMessage(hyperstart.DestroyPod, nil)
+	_, err := h.proxy.connect(pod)
+	if err != nil {
+		return err
+	}
+
+	proxyCmd := hyperstartProxyCmd{
+		cmd:     hyperstart.DestroyPod,
+		message: nil,
+	}
+
+	_, err = h.proxy.sendCmd(proxyCmd)
+	if err != nil {
+		return err
+	}
+
+	err = h.proxy.unregister(pod)
+	if err != nil {
+		return err
+	}
+
+	err = h.proxy.disconnect()
 	if err != nil {
 		return err
 	}
@@ -337,24 +345,20 @@ func (h *hyper) stopPod(pod Pod) error {
 }
 
 // stop is the agent stopping implementation for hyperstart.
+// It does nothing.
 func (h *hyper) stopAgent() error {
-	err := h.hyperstart.CloseSockets()
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
 // startPauseContainer starts a specific container running the pause binary provided.
-func (h *hyper) startPauseContainer(pod Pod) error {
+func (h *hyper) startPauseContainer(pod Pod, ioStream IOStream) error {
 	cmd := Cmd{
 		Args:    []string{fmt.Sprintf("./%s", pauseBinName)},
 		Envs:    []EnvVar{},
 		WorkDir: "/",
 	}
 
-	process, err := h.buildHyperContainerProcess(cmd)
+	process, err := h.buildHyperContainerProcess(cmd, ioStream.StdoutID, ioStream.StderrID)
 	if err != nil {
 		return err
 	}
@@ -371,12 +375,12 @@ func (h *hyper) startPauseContainer(pod Pod) error {
 		return err
 	}
 
-	payload, err := hyperstart.FormatMessage(container)
-	if err != nil {
-		return err
+	proxyCmd := hyperstartProxyCmd{
+		cmd:     hyperstart.NewContainer,
+		message: container,
 	}
 
-	_, err = h.hyperstart.SendCtlMessage(hyperstart.NewContainer, payload)
+	_, err = h.proxy.sendCmd(proxyCmd)
 	if err != nil {
 		return err
 	}
@@ -384,9 +388,8 @@ func (h *hyper) startPauseContainer(pod Pod) error {
 	return nil
 }
 
-// startContainer is the agent Container starting implementation for hyperstart.
-func (h *hyper) startContainer(pod Pod, contConfig ContainerConfig) error {
-	process, err := h.buildHyperContainerProcess(contConfig.Cmd)
+func (h *hyper) startOneContainer(pod Pod, contConfig ContainerConfig, ioStream IOStream) error {
+	process, err := h.buildHyperContainerProcess(contConfig.Cmd, ioStream.StdoutID, ioStream.StderrID)
 	if err != nil {
 		return err
 	}
@@ -404,12 +407,12 @@ func (h *hyper) startContainer(pod Pod, contConfig ContainerConfig) error {
 		return err
 	}
 
-	payload, err := hyperstart.FormatMessage(container)
-	if err != nil {
-		return err
+	proxyCmd := hyperstartProxyCmd{
+		cmd:     hyperstart.NewContainer,
+		message: container,
 	}
 
-	_, err = h.hyperstart.SendCtlMessage(hyperstart.NewContainer, payload)
+	_, err = h.proxy.sendCmd(proxyCmd)
 	if err != nil {
 		return err
 	}
@@ -417,11 +420,43 @@ func (h *hyper) startContainer(pod Pod, contConfig ContainerConfig) error {
 	return nil
 }
 
+// startContainer is the agent Container starting implementation for hyperstart.
+func (h *hyper) startContainer(pod Pod, contConfig ContainerConfig) error {
+	ioStream, err := h.proxy.connect(pod)
+	if err != nil {
+		return err
+	}
+
+	err = h.startOneContainer(pod, contConfig, ioStream)
+	if err != nil {
+		return err
+	}
+
+	return h.proxy.disconnect()
+}
+
 // stopContainer is the agent Container stopping implementation for hyperstart.
 func (h *hyper) stopContainer(pod Pod, container Container) error {
-	payload := []byte(fmt.Sprintf("{\"container\":\"%s\"}", container.id))
+	_, err := h.proxy.connect(pod)
+	if err != nil {
+		return err
+	}
 
-	_, err := h.hyperstart.SendCtlMessage(hyperstart.RemoveContainer, payload)
+	removeContainer := RemoveContainer{
+		Container: container.id,
+	}
+
+	proxyCmd := hyperstartProxyCmd{
+		cmd:     hyperstart.RemoveContainer,
+		message: removeContainer,
+	}
+
+	_, err = h.proxy.sendCmd(proxyCmd)
+	if err != nil {
+		return err
+	}
+
+	err = h.proxy.disconnect()
 	if err != nil {
 		return err
 	}

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -106,6 +106,11 @@ type ExecInfo struct {
 	Process   hyperJson.Process `json:"process"`
 }
 
+type hyperstartProxyCmd struct {
+	cmd     string
+	message interface{}
+}
+
 func (h *hyper) retryConnectSocket(retry int) error {
 	var err error
 

--- a/noop_agent.go
+++ b/noop_agent.go
@@ -22,7 +22,7 @@ type noopAgent struct {
 }
 
 // init initializes the Noop agent, i.e. it does nothing.
-func (n *noopAgent) init(pod Pod, config interface{}) error {
+func (n *noopAgent) init(pod *Pod, config interface{}) error {
 	return nil
 }
 

--- a/noop_agent_test.go
+++ b/noop_agent_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestNoopAgentInit(t *testing.T) {
 	n := &noopAgent{}
-	pod := Pod{}
+	pod := &Pod{}
 
 	err := n.init(pod, nil)
 	if err != nil {

--- a/noop_proxy.go
+++ b/noop_proxy.go
@@ -1,0 +1,57 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+type noopProxy struct{}
+
+// register is the proxy register implementation for testing purpose.
+// It does nothing.
+func (p *noopProxy) register(pod Pod) ([]IOStream, error) {
+	var ioStreams []IOStream
+
+	for i := 0; i < len(pod.containers); i++ {
+		ioStream := IOStream{}
+
+		ioStreams = append(ioStreams, ioStream)
+	}
+
+	return ioStreams, nil
+}
+
+// unregister is the proxy unregister implementation for testing purpose.
+// It does nothing.
+func (p *noopProxy) unregister(pod Pod) error {
+	return nil
+}
+
+// connect is the proxy connect implementation for testing purpose.
+// It does nothing.
+func (p *noopProxy) connect(pod Pod) (IOStream, error) {
+	return IOStream{}, nil
+}
+
+// disconnect is the proxy disconnect implementation for testing purpose.
+// It does nothing.
+func (p *noopProxy) disconnect() error {
+	return nil
+}
+
+// sendCmd is the proxy sendCmd implementation for testing purpose.
+// It does nothing.
+func (p *noopProxy) sendCmd(cmd interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/pod.go
+++ b/pod.go
@@ -242,6 +242,8 @@ type PodConfig struct {
 	NetworkModel  NetworkModel
 	NetworkConfig NetworkConfig
 
+	ProxyType ProxyType
+
 	// Volumes is a list of shared volumes between the host and the Pod.
 	Volumes []Volume
 
@@ -405,7 +407,7 @@ func createPod(podConfig PodConfig, networkNS NetworkNamespace) (*Pod, error) {
 		agentConfig = nil
 	}
 
-	err = p.agent.init(*p, agentConfig)
+	err = p.agent.init(p, agentConfig)
 	if err != nil {
 		p.storage.deletePodResources(p.id, nil)
 		return nil, err

--- a/proxy.go
+++ b/proxy.go
@@ -1,0 +1,103 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"fmt"
+	"os"
+)
+
+// ProxyType describes a proxy type.
+type ProxyType string
+
+const (
+	// CCProxyType is the ccProxy.
+	CCProxyType ProxyType = "ccProxy"
+
+	// NoopProxyType is the noopProxy.
+	NoopProxyType ProxyType = "noopProxy"
+)
+
+// Set sets a proxy type based on the input string.
+func (pType *ProxyType) Set(value string) error {
+	switch value {
+	case "noopProxy":
+		*pType = NoopProxyType
+		return nil
+	case "ccProxy":
+		*pType = CCProxyType
+		return nil
+	default:
+		return fmt.Errorf("Unknown proxy type %s", value)
+	}
+}
+
+// String converts a proxy type to a string.
+func (pType *ProxyType) String() string {
+	switch *pType {
+	case NoopProxyType:
+		return string(NoopProxyType)
+	case CCProxyType:
+		return string(CCProxyType)
+	default:
+		return ""
+	}
+}
+
+// newProxy returns a proxy from a proxy type.
+func newProxy(pType ProxyType) (proxy, error) {
+	switch pType {
+	case NoopProxyType:
+		return &noopProxy{}, nil
+	case CCProxyType:
+		return &ccProxy{}, nil
+	default:
+		return &noopProxy{}, nil
+	}
+}
+
+// IOStream holds three file descriptors returned by the proxy.
+// Those file descriptors will be given to the calling process,
+// so that it can interact with a workload running on a container.
+type IOStream struct {
+	Stdin    *os.File
+	Stdout   *os.File
+	Stderr   *os.File
+	StdinID  uint64
+	StdoutID uint64
+	StderrID uint64
+}
+
+// proxy is the virtcontainers proxy interface.
+type proxy interface {
+	// register connects and registers the proxy to the given VM.
+	// It also returns streams related to containers workloads.
+	register(pod Pod) ([]IOStream, error)
+
+	// unregister unregisters and disconnects the proxy from the given VM.
+	unregister(pod Pod) error
+
+	// connect gets the proxy a handle to a previously registered VM.
+	// It also returns streams related to containers workloads.
+	connect(pod Pod) (IOStream, error)
+
+	// disconnect disconnects from the proxy.
+	disconnect() error
+
+	// sendCmd sends a command to the agent inside the VM through the proxy.
+	sendCmd(cmd interface{}) (interface{}, error)
+}

--- a/sshd.go
+++ b/sshd.go
@@ -76,7 +76,7 @@ func execCmd(session *ssh.Session, cmd string) error {
 }
 
 // init is the agent initialization implementation for sshd.
-func (s *sshd) init(pod Pod, config interface{}) error {
+func (s *sshd) init(pod *Pod, config interface{}) error {
 	c := config.(SshdConfig)
 	if c.validate() == false {
 		return fmt.Errorf("Invalid configuration")


### PR DESCRIPTION
Virtcontainers reached a point where it needs to rely on the hyperstart proxy if we want to go further. This PR solves issue #85 by implementing two proxy interfaces, a raw hyperstart intended to communicate directly  with hyperstart, and a real proxy responsible to do the abstraction layer with the VM.