### PR TITLE
cc-proxy: Follow the latest API change

### DIFF
--- a/cc_proxy.go
+++ b/cc_proxy.go
@@ -77,7 +77,7 @@ func (p *ccProxy) register(pod Pod) ([]IOStream, error) {
 		return []IOStream{}, fmt.Errorf("Wrong agent config type, should be HyperConfig type")
 	}
 
-	err = p.client.Hello(pod.id, hyperConfig.SockCtlName, hyperConfig.SockTtyName)
+	_, err = p.client.Hello(pod.id, hyperConfig.SockCtlName, hyperConfig.SockTtyName, nil)
 	if err != nil {
 		return []IOStream{}, err
 	}
@@ -112,7 +112,7 @@ func (p *ccProxy) connect(pod Pod) (IOStream, error) {
 		return IOStream{}, err
 	}
 
-	err = p.client.Attach(pod.id)
+	_, err = p.client.Attach(pod.id, nil)
 	if err != nil {
 		return IOStream{}, err
 	}


### PR DESCRIPTION
Hopefully the first and only client API change before we tag 2.1.

References: https://github.com/01org/cc-oci-runtime/pull/595
Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>

--

Of course, this PR is going to fail and the related PR in the runtime isn't merged yet.