### PR TITLE
CNM network implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
   - go get github.com/golang/lint/golint
   - go get github.com/client9/misspell/cmd/misspell
   - go get github.com/01org/ciao/test-cases
+  - go get github.com/opencontainers/runc/libcontainer/configs
 
 install:
   - mkdir -p $HOME/build
@@ -28,6 +29,12 @@ install:
   - sudo cp ./bin/bridge /tmp/cni/bin/cni-bridge
   - sudo cp ./bin/loopback /tmp/cni/bin/loopback
   - sudo cp ./bin/host-local /tmp/cni/bin/host-local
+  - popd
+  - mkdir -p $HOME/build_hook
+  - pushd $HOME/build_hook
+  - sudo mkdir -p /tmp/bin
+  - go build -o hook $GOPATH/src/github.com/containers/virtcontainers/hook/mock/hook.go
+  - sudo cp hook /tmp/bin/
   - popd
   - go get -t -v ./...
 

--- a/api.go
+++ b/api.go
@@ -91,27 +91,33 @@ func StartPod(podID string) (*Pod, error) {
 		return nil, err
 	}
 
+	// Initialize the network.
+	n := newNetwork(p.config.NetworkModel)
+	err = n.init(&(p.config.NetworkConfig))
+	if err != nil {
+		return nil, err
+	}
+
+	// Join the network.
+	err = n.join(p.config.NetworkConfig.NetNSPath)
+	if err != nil {
+		return nil, err
+	}
+
 	// Execute prestart hooks
 	err = p.config.Hooks.preStartHooks()
 	if err != nil {
 		return nil, err
 	}
 
-	// Create the network.
-	n := newNetwork(p.config.NetworkModel)
-	networkNS, err := n.add(*p, &(p.config.NetworkConfig))
+	// Add the network
+	networkNS, err := n.add(*p, p.config.NetworkConfig)
 	if err != nil {
 		return nil, err
 	}
 
 	// Store the network
 	err = p.storage.storePodNetwork(p.id, networkNS)
-	if err != nil {
-		return nil, err
-	}
-
-	// Join the network.
-	err = n.join(networkNS)
 	if err != nil {
 		return nil, err
 	}
@@ -206,27 +212,33 @@ func RunPod(podConfig PodConfig) (*Pod, error) {
 	}
 	defer unlockPod(lockFile)
 
+	// Initialize the network.
+	n := newNetwork(p.config.NetworkModel)
+	err = n.init(&(p.config.NetworkConfig))
+	if err != nil {
+		return nil, err
+	}
+
+	// Join the network.
+	err = n.join(p.config.NetworkConfig.NetNSPath)
+	if err != nil {
+		return nil, err
+	}
+
 	// Execute prestart hooks
 	err = p.config.Hooks.preStartHooks()
 	if err != nil {
 		return nil, err
 	}
 
-	// Create the network.
-	n := newNetwork(p.config.NetworkModel)
-	networkNS, err := n.add(*p, &(podConfig.NetworkConfig))
+	// Add the network
+	networkNS, err := n.add(*p, p.config.NetworkConfig)
 	if err != nil {
 		return nil, err
 	}
 
 	// Store the network
 	err = p.storage.storePodNetwork(p.id, networkNS)
-	if err != nil {
-		return nil, err
-	}
-
-	// Join the network.
-	err = n.join(networkNS)
 	if err != nil {
 		return nil, err
 	}

--- a/api.go
+++ b/api.go
@@ -91,6 +91,12 @@ func StartPod(podID string) (*Pod, error) {
 		return nil, err
 	}
 
+	// Execute prestart hooks
+	err = p.config.Hooks.preStartHooks()
+	if err != nil {
+		return nil, err
+	}
+
 	// Create the network.
 	n := newNetwork(p.config.NetworkModel)
 	networkNS, err := n.add(*p, &(p.config.NetworkConfig))
@@ -112,6 +118,12 @@ func StartPod(podID string) (*Pod, error) {
 
 	// Start it.
 	err = p.start()
+	if err != nil {
+		return nil, err
+	}
+
+	// Execute poststart hooks
+	err = p.config.Hooks.postStartHooks()
 	if err != nil {
 		return nil, err
 	}
@@ -159,6 +171,12 @@ func StopPod(podID string) (*Pod, error) {
 		return nil, err
 	}
 
+	// Execute poststop hooks
+	err = p.config.Hooks.postStopHooks()
+	if err != nil {
+		return nil, err
+	}
+
 	err = p.endSession()
 	if err != nil {
 		return nil, err
@@ -188,6 +206,12 @@ func RunPod(podConfig PodConfig) (*Pod, error) {
 	}
 	defer unlockPod(lockFile)
 
+	// Execute prestart hooks
+	err = p.config.Hooks.preStartHooks()
+	if err != nil {
+		return nil, err
+	}
+
 	// Create the network.
 	n := newNetwork(p.config.NetworkModel)
 	networkNS, err := n.add(*p, &(podConfig.NetworkConfig))
@@ -211,6 +235,12 @@ func RunPod(podConfig PodConfig) (*Pod, error) {
 	err = p.start()
 	if err != nil {
 		p.delete()
+		return nil, err
+	}
+
+	// Execute poststart hooks
+	err = p.config.Hooks.postStartHooks()
+	if err != nil {
 		return nil, err
 	}
 

--- a/api.go
+++ b/api.go
@@ -27,7 +27,7 @@ import (
 func CreatePod(podConfig PodConfig) (*Pod, error) {
 	// Create the network.
 	n := newNetwork(podConfig.NetworkModel)
-	networkNS, err := n.add(&(podConfig.NetworkConfig))
+	networkNS, err := n.add(Pod{}, &(podConfig.NetworkConfig))
 	if err != nil {
 		return nil, err
 	}
@@ -35,14 +35,14 @@ func CreatePod(podConfig PodConfig) (*Pod, error) {
 	// Create the pod.
 	p, err := createPod(podConfig, networkNS)
 	if err != nil {
-		n.remove(networkNS)
+		n.remove(Pod{}, networkNS)
 		return nil, err
 	}
 
 	// Store it.
 	err = p.storePod()
 	if err != nil {
-		n.remove(p.networkNS)
+		n.remove(Pod{}, p.networkNS)
 		return nil, err
 	}
 
@@ -71,7 +71,7 @@ func DeletePod(podID string) (*Pod, error) {
 
 	// Remove the network.
 	n := newNetwork(p.config.NetworkModel)
-	err = n.remove(p.networkNS)
+	err = n.remove(Pod{}, p.networkNS)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func StopPod(podID string) (*Pod, error) {
 func RunPod(podConfig PodConfig) (*Pod, error) {
 	// Create the network.
 	n := newNetwork(podConfig.NetworkModel)
-	networkNS, err := n.add(&(podConfig.NetworkConfig))
+	networkNS, err := n.add(Pod{}, &(podConfig.NetworkConfig))
 	if err != nil {
 		return nil, err
 	}
@@ -171,14 +171,14 @@ func RunPod(podConfig PodConfig) (*Pod, error) {
 	// Create the pod.
 	p, err := createPod(podConfig, networkNS)
 	if err != nil {
-		n.remove(networkNS)
+		n.remove(Pod{}, networkNS)
 		return nil, err
 	}
 
 	// Store it.
 	err = p.storePod()
 	if err != nil {
-		n.remove(p.networkNS)
+		n.remove(Pod{}, p.networkNS)
 		return nil, err
 	}
 

--- a/cni.go
+++ b/cni.go
@@ -104,6 +104,11 @@ func (n *cni) add(pod Pod, config *NetworkConfig) (NetworkNamespace, error) {
 		return NetworkNamespace{}, err
 	}
 
+	err = addNetDevHypervisor(pod, networkNS.Endpoints)
+	if err != nil {
+		return NetworkNamespace{}, err
+	}
+
 	return networkNS, nil
 }
 

--- a/cni.go
+++ b/cni.go
@@ -63,7 +63,7 @@ func (n *cni) deleteVirtInterfaces(networkNS NetworkNamespace) error {
 
 // add creates a new network namespace and its virtual network interfaces,
 // and it creates and bridges TAP interfaces for the CNI network.
-func (n *cni) add(config *NetworkConfig) (NetworkNamespace, error) {
+func (n *cni) add(pod Pod, config *NetworkConfig) (NetworkNamespace, error) {
 	var err error
 
 	if config.NetNSPath == "" {
@@ -118,7 +118,7 @@ func (n *cni) join(networkNS NetworkNamespace) error {
 
 // remove unbridges and deletes TAP interfaces. It also removes virtual network
 // interfaces and deletes the network namespace for the CNI network.
-func (n *cni) remove(networkNS NetworkNamespace) error {
+func (n *cni) remove(pod Pod, networkNS NetworkNamespace) error {
 	err := doNetNS(networkNS.NetNsPath, func(_ ns.NetNS) error {
 		for _, endpoint := range networkNS.Endpoints {
 			err := unBridgeNetworkPair(endpoint.NetPair)

--- a/cnm.go
+++ b/cnm.go
@@ -23,7 +23,7 @@ type cnm struct {
 
 // add creates a new network namespace and its virtual network interfaces,
 // and it creates and bridges TAP interfaces for the CNM network.
-func (n *cnm) add(config *NetworkConfig) (NetworkNamespace, error) {
+func (n *cnm) add(pod Pod, config *NetworkConfig) (NetworkNamespace, error) {
 	return NetworkNamespace{}, nil
 }
 
@@ -35,6 +35,6 @@ func (n *cnm) join(networkNS NetworkNamespace) error {
 
 // remove unbridges and deletes TAP interfaces. It also removes virtual network
 // interfaces and deletes the network namespace for the CNM network.
-func (n *cnm) remove(networkNS NetworkNamespace) error {
+func (n *cnm) remove(pod Pod, networkNS NetworkNamespace) error {
 	return nil
 }

--- a/cnm.go
+++ b/cnm.go
@@ -21,16 +21,20 @@ type cnm struct {
 	config NetworkConfig
 }
 
-// add creates a new network namespace and its virtual network interfaces,
-// and it creates and bridges TAP interfaces for the CNM network.
-func (n *cnm) add(pod Pod, config *NetworkConfig) (NetworkNamespace, error) {
-	return NetworkNamespace{}, nil
+// init initializes the network, setting a new network namespace for the CNM network.
+func (n *cnm) init(config *NetworkConfig) error {
+	return nil
 }
 
 // join switches the current process to the specified network namespace
 // for the CNM network.
-func (n *cnm) join(networkNS NetworkNamespace) error {
+func (n *cnm) join(networkNSPath string) error {
 	return nil
+}
+
+// add adds all needed interfaces inside the network namespace for the CNM network.
+func (n *cnm) add(pod Pod, config NetworkConfig) (NetworkNamespace, error) {
+	return NetworkNamespace{}, nil
 }
 
 // remove unbridges and deletes TAP interfaces. It also removes virtual network

--- a/cnm.go
+++ b/cnm.go
@@ -16,29 +16,175 @@
 
 package virtcontainers
 
+import (
+	"net"
+
+	"github.com/01org/ciao/ssntp/uuid"
+	"github.com/containernetworking/cni/pkg/ns"
+	types "github.com/containernetworking/cni/pkg/types/current"
+)
+
 // cnm is a network implementation for the CNM plugin.
 type cnm struct {
 	config NetworkConfig
 }
 
+func (n *cnm) createResult(iface net.Interface, addrs []net.Addr) (types.Result, error) {
+	var ipConfigs []*types.IPConfig
+	for _, addr := range addrs {
+		ip, ipNet, err := net.ParseCIDR(addr.String())
+		if err != nil {
+			return types.Result{}, err
+		}
+
+		version := "6"
+		if ip.To4() != nil {
+			version = "4"
+		}
+		ipNet.IP = ip
+
+		ipConfig := &types.IPConfig{
+			Version:   version,
+			Interface: iface.Index,
+			Address:   *ipNet,
+		}
+
+		ipConfigs = append(ipConfigs, ipConfig)
+	}
+
+	ifaceList := []*types.Interface{
+		{
+			Name: iface.Name,
+			Mac:  iface.HardwareAddr.String(),
+		},
+	}
+
+	res := types.Result{
+		Interfaces: ifaceList,
+		IPs:        ipConfigs,
+	}
+
+	return res, nil
+}
+
+func (n *cnm) createEndpointsFromScan() ([]Endpoint, error) {
+	var endpoints []Endpoint
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return []Endpoint{}, err
+	}
+
+	uniqueID := uuid.Generate().String()
+
+	idx := 0
+	for _, iface := range ifaces {
+		var endpoint Endpoint
+
+		addrs, err := iface.Addrs()
+		if err != nil {
+			return []Endpoint{}, err
+		}
+
+		if iface.Name == "lo" {
+			continue
+		} else {
+			endpoint = createNetworkEndpoint(idx, uniqueID, iface.Name)
+		}
+
+		endpoint.Properties, err = n.createResult(iface, addrs)
+		if err != nil {
+			return []Endpoint{}, err
+		}
+
+		endpoints = append(endpoints, endpoint)
+
+		idx++
+	}
+
+	return endpoints, nil
+}
+
 // init initializes the network, setting a new network namespace for the CNM network.
 func (n *cnm) init(config *NetworkConfig) error {
+	if config.NetNSPath == "" {
+		path, err := createNetNS()
+		if err != nil {
+			return err
+		}
+
+		config.NetNSPath = path
+	}
+
 	return nil
 }
 
 // join switches the current process to the specified network namespace
 // for the CNM network.
 func (n *cnm) join(networkNSPath string) error {
+	err := setNetNS(networkNSPath)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
 // add adds all needed interfaces inside the network namespace for the CNM network.
 func (n *cnm) add(pod Pod, config NetworkConfig) (NetworkNamespace, error) {
-	return NetworkNamespace{}, nil
+	endpoints, err := n.createEndpointsFromScan()
+	if err != nil {
+		return NetworkNamespace{}, err
+	}
+
+	networkNS := NetworkNamespace{
+		NetNsPath: config.NetNSPath,
+		Endpoints: endpoints,
+	}
+
+	err = doNetNS(networkNS.NetNsPath, func(_ ns.NetNS) error {
+		for _, endpoint := range networkNS.Endpoints {
+			err := bridgeNetworkPair(endpoint.NetPair)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return NetworkNamespace{}, err
+	}
+
+	err = addNetDevHypervisor(pod, networkNS.Endpoints)
+	if err != nil {
+		return NetworkNamespace{}, err
+	}
+
+	return networkNS, nil
 }
 
 // remove unbridges and deletes TAP interfaces. It also removes virtual network
 // interfaces and deletes the network namespace for the CNM network.
 func (n *cnm) remove(pod Pod, networkNS NetworkNamespace) error {
+	err := doNetNS(networkNS.NetNsPath, func(_ ns.NetNS) error {
+		for _, endpoint := range networkNS.Endpoints {
+			err := unBridgeNetworkPair(endpoint.NetPair)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	err = deleteNetNS(networkNS.NetNsPath, true)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/cnm_test.go
+++ b/cnm_test.go
@@ -1,0 +1,88 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"net"
+	"reflect"
+	"testing"
+
+	types "github.com/containernetworking/cni/pkg/types/current"
+)
+
+type mockAddr struct {
+	network string
+	ipAddr  string
+}
+
+func (m mockAddr) Network() string {
+	return m.network
+}
+
+func (m mockAddr) String() string {
+	return m.ipAddr
+}
+
+func TestCNMCreateResults(t *testing.T) {
+	plugin := &cnm{}
+
+	macAddr := net.HardwareAddr{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+
+	ip, ipNet, err := net.ParseCIDR("192.168.0.1/8")
+	if err != nil {
+		t.Fatal()
+	}
+	ipNet.IP = ip
+
+	expected := types.Result{
+		Interfaces: []*types.Interface{
+			{
+				Name: "eth0",
+				Mac:  macAddr.String(),
+			},
+		},
+		IPs: []*types.IPConfig{
+			{
+				Version:   "4",
+				Interface: 0,
+				Address:   *ipNet,
+			},
+		},
+	}
+
+	iface := net.Interface{
+		Index:        0,
+		Name:         "eth0",
+		HardwareAddr: macAddr,
+	}
+
+	addr := mockAddr{
+		network: "test-network",
+		ipAddr:  "192.168.0.1/8",
+	}
+
+	addrs := []net.Addr{net.Addr(addr)}
+
+	result, err := plugin.createResult(iface, addrs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if reflect.DeepEqual(result, expected) == false {
+		t.Fatal()
+	}
+}

--- a/filesystem.go
+++ b/filesystem.go
@@ -81,6 +81,7 @@ type resourceStorage interface {
 	fetchPodConfig(podID string) (PodConfig, error)
 	fetchPodState(podID string) (State, error)
 	fetchPodNetwork(podID string) (NetworkNamespace, error)
+	storePodNetwork(podID string, networkNS NetworkNamespace) error
 
 	// Container resources
 	storeContainerResource(podID, containerID string, resource podResource, data interface{}) error
@@ -383,6 +384,10 @@ func (fs *filesystem) fetchPodNetwork(podID string) (NetworkNamespace, error) {
 	}
 
 	return NetworkNamespace{}, fmt.Errorf("Unknown network type")
+}
+
+func (fs *filesystem) storePodNetwork(podID string, networkNS NetworkNamespace) error {
+	return fs.storePodResource(podID, networkFileType, networkNS)
 }
 
 func (fs *filesystem) deletePodResources(podID string, resources []podResource) error {

--- a/hook.go
+++ b/hook.go
@@ -1,0 +1,145 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/golang/glog"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// Hook represents an OCI hook, including its required parameters.
+type Hook struct {
+	Path    string
+	Args    []string
+	Env     []string
+	Timeout int
+}
+
+// Hooks gathers all existing OCI hooks list.
+type Hooks struct {
+	PreStartHooks  []Hook
+	PostStartHooks []Hook
+	PostStopHooks  []Hook
+}
+
+func buildHookState(processID int) specs.State {
+	return specs.State{
+		Pid: processID,
+	}
+}
+
+func (h *Hook) runHook() error {
+	state := buildHookState(os.Getpid())
+	stateJSON, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := &exec.Cmd{
+		Path:   h.Path,
+		Args:   h.Args,
+		Env:    h.Env,
+		Stdin:  bytes.NewReader(stateJSON),
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+
+	err = cmd.Start()
+	if err != nil {
+		return err
+	}
+
+	if h.Timeout == 0 {
+		err = cmd.Wait()
+		if err != nil {
+			return fmt.Errorf("%s: stdout: %s, stderr: %s", err, stdout.String(), stderr.String())
+		}
+	} else {
+		done := make(chan error)
+
+		go func() { done <- cmd.Wait() }()
+
+		select {
+		case err := <-done:
+			if err != nil {
+				return fmt.Errorf("%s: stdout: %s, stderr: %s", err, stdout.String(), stderr.String())
+			}
+		case <-time.After(time.Duration(h.Timeout) * time.Second):
+			return fmt.Errorf("Hook timeout")
+		}
+	}
+
+	return nil
+}
+
+func (h *Hooks) preStartHooks() error {
+	if len(h.PreStartHooks) == 0 {
+		return nil
+	}
+
+	for _, hook := range h.PreStartHooks {
+		err := hook.runHook()
+		if err != nil {
+			glog.Errorf("PreStartHook error: %s\n", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (h *Hooks) postStartHooks() error {
+	if len(h.PostStartHooks) == 0 {
+		return nil
+	}
+
+	for _, hook := range h.PostStartHooks {
+		err := hook.runHook()
+		if err != nil {
+			// In case of post start hook, the error is not fatal,
+			// just need to be logged.
+			glog.Infof("PostStartHook error: %s\n", err)
+		}
+	}
+
+	return nil
+}
+
+func (h *Hooks) postStopHooks() error {
+	if len(h.PostStopHooks) == 0 {
+		return nil
+	}
+
+	for _, hook := range h.PostStopHooks {
+		err := hook.runHook()
+		if err != nil {
+			// In case of post stop hook, the error is not fatal,
+			// just need to be logged.
+			glog.Infof("PostStopHook error: %s\n", err)
+		}
+	}
+
+	return nil
+}

--- a/hook/mock/hook.go
+++ b/hook/mock/hook.go
@@ -1,0 +1,96 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/opencontainers/runc/libcontainer/configs"
+)
+
+var logFile = "/tmp/mock_hook.log"
+var testKey = "test-key"
+var testContainerID = "test-container-id"
+var testControllerID = "test-controller-id"
+
+func main() {
+	err := os.RemoveAll(logFile)
+	if err != nil {
+		os.Exit(1)
+	}
+
+	f, err := os.Create(logFile)
+	if err != nil {
+		os.Exit(1)
+	}
+	defer f.Close()
+
+	fmt.Fprintf(f, "args = %s\n", os.Args)
+
+	if len(os.Args) < 3 {
+		fmt.Fprintf(f, "At least 3 args expected, only %d received\n", len(os.Args))
+		os.Exit(1)
+	}
+
+	if os.Args[0] != testKey {
+		fmt.Fprintf(f, "args[0] should be \"%s\", received \"%s\" instead\n", testKey, os.Args[0])
+		os.Exit(1)
+	}
+
+	if os.Args[1] != testContainerID {
+		fmt.Fprintf(f, "argv[1] should be \"%s\", received \"%s\" instead\n", testContainerID, os.Args[1])
+		os.Exit(1)
+	}
+
+	if os.Args[2] != testControllerID {
+		fmt.Fprintf(f, "argv[2] should be \"%s\", received \"%s\" instead\n", testControllerID, os.Args[2])
+		os.Exit(1)
+	}
+
+	stateBuf, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(f, "Could not read on stdin: %s\n", err)
+		os.Exit(1)
+	}
+
+	var state configs.HookState
+	err = json.Unmarshal(stateBuf, &state)
+	if err != nil {
+		fmt.Fprintf(f, "Could not unmarshal HookState json: %s\n", err)
+		os.Exit(1)
+	}
+
+	if state.Pid < 1 {
+		fmt.Fprintf(f, "Invalid PID: %d\n", state.Pid)
+		os.Exit(1)
+	}
+
+	// Intended to sleep, so as to make the test passing/failing.
+	if len(os.Args) == 4 {
+		timeout, err := strconv.Atoi(os.Args[3])
+		if err != nil {
+			fmt.Fprintf(f, "Could not retrieve timeout %s from args[3]\n", os.Args[3])
+			os.Exit(1)
+		}
+		time.Sleep(time.Duration(timeout) * time.Second)
+	}
+}

--- a/hook_test.go
+++ b/hook_test.go
@@ -1,0 +1,175 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// Important to keep these values in sync with hook test binary
+var testKeyHook = "test-key"
+var testContainerIDHook = "test-container-id"
+var testControllerIDHook = "test-controller-id"
+var testProcessIDHook = 12345
+var testBinHookPath = "/tmp/bin/hook"
+
+func TestBuildHookState(t *testing.T) {
+	expected := specs.State{
+		Pid: testProcessIDHook,
+	}
+
+	hookState := buildHookState(testProcessIDHook)
+
+	if reflect.DeepEqual(hookState, expected) == false {
+		t.Fatal()
+	}
+}
+
+func createHook(timeout int) *Hook {
+	return &Hook{
+		Path:    testBinHookPath,
+		Args:    []string{testKeyHook, testContainerIDHook, testControllerIDHook},
+		Env:     os.Environ(),
+		Timeout: timeout,
+	}
+}
+
+func createWrongHook() *Hook {
+	return &Hook{
+		Path: testBinHookPath,
+		Args: []string{"wrong-args"},
+		Env:  os.Environ(),
+	}
+}
+
+func testRunHook(t *testing.T, timeout int) {
+	hook := createHook(timeout)
+
+	err := hook.runHook()
+	if err != nil {
+		t.Fatal()
+	}
+}
+
+func TestRunHook(t *testing.T) {
+	testRunHook(t, 0)
+}
+
+func TestRunHookTimeout(t *testing.T) {
+	testRunHook(t, 1)
+}
+
+func TestRunHookExitFailure(t *testing.T) {
+	hook := createWrongHook()
+
+	err := hook.runHook()
+	if err == nil {
+		t.Fatal()
+	}
+}
+
+func TestRunHookTimeoutFailure(t *testing.T) {
+	hook := createHook(1)
+
+	hook.Args = append(hook.Args, "2")
+
+	err := hook.runHook()
+	if err == nil {
+		t.Fatal()
+	}
+}
+
+func testHooks(t *testing.T, hook *Hook) {
+	hooks := &Hooks{
+		PreStartHooks:  []Hook{*hook},
+		PostStartHooks: []Hook{*hook},
+		PostStopHooks:  []Hook{*hook},
+	}
+
+	err := hooks.preStartHooks()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = hooks.postStartHooks()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = hooks.postStopHooks()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testFailingHooks(t *testing.T, hook *Hook) {
+	hooks := &Hooks{
+		PreStartHooks:  []Hook{*hook},
+		PostStartHooks: []Hook{*hook},
+		PostStopHooks:  []Hook{*hook},
+	}
+
+	err := hooks.preStartHooks()
+	if err == nil {
+		t.Fatal(err)
+	}
+
+	err = hooks.postStartHooks()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = hooks.postStopHooks()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHooks(t *testing.T) {
+	testHooks(t, createHook(0))
+}
+
+func TestHooksTimeout(t *testing.T) {
+	testHooks(t, createHook(1))
+}
+
+func TestFailingHooks(t *testing.T) {
+	testFailingHooks(t, createWrongHook())
+}
+
+func TestEmptyHooks(t *testing.T) {
+	hooks := &Hooks{}
+
+	err := hooks.preStartHooks()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = hooks.postStartHooks()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = hooks.postStopHooks()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/hypervisor.go
+++ b/hypervisor.go
@@ -164,7 +164,7 @@ func serializeParams(params []Param, delim string) []string {
 // The default hypervisor implementation is Qemu.
 type hypervisor interface {
 	init(config HypervisorConfig) error
-	createPod(podConfig PodConfig, endpoints []Endpoint) error
+	createPod(podConfig PodConfig) error
 	startPod(startCh, stopCh chan struct{}) error
 	stopPod() error
 	addDevice(devInfo interface{}, devType deviceType) error

--- a/mock_hypervisor.go
+++ b/mock_hypervisor.go
@@ -28,7 +28,7 @@ func (m *mockHypervisor) init(config HypervisorConfig) error {
 	return nil
 }
 
-func (m *mockHypervisor) createPod(podConfig PodConfig, endpoints []Endpoint) error {
+func (m *mockHypervisor) createPod(podConfig PodConfig) error {
 	return nil
 }
 

--- a/mock_hypervisor_test.go
+++ b/mock_hypervisor_test.go
@@ -52,9 +52,8 @@ func TestMockHypervisorCreatePod(t *testing.T) {
 	var m *mockHypervisor
 
 	config := PodConfig{}
-	endpoints := []Endpoint{}
 
-	err := m.createPod(config, endpoints)
+	err := m.createPod(config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/network.go
+++ b/network.go
@@ -340,6 +340,30 @@ func deleteNetNS(netNSPath string, mounted bool) error {
 	return nil
 }
 
+func createNetworkEndpoint(idx int, uniqueID string, ifName string) Endpoint {
+	hardAddr := net.HardwareAddr{0x02, 0x00, 0xCA, 0xFE, byte(idx >> 8), byte(idx)}
+
+	endpoint := Endpoint{
+		NetPair: NetworkInterfacePair{
+			ID:   fmt.Sprintf("%s-%d", uniqueID, idx),
+			Name: fmt.Sprintf("br%d", idx),
+			VirtIface: NetworkInterface{
+				Name:     fmt.Sprintf("eth%d", idx),
+				HardAddr: hardAddr.String(),
+			},
+			TAPIface: NetworkInterface{
+				Name: fmt.Sprintf("tap%d", idx),
+			},
+		},
+	}
+
+	if ifName != "" {
+		endpoint.NetPair.VirtIface.Name = ifName
+	}
+
+	return endpoint
+}
+
 func createNetworkEndpoints(numOfEndpoints int) ([]Endpoint, error) {
 	var endpoints []Endpoint
 
@@ -350,23 +374,7 @@ func createNetworkEndpoints(numOfEndpoints int) ([]Endpoint, error) {
 	uniqueID := uuid.Generate().String()
 
 	for i := 0; i < numOfEndpoints; i++ {
-		hardAddr := net.HardwareAddr{0x02, 0x00, 0xCA, 0xFE, byte(i >> 8), byte(i)}
-
-		endpoint := Endpoint{
-			NetPair: NetworkInterfacePair{
-				ID:   fmt.Sprintf("%s-%d", uniqueID, i),
-				Name: fmt.Sprintf("br%d", i),
-				VirtIface: NetworkInterface{
-					Name:     fmt.Sprintf("eth%d", i),
-					HardAddr: hardAddr.String(),
-				},
-				TAPIface: NetworkInterface{
-					Name: fmt.Sprintf("tap%d", i),
-				},
-			},
-		}
-
-		endpoints = append(endpoints, endpoint)
+		endpoints = append(endpoints, createNetworkEndpoint(i, uniqueID, ""))
 	}
 
 	return endpoints, nil

--- a/network.go
+++ b/network.go
@@ -378,12 +378,12 @@ func createNetworkEndpoints(numOfEndpoints int) ([]Endpoint, error) {
 type network interface {
 	// add creates a new network namespace and its virtual network interfaces,
 	// and it creates and bridges TAP interfaces.
-	add(config *NetworkConfig) (NetworkNamespace, error)
+	add(pod Pod, config *NetworkConfig) (NetworkNamespace, error)
 
 	// join switches the current process to the specified network namespace.
 	join(networkNS NetworkNamespace) error
 
 	// remove unbridges and deletes TAP interfaces. It also removes virtual network
 	// interfaces and deletes the network namespace.
-	remove(networkNS NetworkNamespace) error
+	remove(pod Pod, networkNS NetworkNamespace) error
 }

--- a/network.go
+++ b/network.go
@@ -380,12 +380,14 @@ func addNetDevHypervisor(pod Pod, endpoints []Endpoint) error {
 // Container network plugins are used to setup virtual network
 // between VM netns and the host network physical interface.
 type network interface {
-	// add creates a new network namespace and its virtual network interfaces,
-	// and it creates and bridges TAP interfaces.
-	add(pod Pod, config *NetworkConfig) (NetworkNamespace, error)
+	// init initializes the network, setting a new network namespace.
+	init(config *NetworkConfig) error
 
 	// join switches the current process to the specified network namespace.
-	join(networkNS NetworkNamespace) error
+	join(networkNSPath string) error
+
+	// add adds all needed interfaces inside the network namespace.
+	add(pod Pod, config NetworkConfig) (NetworkNamespace, error)
 
 	// remove unbridges and deletes TAP interfaces. It also removes virtual network
 	// interfaces and deletes the network namespace.

--- a/network.go
+++ b/network.go
@@ -372,6 +372,10 @@ func createNetworkEndpoints(numOfEndpoints int) ([]Endpoint, error) {
 	return endpoints, nil
 }
 
+func addNetDevHypervisor(pod Pod, endpoints []Endpoint) error {
+	return pod.hypervisor.addDevice(endpoints, netDev)
+}
+
 // network is the virtcontainers network interface.
 // Container network plugins are used to setup virtual network
 // between VM netns and the host network physical interface.

--- a/network_test.go
+++ b/network_test.go
@@ -1,0 +1,200 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"net"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func testNetworkModelSet(t *testing.T, value string, expected NetworkModel) {
+	var netModel NetworkModel
+
+	err := netModel.Set(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if netModel != expected {
+		t.Fatal()
+	}
+}
+
+func TestNoopNetworkModelSet(t *testing.T) {
+	testNetworkModelSet(t, "noop", NoopNetworkModel)
+}
+
+func TestCNINetworkModelSet(t *testing.T) {
+	testNetworkModelSet(t, "CNI", CNINetworkModel)
+}
+
+func TestCNMNetworkModelSet(t *testing.T) {
+	testNetworkModelSet(t, "CNM", CNMNetworkModel)
+}
+
+func TestNetworkModelSetFailure(t *testing.T) {
+	var netModel NetworkModel
+
+	err := netModel.Set("wrong-value")
+	if err == nil {
+		t.Fatal(err)
+	}
+}
+
+func testNetworkModelString(t *testing.T, netModel *NetworkModel, expected string) {
+	result := netModel.String()
+
+	if result != expected {
+		t.Fatal()
+	}
+}
+
+func TestNoopNetworkModelString(t *testing.T) {
+	netModel := NoopNetworkModel
+	testNetworkModelString(t, &netModel, string(NoopNetworkModel))
+}
+
+func TestCNINetworkModelString(t *testing.T) {
+	netModel := CNINetworkModel
+	testNetworkModelString(t, &netModel, string(CNINetworkModel))
+}
+
+func TestCNMNetworkModelString(t *testing.T) {
+	netModel := CNMNetworkModel
+	testNetworkModelString(t, &netModel, string(CNMNetworkModel))
+}
+
+func TestWrongNetworkModelString(t *testing.T) {
+	var netModel NetworkModel
+	testNetworkModelString(t, &netModel, "")
+}
+
+func testNewNetworkFromNetworkModel(t *testing.T, netModel NetworkModel, expected interface{}) {
+	result := newNetwork(netModel)
+
+	if reflect.DeepEqual(result, expected) == false {
+		t.Fatal()
+	}
+}
+
+func TestNewNoopNetworkFromNetworkModel(t *testing.T) {
+	testNewNetworkFromNetworkModel(t, NoopNetworkModel, &noopNetwork{})
+}
+
+func TestNewCNINetworkFromNetworkModel(t *testing.T) {
+	testNewNetworkFromNetworkModel(t, CNINetworkModel, &cni{})
+}
+
+func TestNewCNMNetworkFromNetworkModel(t *testing.T) {
+	testNewNetworkFromNetworkModel(t, CNMNetworkModel, &cnm{})
+}
+
+func TestNewUnknownNetworkFromNetworkModel(t *testing.T) {
+	var netModel NetworkModel
+	testNewNetworkFromNetworkModel(t, netModel, &noopNetwork{})
+}
+
+func TestCreateDeleteNetNS(t *testing.T) {
+	netNSPath, err := createNetNS()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if netNSPath == "" {
+		t.Fatal()
+	}
+
+	_, err = os.Stat(netNSPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = deleteNetNS(netNSPath, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCreateNetworkEndpoint(t *testing.T) {
+	macAddr := net.HardwareAddr{0x02, 0x00, 0xCA, 0xFE, 0x00, 0x04}
+
+	expected := Endpoint{
+		NetPair: NetworkInterfacePair{
+			ID:   "uniqueTestID-4",
+			Name: "br4",
+			VirtIface: NetworkInterface{
+				Name:     "eth4",
+				HardAddr: macAddr.String(),
+			},
+			TAPIface: NetworkInterface{
+				Name: "tap4",
+			},
+		},
+	}
+
+	result := createNetworkEndpoint(4, "uniqueTestID", "")
+
+	if reflect.DeepEqual(result, expected) == false {
+		t.Fatal()
+	}
+}
+
+func TestCreateNetworkEndpointChooseIfaceName(t *testing.T) {
+	macAddr := net.HardwareAddr{0x02, 0x00, 0xCA, 0xFE, 0x00, 0x04}
+
+	expected := Endpoint{
+		NetPair: NetworkInterfacePair{
+			ID:   "uniqueTestID-4",
+			Name: "br4",
+			VirtIface: NetworkInterface{
+				Name:     "eth1",
+				HardAddr: macAddr.String(),
+			},
+			TAPIface: NetworkInterface{
+				Name: "tap4",
+			},
+		},
+	}
+
+	result := createNetworkEndpoint(4, "uniqueTestID", "eth1")
+
+	if reflect.DeepEqual(result, expected) == false {
+		t.Fatal()
+	}
+}
+
+func TestCreateNetworkEndpoints(t *testing.T) {
+	numOfEndpoints := 3
+
+	endpoints, err := createNetworkEndpoints(numOfEndpoints)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(endpoints) != numOfEndpoints {
+		t.Fatal()
+	}
+}
+
+func TestCreateNetworkEndpointsFailure(t *testing.T) {
+	_, err := createNetworkEndpoints(0)
+	if err == nil {
+		t.Fatal(err)
+	}
+}

--- a/noop_network.go
+++ b/noop_network.go
@@ -21,18 +21,23 @@ package virtcontainers
 type noopNetwork struct {
 }
 
-// add creates a new network namespace and its virtual network interfaces,
-// and it creates and bridges TAP interfaces for the Noop network.
+// init initializes the network, setting a new network namespace for the Noop network.
 // It does nothing.
-func (n *noopNetwork) add(pod Pod, config *NetworkConfig) (NetworkNamespace, error) {
-	return NetworkNamespace{}, nil
+func (n *noopNetwork) init(config *NetworkConfig) error {
+	return nil
 }
 
 // join switches the current process to the specified network namespace for
 // the Noop network.
 // It does nothing.
-func (n *noopNetwork) join(networkNS NetworkNamespace) error {
+func (n *noopNetwork) join(networkNSPath string) error {
 	return nil
+}
+
+// add adds all needed interfaces inside the network namespace the Noop network.
+// It does nothing.
+func (n *noopNetwork) add(pod Pod, config NetworkConfig) (NetworkNamespace, error) {
+	return NetworkNamespace{}, nil
 }
 
 // remove unbridges and deletes TAP interfaces. It also removes virtual network

--- a/noop_network.go
+++ b/noop_network.go
@@ -24,7 +24,7 @@ type noopNetwork struct {
 // add creates a new network namespace and its virtual network interfaces,
 // and it creates and bridges TAP interfaces for the Noop network.
 // It does nothing.
-func (n *noopNetwork) add(config *NetworkConfig) (NetworkNamespace, error) {
+func (n *noopNetwork) add(pod Pod, config *NetworkConfig) (NetworkNamespace, error) {
 	return NetworkNamespace{}, nil
 }
 
@@ -38,6 +38,6 @@ func (n *noopNetwork) join(networkNS NetworkNamespace) error {
 // remove unbridges and deletes TAP interfaces. It also removes virtual network
 // interfaces and deletes the network namespace for the Noop network.
 // It does nothing.
-func (n *noopNetwork) remove(networkNS NetworkNamespace) error {
+func (n *noopNetwork) remove(pod Pod, networkNS NetworkNamespace) error {
 	return nil
 }

--- a/pod.go
+++ b/pod.go
@@ -429,22 +429,20 @@ func createPod(podConfig PodConfig, networkNS NetworkNamespace) (*Pod, error) {
 
 // storePod stores a pod config.
 func (p *Pod) storePod() error {
-	fs := filesystem{}
-
-	err := fs.storePodResource(p.id, configFileType, *(p.config))
+	err := p.storage.storePodResource(p.id, configFileType, *(p.config))
 	if err != nil {
 		return err
 	}
 
 	for _, container := range p.containers {
-		err = fs.storeContainerResource(p.id, container.ID, configFileType, container)
+		err = p.storage.storeContainerResource(p.id, container.ID, configFileType, container)
 		if err != nil {
 			return err
 		}
 	}
 
 	// Store network pairs.
-	err = fs.storePodNetwork(p.id, p.networkNS)
+	err = p.storage.storePodNetwork(p.id, p.networkNS)
 	if err != nil {
 		return err
 	}

--- a/pod.go
+++ b/pod.go
@@ -444,7 +444,7 @@ func (p *Pod) storePod() error {
 	}
 
 	// Store network pairs.
-	err = fs.storePodResource(p.id, networkFileType, p.networkNS)
+	err = fs.storePodNetwork(p.id, p.networkNS)
 	if err != nil {
 		return err
 	}

--- a/pod.go
+++ b/pod.go
@@ -230,6 +230,9 @@ type Resources struct {
 type PodConfig struct {
 	ID string
 
+	// Field specific to OCI specs, needed to setup all the hooks
+	Hooks Hooks
+
 	// VMConfig is the VM configuration to set for this pod.
 	VMConfig Resources
 

--- a/pod_test.go
+++ b/pod_test.go
@@ -59,13 +59,7 @@ func testCreatePod(t *testing.T, id string,
 		Containers:       containers,
 	}
 
-	n := newNetwork(config.NetworkModel)
-	networkNS, err := n.add(&(config.NetworkConfig))
-	if err != nil {
-		return nil, fmt.Errorf("Could not add network: %s", err)
-	}
-
-	pod, err := createPod(config, networkNS)
+	pod, err := createPod(config)
 	if err != nil {
 		return nil, fmt.Errorf("Could not create pod: %s", err)
 	}

--- a/qemu.go
+++ b/qemu.go
@@ -406,7 +406,7 @@ func (q *qemu) setMemoryResources(podConfig PodConfig) ciaoQemu.Memory {
 }
 
 // createPod is the Hypervisor pod creation implementation for ciaoQemu.
-func (q *qemu) createPod(podConfig PodConfig, endpoints []Endpoint) error {
+func (q *qemu) createPod(podConfig PodConfig) error {
 	var devices []ciaoQemu.Device
 
 	machine := ciaoQemu.Machine{
@@ -466,8 +466,6 @@ func (q *qemu) createPod(podConfig PodConfig, endpoints []Endpoint) error {
 	if err != nil {
 		return err
 	}
-
-	devices = q.appendNetworks(devices, endpoints)
 
 	qemuConfig := ciaoQemu.Config{
 		Name:        fmt.Sprintf("pod-%s", podConfig.ID),
@@ -537,6 +535,9 @@ func (q *qemu) addDevice(devInfo interface{}, devType deviceType) error {
 	case serialPortDev:
 		socket := devInfo.(Socket)
 		q.qemuConfig.Devices = q.appendSocket(q.qemuConfig.Devices, socket)
+	case netDev:
+		endpoints := devInfo.([]Endpoint)
+		q.qemuConfig.Devices = q.appendNetworks(q.qemuConfig.Devices, endpoints)
 	default:
 		break
 	}


### PR DESCRIPTION
This PR modifies the way the network interface was handled for the CNI implementation so that it can work for the CNM implementation. Then, it adds the OCI hooks handling, because we need to be able to handle those hooks for network setup. At last, it implements the CNM network interface.