### PR TITLE
network: cni: Update cni package because of libcni changes

### DIFF
--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -32,6 +32,8 @@ const (
 	PluginBinDir  = "/opt/cni/bin"
 )
 
+var confExtensions = []string{".conf"}
+
 // NetworkPlugin is the CNI network plugin handler.
 type NetworkPlugin struct {
 	loNetwork  *cniNetwork
@@ -71,7 +73,7 @@ func NewNetworkPluginWithArgs(confDir, binDir string) (*NetworkPlugin, error) {
 }
 
 func getNetwork(confDir, binDir, defaultName string, local bool) (*cniNetwork, error) {
-	confFiles, err := libcni.ConfFiles(confDir)
+	confFiles, err := libcni.ConfFiles(confDir, confExtensions)
 	if err != nil || confFiles == nil {
 		return nil, fmt.Errorf("Invalid configuration directory %s", confDir)
 	}


### PR DESCRIPTION
We need to update the package because we have a missing arguments
from the recently changed function ConfFiles() from libcni.
We have to provide a list of expected extensions to get it
working as before.