### PR TITLE
Fix build due to recent dependencies changes

### DIFF
--- a/cc_proxy.go
+++ b/cc_proxy.go
@@ -77,7 +77,7 @@ func (p *ccProxy) register(pod Pod) ([]IOStream, error) {
 		return []IOStream{}, fmt.Errorf("Wrong agent config type, should be HyperConfig type")
 	}
 
-	err = p.client.Hello(pod.id, hyperConfig.SockCtlName, hyperConfig.SockTtyName)
+	_, err = p.client.Hello(pod.id, hyperConfig.SockCtlName, hyperConfig.SockTtyName, nil)
 	if err != nil {
 		return []IOStream{}, err
 	}
@@ -112,7 +112,7 @@ func (p *ccProxy) connect(pod Pod) (IOStream, error) {
 		return IOStream{}, err
 	}
 
-	err = p.client.Attach(pod.id)
+	_, err = p.client.Attach(pod.id, nil)
 	if err != nil {
 		return IOStream{}, err
 	}

--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -32,6 +32,8 @@ const (
 	PluginBinDir  = "/opt/cni/bin"
 )
 
+var confExtensions = []string{".conf"}
+
 // NetworkPlugin is the CNI network plugin handler.
 type NetworkPlugin struct {
 	loNetwork  *cniNetwork
@@ -71,7 +73,7 @@ func NewNetworkPluginWithArgs(confDir, binDir string) (*NetworkPlugin, error) {
 }
 
 func getNetwork(confDir, binDir, defaultName string, local bool) (*cniNetwork, error) {
-	confFiles, err := libcni.ConfFiles(confDir)
+	confFiles, err := libcni.ConfFiles(confDir, confExtensions)
 	if err != nil || confFiles == nil {
 		return nil, fmt.Errorf("Invalid configuration directory %s", confDir)
 	}


### PR DESCRIPTION
Our cni package relies on libcni library and they recently updated one function we were using, thus we provide the fix for that.
Then, proxy API from cc-oci-runtime changed recently due to a global re-design, meaning it had to change the Client API too. Because we use this Client API to communicate with cc-proxy, we have to fix it to allow our build to pass.