### PR TITLE
travis: Re-enable code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
     - tip
 
 env:
-    - COVERALLS_TOKEN=zstmJAjtUJNpNu4QtWYwRmmjPYu3Iubi5
+    - COVERALLS_TOKEN=3NUr5Z9zvjIoGRlKi6WIA3Q9em3x22rZp
 
 before_install:
   - go get github.com/mattn/goveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/containers/virtcontainers.svg?branch=master)](https://travis-ci.org/containers/virtcontainers)
 [![Go Report Card](https://goreportcard.com/badge/github.com/containers/virtcontainers)](https://goreportcard.com/report/github.com/containers/virtcontainers)
-[![Coverage Status](https://coveralls.io/repos/github/sameo/virtcontainers/badge.svg?branch=master)](https://coveralls.io/github/sameo/virtcontainers?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/containers/virtcontainers/badge.svg?branch=master)](https://coveralls.io/github/containers/virtcontainers?branch=master)
 [![GoDoc](https://godoc.org/github.com/containers/virtcontainers?status.svg)](https://godoc.org/github.com/containers/virtcontainers)
 
 # virtcontainers


### PR DESCRIPTION
coveralls was still pointing at our old repo.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>