### PR TITLE
Fix the build according to API changes from cni/pkg/types

### DIFF
--- a/network.go
+++ b/network.go
@@ -24,7 +24,7 @@ import (
 	"github.com/01org/ciao/networking/libsnnet"
 	"github.com/01org/ciao/ssntp/uuid"
 	"github.com/containernetworking/cni/pkg/ns"
-	"github.com/containernetworking/cni/pkg/types"
+	types "github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containers/virtcontainers/logger/gloginterface"
 	"golang.org/x/sys/unix"
 )

--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 
 	"github.com/containernetworking/cni/libcni"
-	"github.com/containernetworking/cni/pkg/types"
+	types "github.com/containernetworking/cni/pkg/types/current"
 )
 
 // CNI default values to find plugins and configurations.
@@ -140,7 +140,12 @@ func (plugin *NetworkPlugin) AddNetwork(podID, netNSPath, ifName string) (*types
 		return nil, err
 	}
 
-	res, err := plugin.defNetwork.cniConfig.AddNetwork(plugin.defNetwork.networkConfig, rt)
+	ifaceResult, err := plugin.defNetwork.cniConfig.AddNetwork(plugin.defNetwork.networkConfig, rt)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := types.GetResult(ifaceResult)
 	if err != nil {
 		return nil, err
 	}

--- a/network/cni/cni_test.go
+++ b/network/cni/cni_test.go
@@ -35,18 +35,18 @@ var testLoFile = "99-test_loopback.conf"
 var testWrongFile = "100-test_error.conf"
 
 var testLoFileContent = []byte(`{
-    "cniVersion": "0.2.0",
+    "cniVersion": "0.3.0",
     "name": "testlonetwork",
     "type": "loopback"
 }`)
 
 var testLoFileContentNoName = []byte(`{
-    "cniVersion": "0.2.0",
+    "cniVersion": "0.3.0",
     "type": "loopback"
 }`)
 
 var testDefFileContent = []byte(`{
-    "cniVersion": "0.2.0",
+    "cniVersion": "0.3.0",
     "name": "testdefnetwork",
     "type": "cni-bridge",
     "bridge": "cni0",
@@ -62,7 +62,7 @@ var testDefFileContent = []byte(`{
 }`)
 
 var testDefFileContentNoName = []byte(`{
-    "cniVersion": "0.2.0",
+    "cniVersion": "0.3.0",
     "type": "cni-bridge",
     "bridge": "cni0",
     "isGateway": true,
@@ -77,7 +77,7 @@ var testDefFileContentNoName = []byte(`{
 }`)
 
 var testWrongFileContent = []byte(`{
-    "cniVersion "0.2.0",
+    "cniVersion "0.3.0",
     "type": "loopback"
 }`)
 


### PR DESCRIPTION
The package github.com/containernetworking/cni/pkg/types has been recently
modified and the Result structure has been moved to an interface. Instead,
two new packages cni/pkg/types/020 and cni/pkg/types/current have been added.
Those new packages provides some functions to convert the Result interface
into a 020.Result or current.Result structure.
Because we want to follow latest version, this commit modifies our cni and
virtcontainers packages so as to get current.Result structure.