### PR TITLE
Fix netns usage and improve network unit testing coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,13 @@ install:
   - go build -o hook $GOPATH/src/github.com/containers/virtcontainers/hook/mock/hook.go
   - sudo cp hook /tmp/bin/
   - popd
+  - sudo mkdir -p /etc/cni/net.d
+  - sudo cp $GOPATH/src/github.com/containers/virtcontainers/test/cni/10-mynet.conf /etc/cni/net.d/
+  - sudo cp $GOPATH/src/github.com/containers/virtcontainers/test/cni/99-loopback.conf /etc/cni/net.d/
+  - sudo mkdir -p /opt/cni/bin
+  - sudo cp /tmp/cni/bin/cni-bridge /opt/cni/bin/
+  - sudo cp /tmp/cni/bin/loopback /opt/cni/bin/
+  - sudo cp /tmp/cni/bin/host-local /opt/cni/bin/
   - go get -t -v ./...
 
 script:

--- a/api.go
+++ b/api.go
@@ -92,14 +92,13 @@ func StartPod(podID string) (*Pod, error) {
 	}
 
 	// Initialize the network.
-	n := newNetwork(p.config.NetworkModel)
-	err = n.init(&(p.config.NetworkConfig))
+	err = p.network.init(&(p.config.NetworkConfig))
 	if err != nil {
 		return nil, err
 	}
 
 	// Join the network.
-	err = n.join(p.config.NetworkConfig.NetNSPath)
+	err = p.network.join(p.config.NetworkConfig.NetNSPath)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +110,7 @@ func StartPod(podID string) (*Pod, error) {
 	}
 
 	// Add the network
-	networkNS, err := n.add(*p, p.config.NetworkConfig)
+	networkNS, err := p.network.add(*p, p.config.NetworkConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -171,8 +170,7 @@ func StopPod(podID string) (*Pod, error) {
 	}
 
 	// Remove the network
-	n := newNetwork(p.config.NetworkModel)
-	err = n.remove(*p, networkNS)
+	err = p.network.remove(*p, networkNS)
 	if err != nil {
 		return nil, err
 	}
@@ -213,14 +211,13 @@ func RunPod(podConfig PodConfig) (*Pod, error) {
 	defer unlockPod(lockFile)
 
 	// Initialize the network.
-	n := newNetwork(p.config.NetworkModel)
-	err = n.init(&(p.config.NetworkConfig))
+	err = p.network.init(&(p.config.NetworkConfig))
 	if err != nil {
 		return nil, err
 	}
 
 	// Join the network.
-	err = n.join(p.config.NetworkConfig.NetNSPath)
+	err = p.network.join(p.config.NetworkConfig.NetNSPath)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +229,7 @@ func RunPod(podConfig PodConfig) (*Pod, error) {
 	}
 
 	// Add the network
-	networkNS, err := n.add(*p, p.config.NetworkConfig)
+	networkNS, err := p.network.add(*p, p.config.NetworkConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/cnm.go
+++ b/cnm.go
@@ -121,13 +121,10 @@ func (n *cnm) init(config *NetworkConfig) error {
 
 // join switches the current process to the specified network namespace
 // for the CNM network.
-func (n *cnm) join(networkNSPath string) error {
-	err := setNetNS(networkNSPath)
-	if err != nil {
-		return err
-	}
-
-	return nil
+func (n *cnm) join(networkNSPath string, cb func() error) error {
+	return doNetNS(networkNSPath, func(_ ns.NetNS) error {
+		return cb()
+	})
 }
 
 // add adds all needed interfaces inside the network namespace for the CNM network.

--- a/network.go
+++ b/network.go
@@ -392,7 +392,7 @@ type network interface {
 	init(config *NetworkConfig) error
 
 	// join switches the current process to the specified network namespace.
-	join(networkNSPath string) error
+	join(networkNSPath string, cb func() error) error
 
 	// add adds all needed interfaces inside the network namespace.
 	add(pod Pod, config NetworkConfig) (NetworkNamespace, error)

--- a/noop_network.go
+++ b/noop_network.go
@@ -30,8 +30,8 @@ func (n *noopNetwork) init(config *NetworkConfig) error {
 // join switches the current process to the specified network namespace for
 // the Noop network.
 // It does nothing.
-func (n *noopNetwork) join(networkNSPath string) error {
-	return nil
+func (n *noopNetwork) join(networkNSPath string, cb func() error) error {
+	return cb()
 }
 
 // add adds all needed interfaces inside the network namespace the Noop network.

--- a/pod.go
+++ b/pod.go
@@ -312,6 +312,7 @@ type Pod struct {
 	hypervisor hypervisor
 	agent      agent
 	storage    resourceStorage
+	network    network
 
 	config *PodConfig
 
@@ -370,11 +371,14 @@ func createPod(podConfig PodConfig) (*Pod, error) {
 		return nil, err
 	}
 
+	network := newNetwork(podConfig.NetworkModel)
+
 	p := &Pod{
 		id:         podConfig.ID,
 		hypervisor: hypervisor,
 		agent:      agent,
 		storage:    &filesystem{},
+		network:    network,
 		config:     &podConfig,
 		volumes:    podConfig.Volumes,
 		containers: podConfig.Containers,

--- a/pod.go
+++ b/pod.go
@@ -525,7 +525,12 @@ func (p *Pod) start() error {
 	podStartedCh := make(chan struct{})
 	podStoppedCh := make(chan struct{})
 
-	go p.hypervisor.startPod(podStartedCh, podStoppedCh)
+	go func() {
+		err = p.network.join(p.config.NetworkConfig.NetNSPath, func() error {
+			err := p.hypervisor.startPod(podStartedCh, podStoppedCh)
+			return err
+		})
+	}()
 
 	// Wait for the pod started notification
 	select {

--- a/test/cni/10-mynet.conf
+++ b/test/cni/10-mynet.conf
@@ -1,0 +1,15 @@
+{
+    "cniVersion": "0.3.0",
+    "name": "mynet",
+    "type": "cni-bridge",
+    "bridge": "cni0",
+    "isGateway": true,
+    "ipMasq": true,
+    "ipam": {
+        "type": "host-local",
+        "subnet": "10.88.0.0/16",
+        "routes": [
+            { "dst": "0.0.0.0/0" }
+        ]
+    }
+}

--- a/test/cni/99-loopback.conf
+++ b/test/cni/99-loopback.conf
@@ -1,0 +1,4 @@
+{
+    "cniVersion": "0.3.0",
+    "type": "loopback"
+}


### PR DESCRIPTION
We first needed to fix the way we were using the netns. Indeed, it is not safe to switch to a netns, but instead we should execute a block of code inside the specified namespace.
This allowed us to avoid netns confusion and mixing with CNI plugin, and we have been able to add a new unit test relying on CNI network.