### PR TITLE
network: Rename join to run

### DIFF
--- a/api.go
+++ b/api.go
@@ -98,7 +98,7 @@ func StartPod(podID string) (*Pod, error) {
 	}
 
 	// Execute prestart hooks inside netns
-	err = p.network.join(p.config.NetworkConfig.NetNSPath, func() error {
+	err = p.network.run(p.config.NetworkConfig.NetNSPath, func() error {
 		return p.config.Hooks.preStartHooks()
 	})
 	if err != nil {
@@ -124,7 +124,7 @@ func StartPod(podID string) (*Pod, error) {
 	}
 
 	// Execute poststart hooks inside netns
-	err = p.network.join(networkNS.NetNsPath, func() error {
+	err = p.network.run(networkNS.NetNsPath, func() error {
 		return p.config.Hooks.postStartHooks()
 	})
 	if err != nil {
@@ -168,7 +168,7 @@ func StopPod(podID string) (*Pod, error) {
 	}
 
 	// Execute poststop hooks inside netns
-	err = p.network.join(networkNS.NetNsPath, func() error {
+	err = p.network.run(networkNS.NetNsPath, func() error {
 		return p.config.Hooks.postStopHooks()
 	})
 	if err != nil {
@@ -218,7 +218,7 @@ func RunPod(podConfig PodConfig) (*Pod, error) {
 	}
 
 	// Execute prestart hooks inside netns
-	err = p.network.join(p.config.NetworkConfig.NetNSPath, func() error {
+	err = p.network.run(p.config.NetworkConfig.NetNSPath, func() error {
 		return p.config.Hooks.preStartHooks()
 	})
 	if err != nil {
@@ -245,7 +245,7 @@ func RunPod(podConfig PodConfig) (*Pod, error) {
 	}
 
 	// Execute poststart hooks inside netns
-	err = p.network.join(networkNS.NetNsPath, func() error {
+	err = p.network.run(networkNS.NetNsPath, func() error {
 		return p.config.Hooks.postStartHooks()
 	})
 	if err != nil {

--- a/cni.go
+++ b/cni.go
@@ -75,10 +75,11 @@ func (n *cni) init(config *NetworkConfig) error {
 	return nil
 }
 
-// join does not switch the current process to the specified network namespace
+// run runs a callback in the specified network namespace.
+// run does not switch the current process to the specified network namespace
 // for the CNI network. Indeed, the switch will occur in the add() and remove()
 // functions instead.
-func (n *cni) join(networkNSPath string, cb func() error) error {
+func (n *cni) run(networkNSPath string, cb func() error) error {
 	return doNetNS(networkNSPath, func(_ ns.NetNS) error {
 		return cb()
 	})

--- a/cnm.go
+++ b/cnm.go
@@ -119,9 +119,8 @@ func (n *cnm) init(config *NetworkConfig) error {
 	return nil
 }
 
-// join switches the current process to the specified network namespace
-// for the CNM network.
-func (n *cnm) join(networkNSPath string, cb func() error) error {
+// run runs a callback in the specified network namespace.
+func (n *cnm) run(networkNSPath string, cb func() error) error {
 	return doNetNS(networkNSPath, func(_ ns.NetNS) error {
 		return cb()
 	})

--- a/network.go
+++ b/network.go
@@ -391,8 +391,8 @@ type network interface {
 	// init initializes the network, setting a new network namespace.
 	init(config *NetworkConfig) error
 
-	// join switches the current process to the specified network namespace.
-	join(networkNSPath string, cb func() error) error
+	// run runs a callback function in a specified network namespace.
+	run(networkNSPath string, cb func() error) error
 
 	// add adds all needed interfaces inside the network namespace.
 	add(pod Pod, config NetworkConfig) (NetworkNamespace, error)

--- a/noop_network.go
+++ b/noop_network.go
@@ -27,10 +27,10 @@ func (n *noopNetwork) init(config *NetworkConfig) error {
 	return nil
 }
 
-// join switches the current process to the specified network namespace for
+// run runs a callback in the specified network namespace for
 // the Noop network.
 // It does nothing.
-func (n *noopNetwork) join(networkNSPath string, cb func() error) error {
+func (n *noopNetwork) run(networkNSPath string, cb func() error) error {
 	return cb()
 }
 

--- a/pod.go
+++ b/pod.go
@@ -526,7 +526,7 @@ func (p *Pod) start() error {
 	podStoppedCh := make(chan struct{})
 
 	go func() {
-		err = p.network.join(p.config.NetworkConfig.NetNSPath, func() error {
+		err = p.network.run(p.config.NetworkConfig.NetNSPath, func() error {
 			err := p.hypervisor.startPod(podStartedCh, podStoppedCh)
 			return err
 		})


### PR DESCRIPTION
We're mostly running a callback into a networking namespace, not
just joining a netns.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>