### PR TITLE
OCI utils package

### DIFF
--- a/pkg/oci/LICENSE
+++ b/pkg/oci/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -124,9 +124,9 @@ func networkConfig(ocispec spec.Spec) (vc.NetworkConfig, error) {
 // PodConfig converts an OCI compatible runtime configuration file
 // to a virtcontainers pod configuration structure.
 func PodConfig(runtime RuntimeConfig, bundlePath, cid, console string) (*vc.PodConfig, error) {
-	log.Debugf("converting %s/config.json", bundlePath)
-
 	configPath := filepath.Join(bundlePath, "config.json")
+	log.Debugf("converting %s", configPath)
+
 	configByte, err := ioutil.ReadFile(configPath)
 	if err != nil {
 		return nil, err
@@ -138,6 +138,7 @@ func PodConfig(runtime RuntimeConfig, bundlePath, cid, console string) (*vc.PodC
 	}
 
 	rootfs := filepath.Join(bundlePath, ocispec.Root.Path)
+	log.Debugf("container rootfs: %s", rootfs)
 
 	cmd := vc.Cmd{
 		Args:    ocispec.Process.Args,

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
@@ -64,6 +65,8 @@ func PodConfig(bundlePath, cid, console string, interactive bool) (*vc.PodConfig
 		Args:    ocispec.Process.Args,
 		Envs:    cmdEnvs(ocispec, []vc.EnvVar{}),
 		WorkDir: ocispec.Process.Cwd,
+		User:    strconv.FormatUint(uint64(ocispec.Process.User.UID), 10),
+		Group:   strconv.FormatUint(uint64(ocispec.Process.User.GID), 10),
 	}
 
 	containerConfig := vc.ContainerConfig{

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"encoding/json"
+	"io/ioutil"
+
+	vc "github.com/containers/virtcontainers"
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+	log "github.com/Sirupsen/logrus"
+)
+
+// PodConfig converts an OCI compatible runtime configuration file
+// to a virtcontainers pod configuration structure.
+func PodConfig(path string) (*vc.PodConfig, error) {
+	log.Debugf("converting %s", path)
+
+	configByte, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var ocispec spec.Spec
+	if err = json.Unmarshal(configByte, &ocispec); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -45,7 +45,7 @@ func cmdEnvs(spec spec.Spec, envs []vc.EnvVar) []vc.EnvVar {
 
 // PodConfig converts an OCI compatible runtime configuration file
 // to a virtcontainers pod configuration structure.
-func PodConfig(bundlePath, cid, console string, interactive bool) (*vc.PodConfig, error) {
+func PodConfig(bundlePath, cid, console string) (*vc.PodConfig, error) {
 	log.Debugf("converting %s/config.json", bundlePath)
 
 	configPath := filepath.Join(bundlePath, "config.json")
@@ -72,7 +72,7 @@ func PodConfig(bundlePath, cid, console string, interactive bool) (*vc.PodConfig
 	containerConfig := vc.ContainerConfig{
 		ID:          cid,
 		RootFs:      rootfs,
-		Interactive: interactive,
+		Interactive: ocispec.Process.Terminal,
 		Console:     console,
 		Cmd:         cmd,
 	}

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -19,14 +19,14 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
+	log "github.com/Sirupsen/logrus"
 	vc "github.com/containers/virtcontainers"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
-	log "github.com/Sirupsen/logrus"
 )
 
 // PodConfig converts an OCI compatible runtime configuration file
 // to a virtcontainers pod configuration structure.
-func PodConfig(bundlePath string) (*vc.PodConfig, error) {
+func PodConfig(bundlePath, cid string) (*vc.PodConfig, error) {
 	log.Debugf("converting %s/config.json", bundlePath)
 
 	configPath := filepath.Join(bundlePath, "config.json")
@@ -40,5 +40,13 @@ func PodConfig(bundlePath string) (*vc.PodConfig, error) {
 		return nil, err
 	}
 
-	return nil, nil
+	containerConfig := vc.ContainerConfig{
+		ID: cid,
+	}
+
+	podConfig := vc.PodConfig{
+		Containers: []vc.ContainerConfig{containerConfig},
+	}
+
+	return &podConfig, nil
 }

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -17,6 +17,7 @@ package oci
 import (
 	"encoding/json"
 	"io/ioutil"
+	"path/filepath"
 
 	vc "github.com/containers/virtcontainers"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
@@ -25,10 +26,11 @@ import (
 
 // PodConfig converts an OCI compatible runtime configuration file
 // to a virtcontainers pod configuration structure.
-func PodConfig(path string) (*vc.PodConfig, error) {
-	log.Debugf("converting %s", path)
+func PodConfig(bundlePath string) (*vc.PodConfig, error) {
+	log.Debugf("converting %s/config.json", bundlePath)
 
-	configByte, err := ioutil.ReadFile(path)
+	configPath := filepath.Join(bundlePath, "config.json")
+	configByte, err := ioutil.ReadFile(configPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -26,7 +26,7 @@ import (
 
 // PodConfig converts an OCI compatible runtime configuration file
 // to a virtcontainers pod configuration structure.
-func PodConfig(bundlePath, cid string) (*vc.PodConfig, error) {
+func PodConfig(bundlePath, cid, console string, interactive bool) (*vc.PodConfig, error) {
 	log.Debugf("converting %s/config.json", bundlePath)
 
 	configPath := filepath.Join(bundlePath, "config.json")
@@ -40,8 +40,13 @@ func PodConfig(bundlePath, cid string) (*vc.PodConfig, error) {
 		return nil, err
 	}
 
+	rootfs := filepath.Join(bundlePath, ocispec.Root.Path)
+
 	containerConfig := vc.ContainerConfig{
-		ID: cid,
+		ID:          cid,
+		RootFs:      rootfs,
+		Interactive: interactive,
+		Console:     console,
 	}
 
 	podConfig := vc.PodConfig{

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -18,11 +18,29 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	vc "github.com/containers/virtcontainers"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 )
+
+func cmdEnvs(spec spec.Spec, envs []vc.EnvVar) []vc.EnvVar {
+	for _, env := range spec.Process.Env {
+		kv := strings.Split(env, "=")
+		if len(kv) < 2 {
+			continue
+		}
+
+		envs = append(envs,
+			vc.EnvVar{
+				Var:   kv[0],
+				Value: kv[1],
+			})
+	}
+
+	return envs
+}
 
 // PodConfig converts an OCI compatible runtime configuration file
 // to a virtcontainers pod configuration structure.
@@ -42,11 +60,18 @@ func PodConfig(bundlePath, cid, console string, interactive bool) (*vc.PodConfig
 
 	rootfs := filepath.Join(bundlePath, ocispec.Root.Path)
 
+	cmd := vc.Cmd{
+		Args:    ocispec.Process.Args,
+		Envs:    cmdEnvs(ocispec, []vc.EnvVar{}),
+		WorkDir: ocispec.Process.Cwd,
+	}
+
 	containerConfig := vc.ContainerConfig{
 		ID:          cid,
 		RootFs:      rootfs,
 		Interactive: interactive,
 		Console:     console,
+		Cmd:         cmd,
 	}
 
 	podConfig := vc.PodConfig{

--- a/pkg/oci/utils_test.go
+++ b/pkg/oci/utils_test.go
@@ -1,0 +1,124 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package oci
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	vc "github.com/containers/virtcontainers"
+)
+
+const tempBundlePath = "/tmp/virtc/ocibundle/"
+const containerID = "virtc-oci-test"
+const consolePath = "/tmp/virtc/console"
+
+func createConfig(fileName string, fileData string) (string, error) {
+	configPath := path.Join(tempBundlePath, fileName)
+
+	err := ioutil.WriteFile(configPath, []byte(fileData), 0755)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to create config file %s %v\n", configPath, err)
+		return "", err
+	}
+
+	return configPath, nil
+}
+
+func TestMinimalPodConfig(t *testing.T) {
+	configPath, err := createConfig("config.json", minimalConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runtimeConfig := RuntimeConfig{
+		HypervisorType: vc.QemuHypervisor,
+		AgentType:      vc.HyperstartAgent,
+		ProxyType:      vc.CCProxyType,
+	}
+
+	expectedCmd := vc.Cmd{
+		Args: []string{"sh"},
+		Envs: []vc.EnvVar{
+			{
+				Var:   "PATH",
+				Value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			},
+			{
+				Var:   "TERM",
+				Value: "xterm",
+			},
+		},
+		WorkDir: "/",
+		User:    "0",
+		Group:   "0",
+	}
+
+	expectedContainerConfig := vc.ContainerConfig{
+		ID:          containerID,
+		RootFs:      filepath.Join(tempBundlePath, "rootfs"),
+		Interactive: true,
+		Console:     consolePath,
+		Cmd:         expectedCmd,
+	}
+
+	expectedNetworkConfig := vc.NetworkConfig{
+		NumInterfaces: 1,
+	}
+
+	expectedPodConfig := vc.PodConfig{
+		HypervisorType: vc.QemuHypervisor,
+		AgentType:      vc.HyperstartAgent,
+		ProxyType:      vc.CCProxyType,
+
+		NetworkModel:  vc.CNMNetworkModel,
+		NetworkConfig: expectedNetworkConfig,
+
+		Containers: []vc.ContainerConfig{expectedContainerConfig},
+	}
+
+	podConfig, err := PodConfig(runtimeConfig, tempBundlePath, containerID, consolePath)
+	if err != nil {
+		t.Fatalf("Could not create Pod configuration %v", err)
+	}
+
+	if reflect.DeepEqual(podConfig, &expectedPodConfig) == false {
+		t.Fatalf("Got %v\n expecting %v", podConfig, expectedPodConfig)
+	}
+
+	if err := os.Remove(configPath); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMain(m *testing.M) {
+	/* Create temp bundle directory if necessary */
+	err := os.MkdirAll(tempBundlePath, 0755)
+	if err != nil {
+		fmt.Printf("Unable to create %s %v\n", tempBundlePath, err)
+		os.Exit(1)
+	}
+
+	defer os.RemoveAll(tempBundlePath)
+
+	os.Exit(m.Run())
+}

--- a/pkg/oci/utils_test_config.go
+++ b/pkg/oci/utils_test_config.go
@@ -1,0 +1,179 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package oci
+
+const minimalConfig = `
+{
+	"ociVersion": "1.0.0-rc1-dev",
+	"platform": {
+		"os": "linux",
+		"arch": "amd64"
+	},
+	"process": {
+		"terminal": true,
+		"user": {
+			"uid": 0,
+			"gid": 0
+		},
+		"args": [
+			"sh"
+		],
+		"env": [
+			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			"TERM=xterm"
+		],
+		"cwd": "/",
+		"capabilities": [
+			"CAP_AUDIT_WRITE",
+			"CAP_KILL",
+			"CAP_NET_BIND_SERVICE"
+		],
+		"rlimits": [
+			{
+				"type": "RLIMIT_NOFILE",
+				"hard": 1024,
+				"soft": 1024
+			}
+		],
+		"noNewPrivileges": true
+	},
+	"root": {
+		"path": "rootfs",
+		"readonly": true
+	},
+	"hostname": "runc",
+	"mounts": [
+		{
+			"destination": "/proc",
+			"type": "proc",
+			"source": "proc"
+		},
+		{
+			"destination": "/dev",
+			"type": "tmpfs",
+			"source": "tmpfs",
+			"options": [
+				"nosuid",
+				"strictatime",
+				"mode=755",
+				"size=65536k"
+			]
+		},
+		{
+			"destination": "/dev/pts",
+			"type": "devpts",
+			"source": "devpts",
+			"options": [
+				"nosuid",
+				"noexec",
+				"newinstance",
+				"ptmxmode=0666",
+				"mode=0620",
+				"gid=5"
+			]
+		},
+		{
+			"destination": "/dev/shm",
+			"type": "tmpfs",
+			"source": "shm",
+			"options": [
+				"nosuid",
+				"noexec",
+				"nodev",
+				"mode=1777",
+				"size=65536k"
+			]
+		},
+		{
+			"destination": "/dev/mqueue",
+			"type": "mqueue",
+			"source": "mqueue",
+			"options": [
+				"nosuid",
+				"noexec",
+				"nodev"
+			]
+		},
+		{
+			"destination": "/sys",
+			"type": "sysfs",
+			"source": "sysfs",
+			"options": [
+				"nosuid",
+				"noexec",
+				"nodev",
+				"ro"
+			]
+		},
+		{
+			"destination": "/sys/fs/cgroup",
+			"type": "cgroup",
+			"source": "cgroup",
+			"options": [
+				"nosuid",
+				"noexec",
+				"nodev",
+				"relatime",
+				"ro"
+			]
+		}
+	],
+	"hooks": {},
+	"linux": {
+		"resources": {
+			"devices": [
+				{
+					"allow": false,
+					"access": "rwm"
+				}
+			]
+		},
+		"namespaces": [
+			{
+				"type": "pid"
+			},
+			{
+				"type": "network"
+			},
+			{
+				"type": "ipc"
+			},
+			{
+				"type": "uts"
+			},
+			{
+				"type": "mount"
+			}
+		],
+		"maskedPaths": [
+			"/proc/kcore",
+			"/proc/latency_stats",
+			"/proc/timer_list",
+			"/proc/timer_stats",
+			"/proc/sched_debug"
+		],
+		"readonlyPaths": [
+			"/proc/asound",
+			"/proc/bus",
+			"/proc/fs",
+			"/proc/irq",
+			"/proc/sys",
+			"/proc/sysrq-trigger"
+		]
+	}
+}
+`


### PR DESCRIPTION
This is a package for converting an OCI configuration file (`config.json`) into virtcontainers `PodConfig` structure.
The single exported API is `PodConfig()` that takes a bundle path, a container ID, a console path and a runtime configuration structure as arguments.
The runtime configuration structure will come from e.g. http://github.com/clearcontainers/runtimeissues/25.