### PR TITLE
Add a proxy configuration interface

### DIFF
--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -55,6 +55,12 @@ var podConfigFlags = []cli.Flag{
 	},
 
 	cli.StringFlag{
+		Name:  "proxy-sock",
+		Value: "",
+		Usage: "the agent's proxy socket path",
+	},
+
+	cli.StringFlag{
 		Name:  "sshd-user",
 		Value: "",
 		Usage: "the sshd user",
@@ -123,6 +129,7 @@ var podConfigFlags = []cli.Flag{
 
 func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 	var agConfig interface{}
+	var proxyConfig interface{}
 
 	sshdUser := context.String("sshd-user")
 	sshdServer := context.String("sshd-server")
@@ -131,6 +138,7 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 	hyperCtlSockName := context.String("hyper-ctl-sock-name")
 	hyperTtySockName := context.String("hyper-tty-sock-name")
 	hyperPauseBinPath := context.String("pause-path")
+	proxyRuntimeSocket := context.String("proxy-runtime-sock")
 	vmVCPUs := context.Uint("vm-vcpus")
 	vmMemory := context.Uint("vm-memory")
 	agentType, ok := context.Generic("agent").(*vc.AgentType)
@@ -200,6 +208,16 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 		agConfig = nil
 	}
 
+	switch *proxyType {
+	case vc.CCProxyType:
+		proxyConfig = vc.CCProxyConfig{
+			RuntimeSocketPath: proxyRuntimeSocket,
+		}
+
+	default:
+		proxyConfig = nil
+	}
+
 	vmConfig := vc.Resources{
 		VCPUs:  vmVCPUs,
 		Memory: vmMemory,
@@ -217,7 +235,8 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 		NetworkModel:  *networkModel,
 		NetworkConfig: netConfig,
 
-		ProxyType: *proxyType,
+		ProxyType:   *proxyType,
+		ProxyConfig: proxyConfig,
 
 		Containers: []vc.ContainerConfig{},
 	}

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -42,7 +42,8 @@ type RuntimeConfig struct {
 	AgentType   vc.AgentType
 	AgentConfig interface{}
 
-	ProxyType vc.ProxyType
+	ProxyType   vc.ProxyType
+	ProxyConfig interface{}
 }
 
 func cmdEnvs(spec spec.Spec, envs []vc.EnvVar) []vc.EnvVar {
@@ -172,7 +173,8 @@ func PodConfig(runtime RuntimeConfig, bundlePath, cid, console string) (*vc.PodC
 		AgentType:   runtime.AgentType,
 		AgentConfig: runtime.AgentConfig,
 
-		ProxyType: runtime.ProxyType,
+		ProxyType:   runtime.ProxyType,
+		ProxyConfig: runtime.ProxyConfig,
 
 		NetworkModel:  vc.CNMNetworkModel,
 		NetworkConfig: networkConfig,

--- a/pod.go
+++ b/pod.go
@@ -242,10 +242,11 @@ type PodConfig struct {
 	AgentType   AgentType
 	AgentConfig interface{}
 
+	ProxyType   ProxyType
+	ProxyConfig interface{}
+
 	NetworkModel  NetworkModel
 	NetworkConfig NetworkConfig
-
-	ProxyType ProxyType
 
 	// Volumes is a list of shared volumes between the host and the Pod.
 	Volumes []Volume

--- a/proxy.go
+++ b/proxy.go
@@ -19,6 +19,8 @@ package virtcontainers
 import (
 	"fmt"
 	"os"
+
+	"github.com/mitchellh/mapstructure"
 )
 
 // ProxyType describes a proxy type.
@@ -67,6 +69,23 @@ func newProxy(pType ProxyType) (proxy, error) {
 		return &ccProxy{}, nil
 	default:
 		return &noopProxy{}, nil
+	}
+}
+
+// newProxyConfig returns a proxy config from a generic PodConfig interface.
+func newProxyConfig(config PodConfig) interface{} {
+	switch config.ProxyType {
+	case NoopProxyType:
+		return nil
+	case CCProxyType:
+		var ccConfig CCProxyConfig
+		err := mapstructure.Decode(config.ProxyConfig, &ccConfig)
+		if err != nil {
+			return err
+		}
+		return ccConfig
+	default:
+		return nil
 	}
 }
 


### PR DESCRIPTION
We want to be able to specify some proxy specific settings, like e.g. the proxy runtime socket path for our Clear Containers proxy implementation. Eventually, this will also include the proxy shim socket path.