### PR TITLE
Move VM creation and network setup to CreatePod()

### DIFF
--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -138,7 +138,7 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 	hyperCtlSockName := context.String("hyper-ctl-sock-name")
 	hyperTtySockName := context.String("hyper-tty-sock-name")
 	hyperPauseBinPath := context.String("pause-path")
-	proxyRuntimeSocket := context.String("proxy-runtime-sock")
+	proxyRuntimeSocket := context.String("proxy-sock")
 	vmVCPUs := context.Uint("vm-vcpus")
 	vmMemory := context.Uint("vm-memory")
 	agentType, ok := context.Generic("agent").(*vc.AgentType)

--- a/pod.go
+++ b/pod.go
@@ -604,6 +604,21 @@ func (p *Pod) stopSetStates() error {
 	return nil
 }
 
+// stopVM stops the agent inside the VM and shut down the VM itself.
+func (p *Pod) stopVM() error {
+	err := p.agent.stopAgent()
+	if err != nil {
+		return err
+	}
+
+	err = p.hypervisor.stopPod()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // stop stops a pod. The containers that are making the pod
 // will be destroyed.
 func (p *Pod) stop() error {
@@ -627,12 +642,7 @@ func (p *Pod) stop() error {
 		return err
 	}
 
-	err = p.agent.stopAgent()
-	if err != nil {
-		return err
-	}
-
-	err = p.hypervisor.stopPod()
+	err = p.stopVM()
 	if err != nil {
 		return err
 	}

--- a/pod.go
+++ b/pod.go
@@ -47,10 +47,10 @@ const (
 	stateReady stateString = "ready"
 
 	// stateRunning represents a pod/container that's currently running.
-	stateRunning = "running"
+	stateRunning stateString = "running"
 
 	// statePaused represents a pod/container that has been paused.
-	statePaused = "paused"
+	statePaused stateString = "paused"
 )
 
 // State is a pod state structure.

--- a/pod.go
+++ b/pod.go
@@ -555,11 +555,6 @@ func (p *Pod) start() error {
 		return err
 	}
 
-	err = p.startVM()
-	if err != nil {
-		return err
-	}
-
 	err = p.agent.startPod(*p.config)
 	if err != nil {
 		p.stop()
@@ -627,22 +622,12 @@ func (p *Pod) stop() error {
 		return err
 	}
 
-	err = p.agent.startAgent()
-	if err != nil {
-		return err
-	}
-
 	err = p.agent.stopPod(*p)
 	if err != nil {
 		return err
 	}
 
 	err = p.stopSetStates()
-	if err != nil {
-		return err
-	}
-
-	err = p.stopVM()
 	if err != nil {
 		return err
 	}
@@ -675,11 +660,6 @@ func (p *Pod) setPodState(state stateString) error {
 
 // endSession makes sure to end the session properly.
 func (p *Pod) endSession() error {
-	err := p.agent.stopAgent()
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
In order to allow future performance savings with OCI runtime, this PR moves VM creation/deletion to CreatePod()/DeletePod(). It does the same for the network which is now created/removed from CreatePod()/DeletePod() too.