### PR TITLE
hyperstart: Fix pod stop/restart behavior

### DIFF
--- a/cc_proxy.go
+++ b/cc_proxy.go
@@ -98,15 +98,6 @@ func (p *ccProxy) register(pod Pod) ([]IOStream, error) {
 		return []IOStream{}, err
 	}
 
-	for i := 0; i < len(pod.containers); i++ {
-		ioStream, err := p.allocateIOStream()
-		if err != nil {
-			return []IOStream{}, err
-		}
-
-		ioStreams = append(ioStreams, ioStream)
-	}
-
 	return ioStreams, nil
 }
 
@@ -128,9 +119,11 @@ func (p *ccProxy) connect(pod Pod) (IOStream, error) {
 		return IOStream{}, fmt.Errorf("Wrong proxy config type, should be CCProxyConfig type")
 	}
 
-	p.client, err = p.connectProxy(ccConfig.RuntimeSocketPath)
-	if err != nil {
-		return IOStream{}, err
+	if p.client == nil {
+		p.client, err = p.connectProxy(ccConfig.RuntimeSocketPath)
+		if err != nil {
+			return IOStream{}, err
+		}
 	}
 
 	_, err = p.client.Attach(pod.id, nil)
@@ -153,6 +146,7 @@ func (p *ccProxy) disconnect() error {
 	}
 
 	p.client.Close()
+	p.client = nil
 
 	return nil
 }

--- a/container.go
+++ b/container.go
@@ -289,11 +289,6 @@ func (c *Container) start() error {
 		}
 	}
 
-	err = c.pod.agent.startAgent()
-	if err != nil {
-		return err
-	}
-
 	err = c.pod.agent.startContainer(*c.pod, *(c.config))
 	if err != nil {
 		c.stop()
@@ -328,11 +323,6 @@ func (c *Container) stop() error {
 	}
 
 	err = state.validTransition(StateRunning, StateStopped)
-	if err != nil {
-		return err
-	}
-
-	err = c.pod.agent.startAgent()
 	if err != nil {
 		return err
 	}
@@ -374,11 +364,6 @@ func (c *Container) enter(cmd Cmd) error {
 		return fmt.Errorf("Container not running, impossible to enter")
 	}
 
-	err = c.pod.agent.startAgent()
-	if err != nil {
-		return err
-	}
-
 	err = c.pod.agent.exec(*c.pod, *c, cmd)
 	if err != nil {
 		return err
@@ -404,11 +389,6 @@ func (c *Container) kill(signal syscall.Signal) error {
 
 	if state.State != StateRunning {
 		return fmt.Errorf("Container not running, impossible to signal the container")
-	}
-
-	err = c.pod.agent.startAgent()
-	if err != nil {
-		return err
 	}
 
 	err = c.pod.agent.killContainer(*c.pod, *c, signal)

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -244,9 +244,12 @@ func (h *hyper) init(pod *Pod, config interface{}) error {
 }
 
 // start is the agent starting implementation for hyperstart.
-// It does nothing.
 func (h *hyper) startAgent() error {
-	return nil
+	if _, err := h.proxy.register(*(h.pod)); err != nil {
+		return err
+	}
+
+	return h.proxy.disconnect()
 }
 
 // exec is the agent command execution implementation for hyperstart.
@@ -281,36 +284,51 @@ func (h *hyper) exec(pod Pod, container Container, cmd Cmd) error {
 
 // startPod is the agent Pod starting implementation for hyperstart.
 func (h *hyper) startPod(config PodConfig) error {
-	h.pod.containers = append(h.pod.containers, &Container{})
-
-	ioStreams, err := h.proxy.register(*(h.pod))
+	_, err := h.proxy.connect(*(h.pod))
 	if err != nil {
 		return err
 	}
 
-	hyperPod := hyperJson.Pod{
-		Hostname:             config.ID,
-		DeprecatedContainers: []hyperJson.Container{},
-		ShareDir:             mountTag,
-	}
-
-	proxyCmd := hyperstartProxyCmd{
-		cmd:     hyperstart.StartPod,
-		message: hyperPod,
-	}
-
-	_, err = h.proxy.sendCmd(proxyCmd)
+	podStarted, err := h.pod.checkPodStarted()
 	if err != nil {
 		return err
 	}
 
-	err = h.startPauseContainer(*(h.pod), ioStreams[0])
-	if err != nil {
-		return err
+	if podStarted == false {
+		hyperPod := hyperJson.Pod{
+			Hostname:             config.ID,
+			DeprecatedContainers: []hyperJson.Container{},
+			ShareDir:             mountTag,
+		}
+
+		proxyCmd := hyperstartProxyCmd{
+			cmd:     hyperstart.StartPod,
+			message: hyperPod,
+		}
+
+		_, err = h.proxy.sendCmd(proxyCmd)
+		if err != nil {
+			return err
+		}
+
+		ioStream, err := h.proxy.connect(*(h.pod))
+		if err != nil {
+			return err
+		}
+
+		err = h.startPauseContainer(*(h.pod), ioStream)
+		if err != nil {
+			return err
+		}
 	}
 
-	for idx, c := range config.Containers {
-		err := h.startOneContainer(*(h.pod), c, ioStreams[idx+1])
+	for _, c := range config.Containers {
+		ioStream, err := h.proxy.connect(*(h.pod))
+		if err != nil {
+			return err
+		}
+
+		err = h.startOneContainer(*(h.pod), c, ioStream)
 		if err != nil {
 			return err
 		}
@@ -350,28 +368,20 @@ func (h *hyper) stopPod(pod Pod) error {
 		}
 	}
 
-	err = h.stopPauseContainer()
-	if err != nil {
-		return err
-	}
-
-	err = h.proxy.unregister(pod)
-	if err != nil {
-		return err
-	}
-
-	err = h.proxy.disconnect()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return h.proxy.disconnect()
 }
 
 // stop is the agent stopping implementation for hyperstart.
-// It does nothing.
 func (h *hyper) stopAgent() error {
-	return nil
+	if _, err := h.proxy.connect(*(h.pod)); err != nil {
+		return err
+	}
+
+	if err := h.proxy.unregister(*(h.pod)); err != nil {
+		return err
+	}
+
+	return h.proxy.disconnect()
 }
 
 // startPauseContainer starts a specific container running the pause binary provided.
@@ -457,22 +467,6 @@ func (h *hyper) startContainer(pod Pod, contConfig ContainerConfig) error {
 	}
 
 	return h.proxy.disconnect()
-}
-
-func (h *hyper) stopPauseContainer() error {
-	container := Container{
-		id: pauseContainerName,
-	}
-
-	if err := h.killOneContainer(container, syscall.SIGKILL); err != nil {
-		return err
-	}
-
-	if err := h.unlinkPauseBinary(); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // stopContainer is the agent Container stopping implementation for hyperstart.

--- a/pod.go
+++ b/pod.go
@@ -574,6 +574,22 @@ func (p *Pod) startVM() error {
 	return nil
 }
 
+func (p *Pod) checkPodStarted() (bool, error) {
+	state, err := p.storage.fetchPodState(p.id)
+	if err != nil {
+		return false, err
+	}
+
+	switch state.State {
+	case StateReady:
+		return false, nil
+	case StateRunning, StateStopped:
+		return true, nil
+	}
+
+	return false, fmt.Errorf("Invalid state %s", string(state.State))
+}
+
 // start starts a pod. The containers that are making the pod
 // will be started.
 func (p *Pod) start() error {
@@ -584,7 +600,6 @@ func (p *Pod) start() error {
 
 	err = p.agent.startPod(*p.config)
 	if err != nil {
-		p.stop()
 		return err
 	}
 


### PR DESCRIPTION
This patch allows to re-enable the start/stop pod. Indeed, after we
introduced the change to create and delete a VM from the CreatePod()
and DeletePod(), we were not able to start the pod after it was stopped.