### PR TITLE
api: Fix RunPod() according to changes to VM and network creation

### DIFF
--- a/api.go
+++ b/api.go
@@ -261,7 +261,13 @@ func RunPod(podConfig PodConfig) (*Pod, error) {
 		return nil, err
 	}
 
-	// Start it
+	// Start the VM
+	err = p.startVM()
+	if err != nil {
+		return nil, err
+	}
+
+	// Start the pod
 	err = p.start()
 	if err != nil {
 		p.delete()


### PR DESCRIPTION
When the move of the VM creation and network setup were done in a previous
pull request, the changes to RunPod() have not been done. This patch aims
to fix this.