### PR TITLE
pod: Keep containers instead of containers configs in Pod structure

### DIFF
--- a/container.go
+++ b/container.go
@@ -133,6 +133,32 @@ func (c *Container) createContainersDirs() error {
 	return nil
 }
 
+func createContainers(pod *Pod, contConfigs []ContainerConfig) ([]*Container, error) {
+	var containers []*Container
+
+	for _, contConfig := range contConfigs {
+		if contConfig.valid() == false {
+			return containers, fmt.Errorf("Invalid container configuration")
+		}
+
+		c := &Container{
+			id:            contConfig.ID,
+			podID:         pod.id,
+			rootFs:        contConfig.RootFs,
+			config:        &contConfig,
+			pod:           pod,
+			runPath:       filepath.Join(runStoragePath, pod.id, contConfig.ID),
+			configPath:    filepath.Join(configStoragePath, pod.id, contConfig.ID),
+			containerPath: filepath.Join(pod.id, contConfig.ID),
+			state:         State{},
+		}
+
+		containers = append(containers, c)
+	}
+
+	return containers, nil
+}
+
 func createContainer(pod *Pod, contConfig ContainerConfig) (*Container, error) {
 	if contConfig.valid() == false {
 		return nil, fmt.Errorf("Invalid container configuration")

--- a/filesystem.go
+++ b/filesystem.go
@@ -108,14 +108,14 @@ func (fs *filesystem) createAllResources(pod Pod) error {
 	}
 
 	for _, container := range pod.containers {
-		_, path, _ = fs.containerURI(pod.id, container.ID, configFileType)
+		_, path, _ = fs.containerURI(pod.id, container.id, configFileType)
 		err = os.MkdirAll(path, os.ModeDir)
 		if err != nil {
 			fs.deletePodResources(pod.id, nil)
 			return err
 		}
 
-		_, path, _ = fs.containerURI(pod.id, container.ID, stateFileType)
+		_, path, _ = fs.containerURI(pod.id, container.id, stateFileType)
 		err = os.MkdirAll(path, os.ModeDir)
 		if err != nil {
 			fs.deletePodResources(pod.id, nil)

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -28,16 +28,22 @@ import (
 func TestFilesystemCreateAllResourcesSuccessful(t *testing.T) {
 	fs := &filesystem{}
 
-	containers := []ContainerConfig{
+	contConfigs := []ContainerConfig{
 		{ID: "1"},
 		{ID: "10"},
 		{ID: "100"},
 	}
 
 	pod := Pod{
-		id:         testPodID,
-		containers: containers,
+		id: testPodID,
 	}
+
+	containers, err := createContainers(&pod, contConfigs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pod.containers = containers
 
 	podConfigPath := filepath.Join(configStoragePath, testPodID)
 	podRunPath := filepath.Join(runStoragePath, testPodID)
@@ -45,7 +51,7 @@ func TestFilesystemCreateAllResourcesSuccessful(t *testing.T) {
 	os.RemoveAll(podConfigPath)
 	os.RemoveAll(podRunPath)
 
-	for _, container := range containers {
+	for _, container := range contConfigs {
 		configPath := filepath.Join(configStoragePath, testPodID, container.ID)
 		os.RemoveAll(configPath)
 
@@ -53,7 +59,7 @@ func TestFilesystemCreateAllResourcesSuccessful(t *testing.T) {
 		os.RemoveAll(runPath)
 	}
 
-	err := fs.createAllResources(pod)
+	err = fs.createAllResources(pod)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +75,7 @@ func TestFilesystemCreateAllResourcesSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, container := range containers {
+	for _, container := range contConfigs {
 		configPath := filepath.Join(configStoragePath, testPodID, container.ID)
 		_, err = os.Stat(configPath)
 		if err != nil {
@@ -98,8 +104,8 @@ func TestFilesystemCreateAllResourcesFailingPodIDEmpty(t *testing.T) {
 func TestFilesystemCreateAllResourcesFailingContainerIDEmpty(t *testing.T) {
 	fs := &filesystem{}
 
-	containers := []ContainerConfig{
-		{ID: ""},
+	containers := []*Container{
+		{id: ""},
 	}
 
 	pod := Pod{

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -181,7 +181,11 @@ func (h *hyper) bindUnmountContainerRootfs(container ContainerConfig) error {
 
 func (h *hyper) bindUnmountAllRootfs() {
 	for _, c := range h.pod.containers {
-		h.bindUnmountContainerRootfs(c)
+		if c.config == nil {
+			continue
+		}
+
+		h.bindUnmountContainerRootfs(*(c.config))
 	}
 }
 
@@ -277,7 +281,7 @@ func (h *hyper) exec(pod Pod, container Container, cmd Cmd) error {
 
 // startPod is the agent Pod starting implementation for hyperstart.
 func (h *hyper) startPod(config PodConfig) error {
-	h.pod.containers = append(h.pod.containers, ContainerConfig{})
+	h.pod.containers = append(h.pod.containers, &Container{})
 
 	ioStreams, err := h.proxy.register(*(h.pod))
 	if err != nil {


### PR DESCRIPTION
Until now, the Pod structure was keeping containers configurations but
it is not the right thing to do because we want to be able to access
containers through a handler kept by the Pod structure. That's why
this patch changes the containers configuration list to containers
handler list.