### PR TITLE
oci: Container ID should be considered as pod ID

### DIFF
--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -150,7 +150,6 @@ func PodConfig(runtime RuntimeConfig, bundlePath, cid, console string) (*vc.PodC
 	}
 
 	containerConfig := vc.ContainerConfig{
-		ID:          cid,
 		RootFs:      rootfs,
 		Interactive: ocispec.Process.Terminal,
 		Console:     console,
@@ -163,6 +162,8 @@ func PodConfig(runtime RuntimeConfig, bundlePath, cid, console string) (*vc.PodC
 	}
 
 	podConfig := vc.PodConfig{
+		ID: cid,
+
 		Hooks: containerHooks(ocispec),
 
 		VMConfig: runtime.VMConfig,

--- a/pkg/oci/utils_test.go
+++ b/pkg/oci/utils_test.go
@@ -74,7 +74,6 @@ func TestMinimalPodConfig(t *testing.T) {
 	}
 
 	expectedContainerConfig := vc.ContainerConfig{
-		ID:          containerID,
 		RootFs:      filepath.Join(tempBundlePath, "rootfs"),
 		Interactive: true,
 		Console:     consolePath,
@@ -86,6 +85,8 @@ func TestMinimalPodConfig(t *testing.T) {
 	}
 
 	expectedPodConfig := vc.PodConfig{
+		ID: containerID,
+
 		HypervisorType: vc.QemuHypervisor,
 		AgentType:      vc.HyperstartAgent,
 		ProxyType:      vc.CCProxyType,


### PR DESCRIPTION
Because OCI specification does not have the concept of pod, we have
to match the container ID on the pod ID, and assign an arbitrary
value to the virtcontainers internal container ID. In that case,
we chose "0" but it could be anything else.