### PR TITLE
Add KillContainer API

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -18,6 +18,7 @@ package virtcontainers
 
 import (
 	"fmt"
+	"syscall"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -136,4 +137,7 @@ type agent interface {
 
 	// stopContainer will tell the agent to stop a container related to a Pod.
 	stopContainer(pod Pod, container Container) error
+
+	// killContainer will tell the agent to send a signal to a container related to a Pod.
+	killContainer(pod Pod, container Container, signal syscall.Signal) error
 }

--- a/container.go
+++ b/container.go
@@ -289,6 +289,11 @@ func (c *Container) stop() error {
 		return err
 	}
 
+	err = c.pod.agent.killContainer(*c.pod, *c, syscall.SIGTERM)
+	if err != nil {
+		return err
+	}
+
 	err = c.pod.agent.stopContainer(*c.pod, *c)
 	if err != nil {
 		return err

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -517,3 +517,8 @@ func (h *hyper) stopOneContainer(contConfig ContainerConfig) error {
 
 	return nil
 }
+
+// killContainer is the agent process signal implementation for hyperstart.
+func (h *hyper) killContainer(pod Pod, container Container, signal syscall.Signal) error {
+	return nil
+}

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -499,7 +499,9 @@ func (h *hyper) stopOneContainer(contConfig ContainerConfig) error {
 
 	_, err := h.proxy.sendCmd(proxyCmd)
 	if err != nil {
-		return err
+		// It is likely that we get an error because the container has been
+		// previously killed, preventing us from removing it.
+		glog.Infof("%s\n", err)
 	}
 
 	err = h.bindUnmountContainerRootfs(contConfig)

--- a/noop_agent.go
+++ b/noop_agent.go
@@ -16,6 +16,10 @@
 
 package virtcontainers
 
+import (
+	"syscall"
+)
+
 // noopAgent a.k.a. NO-OP Agent is an empty Agent implementation, for testing and
 // mocking purposes.
 type noopAgent struct {
@@ -58,5 +62,10 @@ func (n *noopAgent) startContainer(pod Pod, contConfig ContainerConfig) error {
 
 // stopContainer is the Noop agent Container stopping implementation. It does nothing.
 func (n *noopAgent) stopContainer(pod Pod, container Container) error {
+	return nil
+}
+
+// killContainer is the Noop agent Container signaling implementation. It does nothing.
+func (n *noopAgent) killContainer(pod Pod, container Container, signal syscall.Signal) error {
 	return nil
 }

--- a/sshd.go
+++ b/sshd.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"strings"
+	"syscall"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -170,5 +171,10 @@ func (s *sshd) startContainer(pod Pod, contConfig ContainerConfig) error {
 
 // stopContainer is the agent Container stopping implementation for sshd.
 func (s *sshd) stopContainer(pod Pod, container Container) error {
+	return nil
+}
+
+// killContainer is the agent Container signaling implementation for sshd.
+func (s *sshd) killContainer(pod Pod, container Container, signal syscall.Signal) error {
 	return nil
 }


### PR DESCRIPTION
Because OCI spec needs to be able to send a signal with the kill command and because it is something generic (not only OCI will need to send signals to containers), this PR adds the way to send a signal to a running container.