### PR TITLE
Introduce Process structure to allow runtime to get useful info about the container's process

### DIFF
--- a/container.go
+++ b/container.go
@@ -26,6 +26,12 @@ import (
 	"github.com/golang/glog"
 )
 
+// Process gathers data related to a container process.
+type Process struct {
+	Token string
+	Pid   int
+}
+
 // ContainerStatus describes a container status.
 type ContainerStatus struct {
 	ID    string
@@ -75,6 +81,8 @@ type Container struct {
 	containerPath string
 
 	state State
+
+	process Process
 }
 
 // ID returns the container identifier string.
@@ -152,6 +160,7 @@ func createContainers(pod *Pod, contConfigs []ContainerConfig) ([]*Container, er
 			configPath:    filepath.Join(configStoragePath, pod.id, contConfig.ID),
 			containerPath: filepath.Join(pod.id, contConfig.ID),
 			state:         State{},
+			process:       Process{},
 		}
 
 		containers = append(containers, c)
@@ -175,6 +184,7 @@ func createContainer(pod *Pod, contConfig ContainerConfig) (*Container, error) {
 		configPath:    filepath.Join(configStoragePath, pod.id, contConfig.ID),
 		containerPath: filepath.Join(pod.id, contConfig.ID),
 		state:         State{},
+		process:       Process{},
 	}
 
 	err := c.createContainersDirs()

--- a/container.go
+++ b/container.go
@@ -90,6 +90,27 @@ func (c *Container) ID() string {
 	return c.id
 }
 
+// GetToken returns the token related to this container's process.
+func (c *Container) GetToken() string {
+	return c.process.Token
+}
+
+// GetPid returns the pid related to this container's process.
+func (c *Container) GetPid() int {
+	return c.process.Pid
+}
+
+// SetPid sets and stores the given pid as the pid of container's process.
+func (c *Container) SetPid(pid int) error {
+	c.process.Pid = pid
+
+	if err := c.pod.storage.storeContainerProcess(c.podID, c.id, c.process); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // fetchContainer fetches a container config from a pod ID and returns a Container.
 func fetchContainer(pod *Pod, containerID string) (*Container, error) {
 	fs := filesystem{}
@@ -168,6 +189,11 @@ func createContainers(pod *Pod, contConfigs []ContainerConfig) ([]*Container, er
 			c.state.State = state.State
 		}
 
+		process, err := c.pod.storage.fetchContainerProcess(c.podID, c.id)
+		if err == nil {
+			c.process = process
+		}
+
 		containers = append(containers, c)
 	}
 
@@ -206,6 +232,11 @@ func createContainer(pod *Pod, contConfig ContainerConfig) (*Container, error) {
 	err = c.pod.setContainerState(c.id, stateReady)
 	if err != nil {
 		return nil, err
+	}
+
+	process, err := c.pod.storage.fetchContainerProcess(c.podID, c.id)
+	if err == nil {
+		c.process = process
 	}
 
 	return c, nil

--- a/container.go
+++ b/container.go
@@ -163,6 +163,11 @@ func createContainers(pod *Pod, contConfigs []ContainerConfig) ([]*Container, er
 			process:       Process{},
 		}
 
+		state, err := c.pod.storage.fetchContainerState(c.podID, c.id)
+		if err == nil {
+			c.state.State = state.State
+		}
+
 		containers = append(containers, c)
 	}
 

--- a/filesystem.go
+++ b/filesystem.go
@@ -39,6 +39,9 @@ const (
 	// networkFileType represents a network file type
 	networkFileType
 
+	// processFileType represents a process file type
+	processFileType
+
 	// lockFileType represents a lock file type
 	lockFileType
 )
@@ -59,6 +62,9 @@ const stateFile = "state.json"
 
 // networkFile is the file name storing a pod network.
 const networkFile = "network.json"
+
+// processFile is the file name storing a container process.
+const processFile = "process.json"
 
 // lockFile is the file name locking the usage of a pod.
 const lockFileName = "lock"
@@ -88,6 +94,8 @@ type resourceStorage interface {
 	deleteContainerResources(podID, containerID string, resources []podResource) error
 	fetchContainerConfig(podID, containerID string) (ContainerConfig, error)
 	fetchContainerState(podID, containerID string) (State, error)
+	fetchContainerProcess(podID, containerID string) (Process, error)
+	storeContainerProcess(podID, containerID string, process Process) error
 }
 
 // filesystem is a resourceStorage interface implementation for a local filesystem.
@@ -193,7 +201,7 @@ func resourceDir(podID, containerID string, resource podResource) (string, error
 	case configFileType:
 		path = configStoragePath
 		break
-	case stateFileType, networkFileType, lockFileType:
+	case stateFileType, networkFileType, processFileType, lockFileType:
 		path = runStoragePath
 		break
 	default:
@@ -225,6 +233,8 @@ func (fs *filesystem) resourceURI(podID, containerID string, resource podResourc
 		filename = stateFile
 	case networkFileType:
 		filename = networkFile
+	case processFileType:
+		filename = processFile
 	case lockFileType:
 		filename = lockFileName
 		break
@@ -287,6 +297,18 @@ func (fs *filesystem) storeResource(podID, containerID string, resource podResou
 
 		return fs.storeFile(networkFile, file)
 
+	case Process:
+		if resource != processFileType {
+			return fmt.Errorf("Invalid pod resource")
+		}
+
+		processFile, _, err := fs.resourceURI(podID, containerID, processFileType)
+		if err != nil {
+			return err
+		}
+
+		return fs.storeFile(processFile, file)
+
 	default:
 		return fmt.Errorf("Invalid resource data type")
 	}
@@ -335,6 +357,15 @@ func (fs *filesystem) fetchResource(podID, containerID string, resource podResou
 		}
 
 		return networkNS, nil
+
+	case processFileType:
+		process := Process{}
+		err = fs.fetchFile(path, &process)
+		if err != nil {
+			return nil, err
+		}
+
+		return process, nil
 	}
 
 	return nil, fmt.Errorf("Invalid pod resource")
@@ -452,6 +483,28 @@ func (fs *filesystem) fetchContainerState(podID, containerID string) (State, err
 	}
 
 	return State{}, fmt.Errorf("Unknown state type")
+}
+
+func (fs *filesystem) fetchContainerProcess(podID, containerID string) (Process, error) {
+	if containerID == "" {
+		return Process{}, fmt.Errorf("Container ID cannot be empty")
+	}
+
+	data, err := fs.fetchResource(podID, containerID, processFileType)
+	if err != nil {
+		return Process{}, err
+	}
+
+	switch process := data.(type) {
+	case Process:
+		return process, nil
+	}
+
+	return Process{}, fmt.Errorf("Unknown process type")
+}
+
+func (fs *filesystem) storeContainerProcess(podID, containerID string, process Process) error {
+	return fs.storeContainerResource(podID, containerID, processFileType, process)
 }
 
 func (fs *filesystem) deleteContainerResources(podID, containerID string, resources []podResource) error {

--- a/filesystem.go
+++ b/filesystem.go
@@ -22,8 +22,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	//	"github.com/01org/ciao/ssntp/uuid"
-	//	"github.com/golang/glog"
 )
 
 // podResource is an int representing a pod resource type

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -35,7 +35,8 @@ func TestFilesystemCreateAllResourcesSuccessful(t *testing.T) {
 	}
 
 	pod := Pod{
-		id: testPodID,
+		id:      testPodID,
+		storage: fs,
 	}
 
 	containers, err := createContainers(&pod, contConfigs)

--- a/pod.go
+++ b/pod.go
@@ -215,16 +215,6 @@ type Cmd struct {
 
 	User  string
 	Group string
-
-	// Hidden field filled by agent implementation and used later by
-	// virtcontainers consumer who wants to start a shim to connect
-	// the proxy.
-	token string
-}
-
-// GetToken returns a shim token associated to the process defined by Cmd structure.
-func (c *Cmd) GetToken() string {
-	return c.token
 }
 
 // Resources describes VM resources configuration.


### PR DESCRIPTION
This PR adds the Process structure so that any runtime implementation can update PID related to the started process on the container. Also it can retrieve the token necessary for the shim to connect the proxy.