### PR TITLE
Fix hyperstart agent implementation of stopContainer after performed testing

### DIFF
--- a/hyperstart.go
+++ b/hyperstart.go
@@ -336,6 +336,14 @@ func (h *hyper) stopPod(pod Pod) error {
 			continue
 		}
 
+		container := Container{
+			id: contConfig.ID,
+		}
+
+		if err := h.killOneContainer(container, syscall.SIGTERM); err != nil {
+			return err
+		}
+
 		err = h.stopOneContainer(contConfig)
 		if err != nil {
 			return err
@@ -499,9 +507,7 @@ func (h *hyper) stopOneContainer(contConfig ContainerConfig) error {
 
 	_, err := h.proxy.sendCmd(proxyCmd)
 	if err != nil {
-		// It is likely that we get an error because the container has been
-		// previously killed, preventing us from removing it.
-		glog.Infof("%s\n", err)
+		return err
 	}
 
 	err = h.bindUnmountContainerRootfs(contConfig)


### PR DESCRIPTION
We were not returning an error in case the REMOVECONTAINER command called from
stopContainer() was getting an error from hyperstart agent. We thought it could
not work to call a REMOVECONTAINER after a KILLCONTAINER, but after further testing,
here is the real behavior of hyperstart v0.7.0:

KILLCONTAINER: calling this command on an existing container will always succeed,
even if no process is running inside the container. This means that several calls
to KILLCONTAINER commands won't hurt. Calling this on a non-existing container will
return an error.

REMOVECONTAINER: calling this command on an existing container with no remaining
process running inside the container will succeed. In case there a remaining process
still running, this command will fail and return an error. If the container does not
exist (or has been previously removed), it will return an error. This means that
several successive calls to REMOVECONTAINER cannot all succeed.

Knowing these things, the patch fix the way a podStop() works and also that we should
not ignore an error from REMOVECONTAINER command.