### PR TITLE
Extend and improve pod and containers status

### DIFF
--- a/api.go
+++ b/api.go
@@ -298,33 +298,17 @@ func ListPod() ([]PodStatus, error) {
 
 	defer dir.Close()
 
-	pods, err := dir.Readdirnames(0)
+	podsID, err := dir.Readdirnames(0)
 	if err != nil {
 		return []PodStatus{}, err
 	}
 
-	fs := filesystem{}
-
 	var podStatusList []PodStatus
 
-	for _, p := range pods {
-		var config PodConfig
-
-		config, err := fs.fetchPodConfig(p)
+	for _, podID := range podsID {
+		podStatus, err := StatusPod(podID)
 		if err != nil {
 			continue
-		}
-
-		state, err := fs.fetchPodState(p)
-		if err != nil {
-			continue
-		}
-
-		podStatus := PodStatus{
-			ID:         config.ID,
-			State:      state,
-			Hypervisor: config.HypervisorType,
-			Agent:      config.AgentType,
 		}
 
 		podStatusList = append(podStatusList, podStatus)
@@ -335,43 +319,28 @@ func ListPod() ([]PodStatus, error) {
 
 // StatusPod is the virtcontainers pod status entry point.
 func StatusPod(podID string) (PodStatus, error) {
-	fs := filesystem{}
-
-	config, err := fs.fetchPodConfig(podID)
-	if err != nil {
-		return PodStatus{}, err
-	}
-
-	state, err := fs.fetchPodState(podID)
+	pod, err := fetchPod(podID)
 	if err != nil {
 		return PodStatus{}, err
 	}
 
 	var contStatusList []ContainerStatus
-	for _, container := range config.Containers {
+	for _, container := range pod.containers {
 		contStatus := ContainerStatus{
-			ID:     container.ID,
-			RootFs: container.RootFs,
-		}
-
-		state, err := fs.fetchContainerState(podID, container.ID)
-		if err == nil {
-			contStatus.State = state
-		}
-
-		process, err := fs.fetchContainerProcess(podID, container.ID)
-		if err == nil {
-			contStatus.PID = process.Pid
+			ID:     container.id,
+			State:  container.state,
+			PID:    container.process.Pid,
+			RootFs: container.config.RootFs,
 		}
 
 		contStatusList = append(contStatusList, contStatus)
 	}
 
 	podStatus := PodStatus{
-		ID:               podID,
-		State:            state,
-		Hypervisor:       config.HypervisorType,
-		Agent:            config.AgentType,
+		ID:               pod.id,
+		State:            pod.state,
+		Hypervisor:       pod.config.HypervisorType,
+		Agent:            pod.config.AgentType,
 		ContainersStatus: contStatusList,
 	}
 
@@ -406,8 +375,7 @@ func CreateContainer(podID string, containerConfig ContainerConfig) (*Container,
 
 	// Update pod config.
 	p.config.Containers = append(p.config.Containers, containerConfig)
-	fs := filesystem{}
-	err = fs.storePodResource(podID, configFileType, *(p.config))
+	err = p.storage.storePodResource(podID, configFileType, *(p.config))
 	if err != nil {
 		return nil, err
 	}
@@ -454,8 +422,7 @@ func DeleteContainer(podID, containerID string) (*Container, error) {
 			break
 		}
 	}
-	fs := filesystem{}
-	err = fs.storePodResource(podID, configFileType, *(p.config))
+	err = p.storage.storePodResource(podID, configFileType, *(p.config))
 	if err != nil {
 		return nil, err
 	}
@@ -575,26 +542,22 @@ func EnterContainer(podID, containerID string, cmd Cmd) (*Container, error) {
 // StatusContainer is the virtcontainers container status entry point.
 // StatusContainer returns a detailed container status.
 func StatusContainer(podID, containerID string) (ContainerStatus, error) {
-	fs := filesystem{}
+	var contStatus ContainerStatus
 
-	contConfig, err := fs.fetchContainerConfig(podID, containerID)
+	pod, err := fetchPod(podID)
 	if err != nil {
 		return ContainerStatus{}, err
 	}
 
-	contStatus := ContainerStatus{
-		ID:     contConfig.ID,
-		RootFs: contConfig.RootFs,
-	}
-
-	state, err := fs.fetchContainerState(podID, containerID)
-	if err == nil {
-		contStatus.State = state
-	}
-
-	process, err := fs.fetchContainerProcess(podID, containerID)
-	if err == nil {
-		contStatus.PID = process.Pid
+	for _, container := range pod.containers {
+		if container.id == containerID {
+			contStatus = ContainerStatus{
+				ID:     container.id,
+				State:  container.state,
+				PID:    container.process.Pid,
+				RootFs: container.config.RootFs,
+			}
+		}
 	}
 
 	return contStatus, nil

--- a/api_test.go
+++ b/api_test.go
@@ -514,8 +514,7 @@ func TestListPodFailingFetchPodState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	path := filepath.Join(runStoragePath, p.id)
-	os.RemoveAll(path)
+	os.RemoveAll(p.configPath)
 
 	_, err = StatusPod(p.id)
 	if err == nil {
@@ -1222,11 +1221,7 @@ func TestStatusContainerFailing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	podDir := filepath.Join(configStoragePath, p.id)
-	_, err = os.Stat(podDir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	os.RemoveAll(p.configPath)
 
 	_, err = StatusContainer(p.id, contID)
 	if err == nil {

--- a/container.go
+++ b/container.go
@@ -34,8 +34,10 @@ type Process struct {
 
 // ContainerStatus describes a container status.
 type ContainerStatus struct {
-	ID    string
-	State State
+	ID     string
+	State  State
+	PID    int
+	RootFs string
 }
 
 // ContainerConfig describes one container runtime configuration.


### PR DESCRIPTION
Runtime implementation needs more information and we provide those information by extending the ContainerStatus structure. Then this PR improve the way those statuses are handled in virtcontainers.