### PR TITLE
pod: Fix pod state not saved

### DIFF
--- a/pod.go
+++ b/pod.go
@@ -440,6 +440,7 @@ func createPod(podConfig PodConfig) (*Pod, error) {
 
 	state, err := p.storage.fetchPodState(p.id)
 	if err == nil && state.State != "" {
+		p.state = state
 		return p, nil
 	}
 


### PR DESCRIPTION
When a pod object was created, we were never assigning its state in case
this state was already existing.