### PR TITLE
OCI package: Return container state instead of pod state

### DIFF
--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -196,7 +196,7 @@ func StatusToOCIState(status vc.PodStatus) (spec.State, error) {
 	state := spec.State{
 		Version: spec.Version,
 		ID:      status.ID,
-		Status:  stateToOCIState(status.State),
+		Status:  stateToOCIState(status.ContainersStatus[0].State),
 		Pid:     status.ContainersStatus[0].PID,
 		Bundle:  status.ContainersStatus[0].RootFs,
 	}

--- a/pkg/oci/utils_test.go
+++ b/pkg/oci/utils_test.go
@@ -134,6 +134,7 @@ func TestStatusToOCIStateSuccessfulWithReadyState(t *testing.T) {
 
 	cStatuses := []vc.ContainerStatus{
 		{
+			State:  state,
 			PID:    testPID,
 			RootFs: testRootFs,
 		},
@@ -167,6 +168,7 @@ func TestStatusToOCIStateSuccessfulWithRunningState(t *testing.T) {
 
 	cStatuses := []vc.ContainerStatus{
 		{
+			State:  state,
 			PID:    testPID,
 			RootFs: testRootFs,
 		},
@@ -200,6 +202,7 @@ func TestStatusToOCIStateSuccessfulWithStoppedState(t *testing.T) {
 
 	cStatuses := []vc.ContainerStatus{
 		{
+			State:  state,
 			PID:    testPID,
 			RootFs: testRootFs,
 		},


### PR DESCRIPTION
Because the container state can be updated from the runtime in case we
check if the process ID is running or not, we want to retrieve the state
of the container instead the state of the pod, in order to be accurate.