### PR TITLE
oci: Fix unit tests

### DIFF
--- a/pkg/oci/utils_test_config.go
+++ b/pkg/oci/utils_test_config.go
@@ -37,11 +37,30 @@ const minimalConfig = `
 			"TERM=xterm"
 		],
 		"cwd": "/",
-		"capabilities": [
-			"CAP_AUDIT_WRITE",
-			"CAP_KILL",
-			"CAP_NET_BIND_SERVICE"
-		],
+		"capabilities": {
+			"bounding": [
+				"CAP_AUDIT_WRITE",
+				"CAP_KILL",
+				"CAP_NET_BIND_SERVICE"
+			],
+			"permitted": [
+				"CAP_AUDIT_WRITE",
+				"CAP_KILL",
+				"CAP_NET_BIND_SERVICE"
+			],
+			"inheritable": [
+				"CAP_AUDIT_WRITE",
+				"CAP_KILL",
+				"CAP_NET_BIND_SERVICE"
+			],
+			"effective": [
+				"CAP_AUDIT_WRITE",
+				"CAP_KILL"
+			],
+			"ambient": [
+				"CAP_NET_BIND_SERVICE"
+			]
+		},
 		"rlimits": [
 			{
 				"type": "RLIMIT_NOFILE",


### PR DESCRIPTION
The rc4+ OCI specs has moved from a single array of
capabilities to an array of arrays.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>