### PR TITLE
0.6.0 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,12 @@
+0.6.0:
+	Added pullapprove support
+	Added Slack integration
+	Added KillContainer API
+	Added networking documentation
+	Added a Process structure for describing container processes
+	Added a more complete pod and container status structure
+	Fixed hyperstart implementation for stopping containers
+
 0.5.0:
 	Changed the CreatePod/StartPod logic
 	Added an OCI config file conversion package


### PR DESCRIPTION
Added pullapprove support
Added Slack integration
Added KillContainer API
Added networking documentation
Added a Process structure for describing container processes
Added a more complete pod and container status structure
Fixed hyperstart implementation for stopping containers

Shortlog:

5d01bc4 pkg: oci: Return container state instead of pod state
87433a3 CONTRIBUTING: Add contributions guidelines
1ced118 travis: Add go 1.8 to the test matrix
a12f01a oci: Fix unit tests
8055f58 documentation: Add network diagrams to README.md
55263ae pod: Fix pod state not saved
ad20d1e pkg: oci: Translate virtcontainers status to OCI state
103540c api: Remove hardcoded filesystem calls
8721a59 container: Add PID and RootFs to ContainerStatus structure
b208b12 state: Make virtcontainers states public
3dbb2b0 agent: hyperstart: Fix stopContainer after did some testing
a10b902 container: Store and fetch container's process
2b31b4e pod: Remove token from Cmd structure
520bfb0 filesystem: Remove commented imports
193c6c7 filesystem: Add process file type for containers
d61b20e container: Fetch state for each container from createContainers
35f2e69 container: Add Process structure
ea967b0 container: Kill a container before to remove it
c9d227a api: New KillContainer() API
8d650d7 agent: hyperstart: Implement killContainer()
faf17d8 agent: Add killContainer() method to the interface
a77aef5 oci: Container ID should be considered as pod ID
6f79d96 pod: Keep containers instead of containers configs in Pod structure
60c7507 pod: Change paused state to stopped state
377c864 pod: Add token field to Cmd structure
c277cfb api: Don't print ListPod() to stdout
33b63b0 api: Return a list of PodStatus struct from ListPod() API
d559e84 api: Don't print StatusContainer() to stdout
cad4749 api: Return new ContainerStatus structure from StatusContainer() API
0ca88d8 api: Don't print StatusPod() to stdout
897e057 api: Return new PodStatus structure from StatusPod() API
3879e59 api: Fix RunPod() according to changes to VM and network creation
053d4c8 ci: Send Travis notifications to Slack
401790e ci: Add pullapprove configuration file

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>