### PR TITLE
hyperstart/mock: Don't directly print to stderr

### DIFF
--- a/pkg/hyperstart/mock/hyperstart.go
+++ b/pkg/hyperstart/mock/hyperstart.go
@@ -133,11 +133,11 @@ func (h *Hyperstart) log(s string) {
 }
 
 func (h *Hyperstart) logf(format string, args ...interface{}) {
-	fmt.Fprintf(os.Stderr, "[hyperstart] "+format, args...)
+	h.t.Logf("[hyperstart] "+format, args...)
 }
 
 func (h *Hyperstart) logData(data []byte) {
-	fmt.Fprintln(os.Stderr, hex.Dump(data))
+	h.t.Log(hex.Dump(data))
 }
 
 //


### PR DESCRIPTION
Instead of manually printing to stderr, use the built-in testing.Log(f)
functions to output debug messages when the test running is set up to be
verbose.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>