### PR TITLE
pod: Remove redundant call to newAgent().

### DIFF
--- a/pod.go
+++ b/pod.go
@@ -273,8 +273,6 @@ type PodConfig struct {
 
 // valid checks that the pod configuration is valid.
 func (podConfig *PodConfig) valid() bool {
-	newAgent(podConfig.AgentType)
-
 	if _, err := newHypervisor(podConfig.HypervisorType); err != nil {
 		podConfig.HypervisorType = QemuHypervisor
 	}


### PR DESCRIPTION
PodConfig.valid() was calling newAgent() but ignoring the return value.
Since the return value isn't needed, remove the call.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>