### PR TITLE
network: Make createNetworkEndpoint() return an error.

### DIFF
--- a/cnm.go
+++ b/cnm.go
@@ -89,7 +89,10 @@ func (n *cnm) createEndpointsFromScan() ([]Endpoint, error) {
 		if iface.Name == "lo" {
 			continue
 		} else {
-			endpoint = createNetworkEndpoint(idx, uniqueID, iface.Name)
+			endpoint, err = createNetworkEndpoint(idx, uniqueID, iface.Name)
+			if err != nil {
+				return []Endpoint{}, err
+			}
 		}
 
 		endpoint.Properties, err = n.createResult(iface, addrs)

--- a/network_test.go
+++ b/network_test.go
@@ -152,7 +152,10 @@ func TestCreateNetworkEndpoint(t *testing.T) {
 		},
 	}
 
-	result := createNetworkEndpoint(4, "uniqueTestID", "")
+	result, err := createNetworkEndpoint(4, "uniqueTestID", "")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if reflect.DeepEqual(result, expected) == false {
 		t.Fatal()
@@ -176,10 +179,40 @@ func TestCreateNetworkEndpointChooseIfaceName(t *testing.T) {
 		},
 	}
 
-	result := createNetworkEndpoint(4, "uniqueTestID", "eth1")
+	result, err := createNetworkEndpoint(4, "uniqueTestID", "eth1")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if reflect.DeepEqual(result, expected) == false {
 		t.Fatal()
+	}
+}
+
+func TestCreateNetworkEndpointInvalidArgs(t *testing.T) {
+	type endpointValues struct {
+		idx      int
+		uniqueID string
+		ifName   string
+	}
+
+	// all elements are expected to result in failure
+	failingValues := []endpointValues{
+		{-1, "foo", "bar"},
+		{-1, "foo", ""},
+		{-3, "foo", "bar"},
+		{-3, "foo", ""},
+		{0, "", "bar"},
+		{0, "", ""},
+		{1, "", "bar"},
+		{1, "", ""},
+	}
+
+	for _, d := range failingValues {
+		result, err := createNetworkEndpoint(d.idx, d.uniqueID, d.ifName)
+		if err == nil {
+			t.Fatalf("expected invalid endpoint for %v, got %v", d, result)
+		}
 	}
 }
 


### PR DESCRIPTION
createNetworkEndpoint() can be passed invalid arguments, so make it
return an error to handle these situations.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>