### PR TITLE
agent: Cleanup the interface by removing unused parameters

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -132,6 +132,9 @@ type agent interface {
 	// stopPod will tell the agent to stop all containers related to the Pod.
 	stopPod(pod Pod) error
 
+	// createContainer will tell the agent to create a container related to a Pod.
+	createContainer(contConfig ContainerConfig) error
+
 	// startContainer will tell the agent to start a container related to a Pod.
 	startContainer(pod Pod, contConfig ContainerConfig) error
 

--- a/agent.go
+++ b/agent.go
@@ -118,29 +118,29 @@ type agent interface {
 	init(pod *Pod, config interface{}) error
 
 	// startAgent will start the agent.
-	startAgent() error
+	startAgent(pod *Pod) error
 
 	// stopAgent will stop the agent.
-	stopAgent() error
+	stopAgent(pod Pod) error
 
 	// exec will tell the agent to run a command in an already running container.
-	exec(pod Pod, container Container, cmd Cmd) (*Process, error)
+	exec(pod Pod, c Container, cmd Cmd) (*Process, error)
 
 	// startPod will tell the agent to start all containers related to the Pod.
-	startPod(config PodConfig) error
+	startPod(pod Pod) error
 
 	// stopPod will tell the agent to stop all containers related to the Pod.
 	stopPod(pod Pod) error
 
 	// createContainer will tell the agent to create a container related to a Pod.
-	createContainer(contConfig ContainerConfig) error
+	createContainer(pod Pod, c *Container) error
 
 	// startContainer will tell the agent to start a container related to a Pod.
-	startContainer(pod Pod, contConfig ContainerConfig) error
+	startContainer(pod Pod, c Container) error
 
 	// stopContainer will tell the agent to stop a container related to a Pod.
-	stopContainer(pod Pod, container Container) error
+	stopContainer(pod Pod, c Container) error
 
 	// killContainer will tell the agent to send a signal to a container related to a Pod.
-	killContainer(pod Pod, container Container, signal syscall.Signal) error
+	killContainer(pod Pod, c Container, signal syscall.Signal) error
 }

--- a/agent.go
+++ b/agent.go
@@ -124,7 +124,7 @@ type agent interface {
 	stopAgent() error
 
 	// exec will tell the agent to run a command in an already running container.
-	exec(pod Pod, container Container, cmd Cmd) error
+	exec(pod Pod, container Container, cmd Cmd) (*Process, error)
 
 	// startPod will tell the agent to start all containers related to the Pod.
 	startPod(config PodConfig) error

--- a/api.go
+++ b/api.go
@@ -507,36 +507,36 @@ func StopContainer(podID, containerID string) (*Container, error) {
 
 // EnterContainer is the virtcontainers container command execution entry point.
 // EnterContainer enters an already running container and runs a given command.
-func EnterContainer(podID, containerID string, cmd Cmd) (*Container, error) {
+func EnterContainer(podID, containerID string, cmd Cmd) (*Container, *Process, error) {
 	lockFile, err := lockPod(podID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer unlockPod(lockFile)
 
 	p, err := fetchPod(podID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Fetch the container.
 	c, err := fetchContainer(p, containerID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Enter it.
-	err = c.enter(cmd)
+	process, err := c.enter(cmd)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	err = p.endSession()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return c, nil
+	return c, process, nil
 }
 
 // StatusContainer is the virtcontainers container status entry point.

--- a/api_test.go
+++ b/api_test.go
@@ -281,7 +281,7 @@ func TestStartPodHyperstartAgentSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p.agent.(*hyper).bindUnmountAllRootfs()
+	p.agent.(*hyper).bindUnmountAllRootfs(*p)
 
 	err = os.Remove(pauseBinPath)
 	if err != nil {
@@ -399,7 +399,7 @@ func TestRunPodHyperstartAgentSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p.agent.(*hyper).bindUnmountAllRootfs()
+	p.agent.(*hyper).bindUnmountAllRootfs(*p)
 
 	err = os.Remove(pauseBinPath)
 	if err != nil {
@@ -799,7 +799,7 @@ func TestStartStopContainerHyperstartAgentSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p.agent.(*hyper).bindUnmountAllRootfs()
+	p.agent.(*hyper).bindUnmountAllRootfs(*p)
 
 	err = os.Remove(pauseBinPath)
 	if err != nil {
@@ -993,7 +993,7 @@ func TestEnterContainerHyperstartAgentSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p.agent.(*hyper).bindUnmountAllRootfs()
+	p.agent.(*hyper).bindUnmountAllRootfs(*p)
 
 	err = os.Remove(pauseBinPath)
 	if err != nil {

--- a/api_test.go
+++ b/api_test.go
@@ -934,7 +934,7 @@ func TestEnterContainerNoopAgentSuccessful(t *testing.T) {
 
 	cmd := newBasicTestCmd()
 
-	c, err = EnterContainer(p.id, contID, cmd)
+	c, _, err = EnterContainer(p.id, contID, cmd)
 	if c == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -983,7 +983,7 @@ func TestEnterContainerHyperstartAgentSuccessful(t *testing.T) {
 
 	cmd := newBasicTestCmd()
 
-	_, err = EnterContainer(p.id, contID, cmd)
+	_, _, err = EnterContainer(p.id, contID, cmd)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1008,7 +1008,7 @@ func TestEnterContainerFailingNoPod(t *testing.T) {
 
 	cmd := newBasicTestCmd()
 
-	c, err := EnterContainer(testPodID, contID, cmd)
+	c, _, err := EnterContainer(testPodID, contID, cmd)
 	if c != nil || err == nil {
 		t.Fatal()
 	}
@@ -1031,7 +1031,7 @@ func TestEnterContainerFailingNoContainer(t *testing.T) {
 
 	cmd := newBasicTestCmd()
 
-	c, err := EnterContainer(p.id, contID, cmd)
+	c, _, err := EnterContainer(p.id, contID, cmd)
 	if c != nil || err == nil {
 		t.Fatal()
 	}
@@ -1061,7 +1061,7 @@ func TestEnterContainerFailingContNotStarted(t *testing.T) {
 
 	cmd := newBasicTestCmd()
 
-	c, err = EnterContainer(p.id, contID, cmd)
+	c, _, err = EnterContainer(p.id, contID, cmd)
 	if c != nil || err == nil {
 		t.Fatal()
 	}

--- a/container.go
+++ b/container.go
@@ -248,7 +248,9 @@ func createContainer(pod *Pod, contConfig ContainerConfig) (*Container, error) {
 	// found and that we are in the first creation of this container.
 	// We don't want the following code to be executed outside of this
 	// specific case.
-	if err := c.pod.agent.createContainer(*(c.config)); err != nil {
+	pod.containers = append(pod.containers, c)
+
+	if err := c.pod.agent.createContainer(*pod, c); err != nil {
 		return nil, err
 	}
 
@@ -304,7 +306,7 @@ func (c *Container) start() error {
 		}
 	}
 
-	err = c.pod.agent.startContainer(*c.pod, *(c.config))
+	err = c.pod.agent.startContainer(*(c.pod), *c)
 	if err != nil {
 		c.stop()
 		return err
@@ -342,12 +344,12 @@ func (c *Container) stop() error {
 		return err
 	}
 
-	err = c.pod.agent.killContainer(*c.pod, *c, syscall.SIGTERM)
+	err = c.pod.agent.killContainer(*(c.pod), *c, syscall.SIGTERM)
 	if err != nil {
 		return err
 	}
 
-	err = c.pod.agent.stopContainer(*c.pod, *c)
+	err = c.pod.agent.stopContainer(*(c.pod), *c)
 	if err != nil {
 		return err
 	}
@@ -379,7 +381,7 @@ func (c *Container) enter(cmd Cmd) (*Process, error) {
 		return nil, fmt.Errorf("Container not running, impossible to enter")
 	}
 
-	process, err := c.pod.agent.exec(*c.pod, *c, cmd)
+	process, err := c.pod.agent.exec(*(c.pod), *c, cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -406,7 +408,7 @@ func (c *Container) kill(signal syscall.Signal) error {
 		return fmt.Errorf("Container not running, impossible to signal the container")
 	}
 
-	err = c.pod.agent.killContainer(*c.pod, *c, signal)
+	err = c.pod.agent.killContainer(*(c.pod), *c, signal)
 	if err != nil {
 		return err
 	}

--- a/container.go
+++ b/container.go
@@ -353,31 +353,31 @@ func (c *Container) stop() error {
 	return nil
 }
 
-func (c *Container) enter(cmd Cmd) error {
+func (c *Container) enter(cmd Cmd) (*Process, error) {
 	state, err := c.pod.storage.fetchPodState(c.pod.id)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if state.State != StateRunning {
-		return fmt.Errorf("Pod not running, impossible to enter the container")
+		return nil, fmt.Errorf("Pod not running, impossible to enter the container")
 	}
 
 	state, err = c.pod.storage.fetchContainerState(c.pod.id, c.id)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if state.State != StateRunning {
-		return fmt.Errorf("Container not running, impossible to enter")
+		return nil, fmt.Errorf("Container not running, impossible to enter")
 	}
 
-	err = c.pod.agent.exec(*c.pod, *c, cmd)
+	process, err := c.pod.agent.exec(*c.pod, *c, cmd)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return process, nil
 }
 
 func (c *Container) kill(signal syscall.Signal) error {

--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -519,7 +519,7 @@ func enterContainer(context *cli.Context) error {
 		WorkDir: "/",
 	}
 
-	c, err := vc.EnterContainer(context.String("pod-id"), context.String("id"), cmd)
+	c, _, err := vc.EnterContainer(context.String("pod-id"), context.String("id"), cmd)
 	if err != nil {
 		return fmt.Errorf("Could not enter container: %s", err)
 	}

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -91,7 +91,6 @@ func (c *HyperConfig) validate(pod Pod) bool {
 
 // hyper is the Agent interface implementation for hyperstart.
 type hyper struct {
-	pod    *Pod
 	config HyperConfig
 	proxy  proxy
 }
@@ -147,11 +146,10 @@ func (h *hyper) buildHyperContainerProcess(cmd Cmd, stdio uint64, stderr uint64,
 	return process, nil
 }
 
-func (h *hyper) linkPauseBinary() error {
-	pauseDir := filepath.Join(defaultSharedDir, h.pod.id, pauseContainerName, rootfsDir)
+func (h *hyper) linkPauseBinary(podID string) error {
+	pauseDir := filepath.Join(defaultSharedDir, podID, pauseContainerName, rootfsDir)
 
-	err := os.MkdirAll(pauseDir, dirMode)
-	if err != nil {
+	if err := os.MkdirAll(pauseDir, dirMode); err != nil {
 		return err
 	}
 
@@ -160,37 +158,33 @@ func (h *hyper) linkPauseBinary() error {
 	return os.Link(h.config.PauseBinPath, pausePath)
 }
 
-func (h *hyper) unlinkPauseBinary() error {
-	pauseDir := filepath.Join(defaultSharedDir, h.pod.id, pauseContainerName)
+func (h *hyper) unlinkPauseBinary(podID string) error {
+	pauseDir := filepath.Join(defaultSharedDir, podID, pauseContainerName)
 
 	return os.RemoveAll(pauseDir)
 }
 
-func (h *hyper) bindMountContainerRootfs(container ContainerConfig) error {
-	rootfsDest := filepath.Join(defaultSharedDir, h.pod.id, container.ID)
+func (h *hyper) bindMountContainerRootfs(podID, cID, cRootFs string) error {
+	rootfsDest := filepath.Join(defaultSharedDir, podID, cID)
 
-	return bindMount(container.RootFs, rootfsDest)
+	return bindMount(cRootFs, rootfsDest)
 }
 
-func (h *hyper) bindUnmountContainerRootfs(container ContainerConfig) error {
-	rootfsDest := filepath.Join(defaultSharedDir, h.pod.id, container.ID)
+func (h *hyper) bindUnmountContainerRootfs(podID, cID string) error {
+	rootfsDest := filepath.Join(defaultSharedDir, podID, cID)
 	syscall.Unmount(rootfsDest, 0)
 
 	return nil
 }
 
-func (h *hyper) bindUnmountAllRootfs() {
-	for _, c := range h.pod.containers {
-		if c.config == nil {
-			continue
-		}
-
-		h.bindUnmountContainerRootfs(*(c.config))
+func (h *hyper) bindUnmountAllRootfs(pod Pod) {
+	for _, c := range pod.containers {
+		h.bindUnmountContainerRootfs(pod.id, c.id)
 	}
 }
 
 // init is the agent initialization implementation for hyperstart.
-func (h *hyper) init(pod *Pod, config interface{}) error {
+func (h *hyper) init(pod *Pod, config interface{}) (err error) {
 	switch c := config.(type) {
 	case HyperConfig:
 		if c.validate(*pod) == false {
@@ -201,18 +195,18 @@ func (h *hyper) init(pod *Pod, config interface{}) error {
 		return fmt.Errorf("Invalid config type")
 	}
 
+	// Override pod agent configuration
 	pod.config.AgentConfig = h.config
-	h.pod = pod
 
 	for _, volume := range h.config.Volumes {
-		err := h.pod.hypervisor.addDevice(volume, fsDev)
+		err := pod.hypervisor.addDevice(volume, fsDev)
 		if err != nil {
 			return err
 		}
 	}
 
 	for _, socket := range h.config.Sockets {
-		err := h.pod.hypervisor.addDevice(socket, serialPortDev)
+		err := pod.hypervisor.addDevice(socket, serialPortDev)
 		if err != nil {
 			return err
 		}
@@ -225,13 +219,11 @@ func (h *hyper) init(pod *Pod, config interface{}) error {
 		HostPath: filepath.Join(defaultSharedDir, pod.id),
 	}
 
-	err := os.MkdirAll(sharedVolume.HostPath, dirMode)
-	if err != nil {
+	if err := os.MkdirAll(sharedVolume.HostPath, dirMode); err != nil {
 		return err
 	}
 
-	err = h.pod.hypervisor.addDevice(sharedVolume, fsDev)
-	if err != nil {
+	if err := pod.hypervisor.addDevice(sharedVolume, fsDev); err != nil {
 		return err
 	}
 
@@ -243,25 +235,25 @@ func (h *hyper) init(pod *Pod, config interface{}) error {
 	return nil
 }
 
-// start is the agent starting implementation for hyperstart.
-func (h *hyper) startAgent() error {
-	proxyInfos, err := h.proxy.register(*(h.pod), true)
+// startAgent is the agent starting implementation for hyperstart.
+func (h *hyper) startAgent(pod *Pod) error {
+	proxyInfos, err := h.proxy.register(*pod, true)
 	if err != nil {
 		return err
 	}
 
-	if len(proxyInfos) != len(h.pod.containers) {
-		return fmt.Errorf("Retrieved %d proxy infos, expecting %d", len(proxyInfos), len(h.pod.containers))
+	if len(proxyInfos) != len(pod.containers) {
+		return fmt.Errorf("Retrieved %d proxy infos, expecting %d", len(proxyInfos), len(pod.containers))
 	}
 
-	for idx := range h.pod.containers {
-		h.pod.containers[idx].process = Process{
+	for idx := range pod.containers {
+		pod.containers[idx].process = Process{
 			Token:  proxyInfos[idx].Token,
 			Stdio:  proxyInfos[idx].StdioID,
 			Stderr: proxyInfos[idx].StderrID,
 		}
 
-		if err := h.pod.containers[idx].storeProcess(); err != nil {
+		if err := pod.containers[idx].storeProcess(); err != nil {
 			return err
 		}
 	}
@@ -269,20 +261,33 @@ func (h *hyper) startAgent() error {
 	return h.proxy.disconnect()
 }
 
+// stopAgent is the agent stopping implementation for hyperstart.
+func (h *hyper) stopAgent(pod Pod) error {
+	if _, err := h.proxy.connect(pod, false); err != nil {
+		return err
+	}
+
+	if err := h.proxy.unregister(pod); err != nil {
+		return err
+	}
+
+	return h.proxy.disconnect()
+}
+
 // exec is the agent command execution implementation for hyperstart.
-func (h *hyper) exec(pod Pod, container Container, cmd Cmd) (*Process, error) {
+func (h *hyper) exec(pod Pod, c Container, cmd Cmd) (*Process, error) {
 	proxyInfo, err := h.proxy.connect(pod, true)
 	if err != nil {
 		return nil, err
 	}
 
-	process, err := h.buildHyperContainerProcess(cmd, proxyInfo.StdioID, proxyInfo.StderrID, container.config.Interactive)
+	process, err := h.buildHyperContainerProcess(cmd, proxyInfo.StdioID, proxyInfo.StderrID, c.config.Interactive)
 	if err != nil {
 		return nil, err
 	}
 
 	execInfo := ExecInfo{
-		Container: container.id,
+		Container: c.id,
 		Process:   *process,
 	}
 
@@ -307,27 +312,13 @@ func (h *hyper) exec(pod Pod, container Container, cmd Cmd) (*Process, error) {
 }
 
 // startPod is the agent Pod starting implementation for hyperstart.
-func (h *hyper) startPod(config PodConfig) error {
-	if _, err := h.proxy.connect(*(h.pod), false); err != nil {
+func (h *hyper) startPod(pod Pod) error {
+	if _, err := h.proxy.connect(pod, false); err != nil {
 		return err
 	}
 
-	var proxyInfos []ProxyInfo
-	for _, c := range h.pod.containers {
-		proxyInfo := ProxyInfo{
-			StdioID:  c.process.Stdio,
-			StderrID: c.process.Stderr,
-		}
-
-		proxyInfos = append(proxyInfos, proxyInfo)
-	}
-
-	if len(proxyInfos) != len(config.Containers) {
-		return fmt.Errorf("Retrieved %d proxy infos, expecting %d", len(proxyInfos), len(config.Containers))
-	}
-
 	hyperPod := hyperJson.Pod{
-		Hostname:             config.ID,
+		Hostname:             pod.id,
 		DeprecatedContainers: []hyperJson.Container{},
 		ShareDir:             mountTag,
 	}
@@ -341,13 +332,12 @@ func (h *hyper) startPod(config PodConfig) error {
 		return err
 	}
 
-	if err := h.startPauseContainer(*(h.pod)); err != nil {
+	if err := h.startPauseContainer(pod.id); err != nil {
 		return err
 	}
 
-	for idx, c := range config.Containers {
-		err := h.startOneContainer(*(h.pod), c, proxyInfos[idx])
-		if err != nil {
+	for _, c := range pod.containers {
+		if err := h.startOneContainer(pod, *c); err != nil {
 			return err
 		}
 	}
@@ -357,13 +347,12 @@ func (h *hyper) startPod(config PodConfig) error {
 
 // stopPod is the agent Pod stopping implementation for hyperstart.
 func (h *hyper) stopPod(pod Pod) error {
-	_, err := h.proxy.connect(pod, false)
-	if err != nil {
+	if _, err := h.proxy.connect(pod, false); err != nil {
 		return err
 	}
 
-	for _, contConfig := range pod.config.Containers {
-		state, err := pod.storage.fetchContainerState(pod.id, contConfig.ID)
+	for _, c := range pod.containers {
+		state, err := pod.storage.fetchContainerState(pod.id, c.id)
 		if err != nil {
 			return err
 		}
@@ -372,47 +361,28 @@ func (h *hyper) stopPod(pod Pod) error {
 			continue
 		}
 
-		container := Container{
-			id: contConfig.ID,
-		}
-
-		if err := h.killOneContainer(container, syscall.SIGTERM); err != nil {
+		if err := h.killOneContainer(c.id, syscall.SIGTERM); err != nil {
 			return err
 		}
 
-		if err := h.stopOneContainer(contConfig); err != nil {
+		if err := h.stopOneContainer(pod.id, c.id); err != nil {
 			return err
 		}
 	}
 
-	err = h.stopPauseContainer()
-	if err != nil {
+	if err := h.stopPauseContainer(pod.id); err != nil {
 		return err
 	}
 
-	err = h.proxy.disconnect()
-	if err != nil {
+	if err := h.proxy.disconnect(); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-// stop is the agent stopping implementation for hyperstart.
-func (h *hyper) stopAgent() error {
-	if _, err := h.proxy.connect(*(h.pod), false); err != nil {
-		return err
-	}
-
-	if err := h.proxy.unregister(*(h.pod)); err != nil {
-		return err
-	}
-
-	return h.proxy.disconnect()
-}
-
 // startPauseContainer starts a specific container running the pause binary provided.
-func (h *hyper) startPauseContainer(pod Pod) error {
+func (h *hyper) startPauseContainer(podID string) error {
 	cmd := Cmd{
 		Args:    []string{fmt.Sprintf("./%s", pauseBinName)},
 		Envs:    []EnvVar{},
@@ -431,8 +401,7 @@ func (h *hyper) startPauseContainer(pod Pod) error {
 		Process: process,
 	}
 
-	err = h.linkPauseBinary()
-	if err != nil {
+	if err := h.linkPauseBinary(podID); err != nil {
 		return err
 	}
 
@@ -441,30 +410,28 @@ func (h *hyper) startPauseContainer(pod Pod) error {
 		message: container,
 	}
 
-	_, err = h.proxy.sendCmd(proxyCmd)
-	if err != nil {
+	if _, err := h.proxy.sendCmd(proxyCmd); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (h *hyper) startOneContainer(pod Pod, contConfig ContainerConfig, proxyInfo ProxyInfo) error {
-	process, err := h.buildHyperContainerProcess(contConfig.Cmd, proxyInfo.StdioID, proxyInfo.StderrID, contConfig.Interactive)
+func (h *hyper) startOneContainer(pod Pod, c Container) error {
+	process, err := h.buildHyperContainerProcess(c.config.Cmd, c.process.Stdio, c.process.Stderr, c.config.Interactive)
 	if err != nil {
 		return err
 	}
 
 	container := hyperJson.Container{
-		Id:      contConfig.ID,
-		Image:   contConfig.ID,
+		Id:      c.id,
+		Image:   c.id,
 		Rootfs:  rootfsDir,
 		Process: process,
 	}
 
-	err = h.bindMountContainerRootfs(contConfig)
-	if err != nil {
-		h.bindUnmountAllRootfs()
+	if err := h.bindMountContainerRootfs(pod.id, c.id, c.rootFs); err != nil {
+		h.bindUnmountAllRootfs(pod)
 		return err
 	}
 
@@ -473,8 +440,7 @@ func (h *hyper) startOneContainer(pod Pod, contConfig ContainerConfig, proxyInfo
 		message: container,
 	}
 
-	_, err = h.proxy.sendCmd(proxyCmd)
-	if err != nil {
+	if _, err := h.proxy.sendCmd(proxyCmd); err != nil {
 		return err
 	}
 
@@ -482,24 +448,19 @@ func (h *hyper) startOneContainer(pod Pod, contConfig ContainerConfig, proxyInfo
 }
 
 // createContainer is the agent Container creation implementation for hyperstart.
-func (h *hyper) createContainer(contConfig ContainerConfig) error {
-	proxyInfo, err := h.proxy.connect(*(h.pod), true)
+func (h *hyper) createContainer(pod Pod, c *Container) error {
+	proxyInfo, err := h.proxy.connect(pod, true)
 	if err != nil {
 		return err
 	}
 
-	container := &Container{
-		id:    contConfig.ID,
-		podID: h.pod.id,
-		pod:   h.pod,
-		process: Process{
-			Token:  proxyInfo.Token,
-			Stdio:  proxyInfo.StdioID,
-			Stderr: proxyInfo.StderrID,
-		},
+	c.process = Process{
+		Token:  proxyInfo.Token,
+		Stdio:  proxyInfo.StdioID,
+		Stderr: proxyInfo.StderrID,
 	}
 
-	if err := container.storeProcess(); err != nil {
+	if err := c.storeProcess(); err != nil {
 		return err
 	}
 
@@ -507,49 +468,24 @@ func (h *hyper) createContainer(contConfig ContainerConfig) error {
 }
 
 // startContainer is the agent Container starting implementation for hyperstart.
-func (h *hyper) startContainer(pod Pod, contConfig ContainerConfig) error {
-	_, err := h.proxy.connect(pod, false)
-	if err != nil {
+func (h *hyper) startContainer(pod Pod, c Container) error {
+	if _, err := h.proxy.connect(pod, false); err != nil {
 		return err
 	}
 
-	var proxyInfo ProxyInfo
-	containerFound := false
-	for _, c := range h.pod.containers {
-		if c.id != contConfig.ID {
-			continue
-		}
-
-		proxyInfo.StdioID = c.process.Stdio
-		proxyInfo.StderrID = c.process.Stderr
-
-		containerFound = true
-
-		break
-	}
-
-	if containerFound == false {
-		return fmt.Errorf("Could not find container %s in the pod", contConfig.ID)
-	}
-
-	err = h.startOneContainer(pod, contConfig, proxyInfo)
-	if err != nil {
+	if err := h.startOneContainer(pod, c); err != nil {
 		return err
 	}
 
 	return h.proxy.disconnect()
 }
 
-func (h *hyper) stopPauseContainer() error {
-	container := Container{
-		id: pauseContainerName,
-	}
-
-	if err := h.killOneContainer(container, syscall.SIGKILL); err != nil {
+func (h *hyper) stopPauseContainer(podID string) error {
+	if err := h.killOneContainer(pauseContainerName, syscall.SIGKILL); err != nil {
 		return err
 	}
 
-	if err := h.unlinkPauseBinary(); err != nil {
+	if err := h.unlinkPauseBinary(podID); err != nil {
 		return err
 	}
 
@@ -557,55 +493,12 @@ func (h *hyper) stopPauseContainer() error {
 }
 
 // stopContainer is the agent Container stopping implementation for hyperstart.
-func (h *hyper) stopContainer(pod Pod, container Container) error {
-	_, err := h.proxy.connect(pod, false)
-	if err != nil {
-		return err
-	}
-
-	err = h.stopOneContainer(*(container.config))
-	if err != nil {
-		return err
-	}
-
-	err = h.proxy.disconnect()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (h *hyper) stopOneContainer(contConfig ContainerConfig) error {
-	removeContainer := RemoveContainer{
-		Container: contConfig.ID,
-	}
-
-	proxyCmd := hyperstartProxyCmd{
-		cmd:     hyperstart.RemoveContainer,
-		message: removeContainer,
-	}
-
-	_, err := h.proxy.sendCmd(proxyCmd)
-	if err != nil {
-		return err
-	}
-
-	err = h.bindUnmountContainerRootfs(contConfig)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// killContainer is the agent process signal implementation for hyperstart.
-func (h *hyper) killContainer(pod Pod, container Container, signal syscall.Signal) error {
+func (h *hyper) stopContainer(pod Pod, c Container) error {
 	if _, err := h.proxy.connect(pod, false); err != nil {
 		return err
 	}
 
-	if err := h.killOneContainer(container, signal); err != nil {
+	if err := h.stopOneContainer(pod.id, c.id); err != nil {
 		return err
 	}
 
@@ -616,9 +509,47 @@ func (h *hyper) killContainer(pod Pod, container Container, signal syscall.Signa
 	return nil
 }
 
-func (h *hyper) killOneContainer(container Container, signal syscall.Signal) error {
+func (h *hyper) stopOneContainer(podID, cID string) error {
+	removeContainer := RemoveContainer{
+		Container: cID,
+	}
+
+	proxyCmd := hyperstartProxyCmd{
+		cmd:     hyperstart.RemoveContainer,
+		message: removeContainer,
+	}
+
+	if _, err := h.proxy.sendCmd(proxyCmd); err != nil {
+		return err
+	}
+
+	if err := h.bindUnmountContainerRootfs(podID, cID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// killContainer is the agent process signal implementation for hyperstart.
+func (h *hyper) killContainer(pod Pod, c Container, signal syscall.Signal) error {
+	if _, err := h.proxy.connect(pod, false); err != nil {
+		return err
+	}
+
+	if err := h.killOneContainer(c.id, signal); err != nil {
+		return err
+	}
+
+	if err := h.proxy.disconnect(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *hyper) killOneContainer(cID string, signal syscall.Signal) error {
 	killCmd := KillCommand{
-		Container: container.id,
+		Container: cID,
 		Signal:    signal,
 	}
 

--- a/noop_agent.go
+++ b/noop_agent.go
@@ -55,6 +55,11 @@ func (n *noopAgent) stopAgent() error {
 	return nil
 }
 
+// createContainer is the Noop agent Container creation implementation. It does nothing.
+func (n *noopAgent) createContainer(contConfig ContainerConfig) error {
+	return nil
+}
+
 // startContainer is the Noop agent Container starting implementation. It does nothing.
 func (n *noopAgent) startContainer(pod Pod, contConfig ContainerConfig) error {
 	return nil

--- a/noop_agent.go
+++ b/noop_agent.go
@@ -31,17 +31,22 @@ func (n *noopAgent) init(pod *Pod, config interface{}) error {
 }
 
 // start is the Noop agent starting implementation. It does nothing.
-func (n *noopAgent) startAgent() error {
+func (n *noopAgent) startAgent(pod *Pod) error {
+	return nil
+}
+
+// stop is the Noop agent stopping implementation. It does nothing.
+func (n *noopAgent) stopAgent(pod Pod) error {
 	return nil
 }
 
 // exec is the Noop agent command execution implementation. It does nothing.
-func (n *noopAgent) exec(pod Pod, container Container, cmd Cmd) (*Process, error) {
+func (n *noopAgent) exec(pod Pod, c Container, cmd Cmd) (*Process, error) {
 	return nil, nil
 }
 
 // startPod is the Noop agent Pod starting implementation. It does nothing.
-func (n *noopAgent) startPod(config PodConfig) error {
+func (n *noopAgent) startPod(pod Pod) error {
 	return nil
 }
 
@@ -50,27 +55,22 @@ func (n *noopAgent) stopPod(pod Pod) error {
 	return nil
 }
 
-// stop is the Noop agent stopping implementation. It does nothing.
-func (n *noopAgent) stopAgent() error {
-	return nil
-}
-
 // createContainer is the Noop agent Container creation implementation. It does nothing.
-func (n *noopAgent) createContainer(contConfig ContainerConfig) error {
+func (n *noopAgent) createContainer(pod Pod, c *Container) error {
 	return nil
 }
 
 // startContainer is the Noop agent Container starting implementation. It does nothing.
-func (n *noopAgent) startContainer(pod Pod, contConfig ContainerConfig) error {
+func (n *noopAgent) startContainer(pod Pod, c Container) error {
 	return nil
 }
 
 // stopContainer is the Noop agent Container stopping implementation. It does nothing.
-func (n *noopAgent) stopContainer(pod Pod, container Container) error {
+func (n *noopAgent) stopContainer(pod Pod, c Container) error {
 	return nil
 }
 
 // killContainer is the Noop agent Container signaling implementation. It does nothing.
-func (n *noopAgent) killContainer(pod Pod, container Container, signal syscall.Signal) error {
+func (n *noopAgent) killContainer(pod Pod, c Container, signal syscall.Signal) error {
 	return nil
 }

--- a/noop_agent.go
+++ b/noop_agent.go
@@ -36,8 +36,8 @@ func (n *noopAgent) startAgent() error {
 }
 
 // exec is the Noop agent command execution implementation. It does nothing.
-func (n *noopAgent) exec(pod Pod, container Container, cmd Cmd) error {
-	return nil
+func (n *noopAgent) exec(pod Pod, container Container, cmd Cmd) (*Process, error) {
+	return nil, nil
 }
 
 // startPod is the Noop agent Pod starting implementation. It does nothing.

--- a/noop_agent_test.go
+++ b/noop_agent_test.go
@@ -79,6 +79,16 @@ func TestNoopAgentStopAgent(t *testing.T) {
 	}
 }
 
+func TestNoopAgentCreateContainer(t *testing.T) {
+	n := &noopAgent{}
+	contConfig := ContainerConfig{}
+
+	err := n.createContainer(contConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestNoopAgentStartContainer(t *testing.T) {
 	n := &noopAgent{}
 	pod := Pod{}

--- a/noop_agent_test.go
+++ b/noop_agent_test.go
@@ -32,8 +32,9 @@ func TestNoopAgentInit(t *testing.T) {
 
 func TestNoopAgentStartAgent(t *testing.T) {
 	n := &noopAgent{}
+	pod := &Pod{}
 
-	err := n.startAgent()
+	err := n.startAgent(pod)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,9 +53,9 @@ func TestNoopAgentExec(t *testing.T) {
 
 func TestNoopAgentStartPod(t *testing.T) {
 	n := &noopAgent{}
-	podConfig := PodConfig{}
+	pod := Pod{}
 
-	err := n.startPod(podConfig)
+	err := n.startPod(pod)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,8 +73,9 @@ func TestNoopAgentStopPod(t *testing.T) {
 
 func TestNoopAgentStopAgent(t *testing.T) {
 	n := &noopAgent{}
+	pod := Pod{}
 
-	err := n.stopAgent()
+	err := n.stopAgent(pod)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,9 +83,10 @@ func TestNoopAgentStopAgent(t *testing.T) {
 
 func TestNoopAgentCreateContainer(t *testing.T) {
 	n := &noopAgent{}
-	contConfig := ContainerConfig{}
+	pod := Pod{}
+	container := &Container{}
 
-	err := n.createContainer(contConfig)
+	err := n.createContainer(pod, container)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,9 +95,9 @@ func TestNoopAgentCreateContainer(t *testing.T) {
 func TestNoopAgentStartContainer(t *testing.T) {
 	n := &noopAgent{}
 	pod := Pod{}
-	contConfig := ContainerConfig{}
+	container := Container{}
 
-	err := n.startContainer(pod, contConfig)
+	err := n.startContainer(pod, container)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/noop_agent_test.go
+++ b/noop_agent_test.go
@@ -45,8 +45,7 @@ func TestNoopAgentExec(t *testing.T) {
 	container := Container{}
 	cmd := Cmd{}
 
-	err := n.exec(pod, container, cmd)
-	if err != nil {
+	if _, err := n.exec(pod, container, cmd); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/noop_proxy.go
+++ b/noop_proxy.go
@@ -20,16 +20,20 @@ type noopProxy struct{}
 
 // register is the proxy register implementation for testing purpose.
 // It does nothing.
-func (p *noopProxy) register(pod Pod) ([]IOStream, error) {
-	var ioStreams []IOStream
+func (p *noopProxy) register(pod Pod, newInfos bool) ([]ProxyInfo, error) {
+	var proxyInfos []ProxyInfo
 
-	for i := 0; i < len(pod.containers); i++ {
-		ioStream := IOStream{}
-
-		ioStreams = append(ioStreams, ioStream)
+	if newInfos == false {
+		return []ProxyInfo{}, nil
 	}
 
-	return ioStreams, nil
+	for i := 0; i < len(pod.containers); i++ {
+		proxyInfo := ProxyInfo{}
+
+		proxyInfos = append(proxyInfos, proxyInfo)
+	}
+
+	return proxyInfos, nil
 }
 
 // unregister is the proxy unregister implementation for testing purpose.
@@ -40,8 +44,8 @@ func (p *noopProxy) unregister(pod Pod) error {
 
 // connect is the proxy connect implementation for testing purpose.
 // It does nothing.
-func (p *noopProxy) connect(pod Pod) (IOStream, error) {
-	return IOStream{}, nil
+func (p *noopProxy) connect(pod Pod, newInfo bool) (ProxyInfo, error) {
+	return ProxyInfo{}, nil
 }
 
 // disconnect is the proxy disconnect implementation for testing purpose.

--- a/pod.go
+++ b/pod.go
@@ -566,7 +566,7 @@ func (p *Pod) startVM() error {
 		return fmt.Errorf("Did not receive the pod started notification")
 	}
 
-	err := p.agent.startAgent()
+	err := p.agent.startAgent(p)
 	if err != nil {
 		p.stop()
 		return err
@@ -585,7 +585,7 @@ func (p *Pod) start() error {
 		return err
 	}
 
-	err = p.agent.startPod(*p.config)
+	err = p.agent.startPod(*p)
 	if err != nil {
 		p.stop()
 		return err
@@ -631,7 +631,7 @@ func (p *Pod) stopSetStates() error {
 
 // stopVM stops the agent inside the VM and shut down the VM itself.
 func (p *Pod) stopVM() error {
-	err := p.agent.stopAgent()
+	err := p.agent.stopAgent(*p)
 	if err != nil {
 		return err
 	}

--- a/proxy.go
+++ b/proxy.go
@@ -18,7 +18,6 @@ package virtcontainers
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -89,30 +88,29 @@ func newProxyConfig(config PodConfig) interface{} {
 	}
 }
 
-// IOStream holds three file descriptors returned by the proxy.
-// Those file descriptors will be given to the calling process,
-// so that it can interact with a workload running on a container.
-type IOStream struct {
-	Stdin    *os.File
-	Stdout   *os.File
-	Stderr   *os.File
-	StdinID  uint64
-	StdoutID uint64
+// ProxyInfo holds the token and url returned by the proxy.
+// Each ProxyInfo relates to a process running inside a container.
+type ProxyInfo struct {
+	Token string
+	URL   string
+
+	// Keep for legacy, will be removed when new proxy is ready.
+	StdioID  uint64
 	StderrID uint64
 }
 
 // proxy is the virtcontainers proxy interface.
 type proxy interface {
 	// register connects and registers the proxy to the given VM.
-	// It also returns streams related to containers workloads.
-	register(pod Pod) ([]IOStream, error)
+	// It also returns information related to containers workloads.
+	register(pod Pod, reuseConnection bool) ([]ProxyInfo, error)
 
 	// unregister unregisters and disconnects the proxy from the given VM.
 	unregister(pod Pod) error
 
 	// connect gets the proxy a handle to a previously registered VM.
-	// It also returns streams related to containers workloads.
-	connect(pod Pod) (IOStream, error)
+	// It also returns information related to containers workloads.
+	connect(pod Pod, reuseConnection bool) (ProxyInfo, error)
 
 	// disconnect disconnects from the proxy.
 	disconnect() error

--- a/sshd.go
+++ b/sshd.go
@@ -164,6 +164,11 @@ func (s *sshd) stopAgent() error {
 	return nil
 }
 
+// createContainer is the agent Container creation implementation for sshd.
+func (s *sshd) createContainer(contConfig ContainerConfig) error {
+	return nil
+}
+
 // startContainer is the agent Container starting implementation for sshd.
 func (s *sshd) startContainer(pod Pod, contConfig ContainerConfig) error {
 	return nil

--- a/sshd.go
+++ b/sshd.go
@@ -89,8 +89,8 @@ func (s *sshd) init(pod *Pod, config interface{}) error {
 	return nil
 }
 
-// start is the agent starting implementation for sshd.
-func (s *sshd) startAgent() error {
+// startAgent is the agent starting implementation for sshd.
+func (s *sshd) startAgent(pod *Pod) error {
 	if s.client != nil {
 		session, err := s.client.NewSession()
 		if err == nil {
@@ -129,8 +129,13 @@ func (s *sshd) startAgent() error {
 	return nil
 }
 
+// stopAgent is the agent stopping implementation for sshd.
+func (s *sshd) stopAgent(pod Pod) error {
+	return nil
+}
+
 // exec is the agent command execution implementation for sshd.
-func (s *sshd) exec(pod Pod, container Container, cmd Cmd) (*Process, error) {
+func (s *sshd) exec(pod Pod, c Container, cmd Cmd) (*Process, error) {
 	session, err := s.client.NewSession()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create session")
@@ -150,7 +155,7 @@ func (s *sshd) exec(pod Pod, container Container, cmd Cmd) (*Process, error) {
 }
 
 // startPod is the agent Pod starting implementation for sshd.
-func (s *sshd) startPod(config PodConfig) error {
+func (s *sshd) startPod(pod Pod) error {
 	return nil
 }
 
@@ -159,27 +164,22 @@ func (s *sshd) stopPod(pod Pod) error {
 	return nil
 }
 
-// stop is the agent stopping implementation for sshd.
-func (s *sshd) stopAgent() error {
-	return nil
-}
-
 // createContainer is the agent Container creation implementation for sshd.
-func (s *sshd) createContainer(contConfig ContainerConfig) error {
+func (s *sshd) createContainer(pod Pod, c *Container) error {
 	return nil
 }
 
 // startContainer is the agent Container starting implementation for sshd.
-func (s *sshd) startContainer(pod Pod, contConfig ContainerConfig) error {
+func (s *sshd) startContainer(pod Pod, c Container) error {
 	return nil
 }
 
 // stopContainer is the agent Container stopping implementation for sshd.
-func (s *sshd) stopContainer(pod Pod, container Container) error {
+func (s *sshd) stopContainer(pod Pod, c Container) error {
 	return nil
 }
 
 // killContainer is the agent Container signaling implementation for sshd.
-func (s *sshd) killContainer(pod Pod, container Container, signal syscall.Signal) error {
+func (s *sshd) killContainer(pod Pod, c Container, signal syscall.Signal) error {
 	return nil
 }

--- a/sshd.go
+++ b/sshd.go
@@ -130,23 +130,23 @@ func (s *sshd) startAgent() error {
 }
 
 // exec is the agent command execution implementation for sshd.
-func (s *sshd) exec(pod Pod, container Container, cmd Cmd) error {
+func (s *sshd) exec(pod Pod, container Container, cmd Cmd) (*Process, error) {
 	session, err := s.client.NewSession()
 	if err != nil {
-		return fmt.Errorf("Failed to create session")
+		return nil, fmt.Errorf("Failed to create session")
 	}
 	defer session.Close()
 
 	if s.spawner != nil {
 		cmd.Args, err = s.spawner.formatArgs(cmd.Args)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	strCmd := strings.Join(cmd.Args, " ")
 
-	return execCmd(session, strCmd)
+	return nil, execCmd(session, strCmd)
 }
 
 // startPod is the agent Pod starting implementation for sshd.


### PR DESCRIPTION
A lot of functions exposed by the interface were expecting a pod as
parameter but it could generate some conflicts with the pod pointer
internally stored by each agent implementation.
Moreover, because we are always expecting the agent init() function
to be called every time we need to recreate a pod handler, this means
we expect the agent to store this handler when passed through init().
That way, we don't have to give this parameter again for each function.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>