### PR TITLE
hypervisor: Add Debug option to HypervisorConfig.

### DIFF
--- a/hypervisor.go
+++ b/hypervisor.go
@@ -117,6 +117,10 @@ type HypervisorConfig struct {
 
 	// HypervisorParams are additional hypervisor parameters.
 	HypervisorParams []Param
+
+	// Debug changes the default hypervisor and kernel parameters to
+	// enable debug output where available.
+	Debug bool
 }
 
 func (conf *HypervisorConfig) valid() (bool, error) {

--- a/qemu.go
+++ b/qemu.go
@@ -103,15 +103,36 @@ var kernelDefaultParams = []Param{
 	{"init", "/usr/lib/systemd/systemd"},
 	{"systemd.unit", "container.target"},
 	{"iommu", "off"},
-	{"quiet", ""},
 	{"systemd.mask", "systemd-networkd.service"},
 	{"systemd.mask", "systemd-networkd.socket"},
-	{"systemd.show_status", "false"},
 	{"cryptomgr.notests", ""},
+}
+
+// kernelDefaultParamsNonDebug is a list of the default kernel
+// parameters that will be used in standard (non-debug) mode.
+var kernelDefaultParamsNonDebug = []Param{
+	{"quiet", ""},
+	{"systemd.show_status", "false"},
+}
+
+// kernelDefaultParamsDebug is a list of the default kernel
+// parameters that will be used in debug mode (as much boot output as
+// possible).
+var kernelDefaultParamsDebug = []Param{
+	{"debug", ""},
+	{"systemd.show_status", "true"},
+	{"systemd.log_level", "debug"},
 }
 
 func (q *qemu) buildKernelParams(config HypervisorConfig) error {
 	params := kernelDefaultParams
+
+	if config.Debug == true {
+		params = append(params, kernelDefaultParamsDebug...)
+	} else {
+		params = append(params, kernelDefaultParamsNonDebug...)
+	}
+
 	params = append(params, config.KernelParams...)
 
 	q.kernelParams = serializeParams(params, "=")

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -34,9 +34,13 @@ func newQemuConfig() HypervisorConfig {
 	}
 }
 
-func testQemuBuildKernelParams(t *testing.T, kernelParams []Param, expected string) {
+func testQemuBuildKernelParams(t *testing.T, kernelParams []Param, expected string, debug bool) {
 	qemuConfig := newQemuConfig()
 	qemuConfig.KernelParams = kernelParams
+
+	if debug == true {
+		qemuConfig.Debug = true
+	}
 
 	q := &qemu{}
 
@@ -50,12 +54,14 @@ func testQemuBuildKernelParams(t *testing.T, kernelParams []Param, expected stri
 	}
 }
 
-var testQemuKernelParams = "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug init=/usr/lib/systemd/systemd systemd.unit=container.target iommu=off quiet systemd.mask=systemd-networkd.service systemd.mask=systemd-networkd.socket systemd.show_status=false cryptomgr.notests"
+var testQemuKernelParamsBase = "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug init=/usr/lib/systemd/systemd systemd.unit=container.target iommu=off systemd.mask=systemd-networkd.service systemd.mask=systemd-networkd.socket cryptomgr.notests"
+var testQemuKernelParamsNonDebug = "quiet systemd.show_status=false"
+var testQemuKernelParamsDebug = "debug systemd.show_status=true systemd.log_level=debug"
 
 func TestQemuBuildKernelParamsFoo(t *testing.T) {
-	expectedOut := testQemuKernelParams + " foo=foo bar=bar"
-
-	params := []Param{
+	// two representations of the same kernel parameters
+	suffixStr := "foo=foo bar=bar"
+	suffixParams := []Param{
 		{
 			parameter: "foo",
 			value:     "foo",
@@ -66,7 +72,27 @@ func TestQemuBuildKernelParamsFoo(t *testing.T) {
 		},
 	}
 
-	testQemuBuildKernelParams(t, params, expectedOut)
+	type testData struct {
+		debugParams string
+		debugValue  bool
+	}
+
+	data := []testData{
+		{testQemuKernelParamsNonDebug, false},
+		{testQemuKernelParamsDebug, true},
+	}
+
+	for _, d := range data {
+		// kernel params consist of a default set of params,
+		// followed by a set of params that depend on whether
+		// debug mode is enabled and end with any user-supplied
+		// params.
+		expected := []string{testQemuKernelParamsBase, d.debugParams, suffixStr}
+
+		expectedOut := strings.Join(expected, " ")
+
+		testQemuBuildKernelParams(t, suffixParams, expectedOut, d.debugValue)
+	}
 }
 
 func testQemuAppend(t *testing.T, structure interface{}, expected []ciaoQemu.Device, devType deviceType) {
@@ -318,7 +344,10 @@ func TestQemuInit(t *testing.T) {
 		t.Fatal()
 	}
 
-	if strings.Join(q.kernelParams, " ") != testQemuKernelParams {
+	// non-debug is the default
+	var testQemuKernelParamsDefault = testQemuKernelParamsBase + " " + testQemuKernelParamsNonDebug
+
+	if strings.Join(q.kernelParams, " ") != testQemuKernelParamsDefault {
 		t.Fatal()
 	}
 }


### PR DESCRIPTION
Setting HypervisorConfig.Debug will change the default set of kernel
parameters to enable debug (boot) output. It could also be used to
enable hypervisor debug where available.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>