### PR TITLE
oci: Add a EnvVar slice conversion API

### DIFF
--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -218,3 +218,40 @@ func stateToOCIState(state vc.State) string {
 		return ""
 	}
 }
+
+// EnvVars converts an OCI process environment variables slice
+// into a virtcontainers EnvVar slice.
+func EnvVars(envs []string) ([]vc.EnvVar, error) {
+	var envVars []vc.EnvVar
+
+	envDelimiter := "="
+	expectedEnvLen := 2
+
+	for _, env := range envs {
+		envSlice := strings.SplitN(env, envDelimiter, expectedEnvLen)
+
+		if len(envSlice) < expectedEnvLen {
+			return []vc.EnvVar{}, fmt.Errorf("Wrong string format: %s, expecting only %v parameters separated with %q",
+				env, expectedEnvLen, envDelimiter)
+		}
+
+		if envSlice[0] == "" {
+			return []vc.EnvVar{}, fmt.Errorf("Environment variable cannot be empty")
+		}
+
+		envSlice[1] = strings.Trim(envSlice[1], "' ")
+
+		if envSlice[1] == "" {
+			return []vc.EnvVar{}, fmt.Errorf("Environment value cannot be empty")
+		}
+
+		envVar := vc.EnvVar{
+			Var:   envSlice[0],
+			Value: envSlice[1],
+		}
+
+		envVars = append(envVars, envVar)
+	}
+
+	return envVars, nil
+}

--- a/pkg/oci/utils_test.go
+++ b/pkg/oci/utils_test.go
@@ -293,6 +293,67 @@ func TestStateToOCIState(t *testing.T) {
 	}
 }
 
+func TestEnvVars(t *testing.T) {
+	envVars := []string{"foo=bar", "TERM=xterm", "HOME=/home/foo", "TERM=\"bar\"", "foo=\"\""}
+	expectecVcEnvVars := []vc.EnvVar{
+		{
+			Var:   "foo",
+			Value: "bar",
+		},
+		{
+			Var:   "TERM",
+			Value: "xterm",
+		},
+		{
+			Var:   "HOME",
+			Value: "/home/foo",
+		},
+		{
+			Var:   "TERM",
+			Value: "\"bar\"",
+		},
+		{
+			Var:   "foo",
+			Value: "\"\"",
+		},
+	}
+
+	vcEnvVars, err := EnvVars(envVars)
+	if err != nil {
+		t.Fatalf("Could not create environment variable slice %v", err)
+	}
+
+	if reflect.DeepEqual(vcEnvVars, expectecVcEnvVars) == false {
+		t.Fatalf("Got %v\n expecting %v", vcEnvVars, expectecVcEnvVars)
+	}
+}
+
+func TestMalformedEnvVars(t *testing.T) {
+	envVars := []string{"foo"}
+	r, err := EnvVars(envVars)
+	if err == nil {
+		t.Fatalf("EnvVars() succeeded unexpectedly: [%s] variable=%s value=%s", envVars[0], r[0].Var, r[0].Value)
+	}
+
+	envVars = []string{"TERM="}
+	r, err = EnvVars(envVars)
+	if err == nil {
+		t.Fatalf("EnvVars() succeeded unexpectedly: [%s] variable=%s value=%s", envVars[0], r[0].Var, r[0].Value)
+	}
+
+	envVars = []string{"=foo"}
+	r, err = EnvVars(envVars)
+	if err == nil {
+		t.Fatalf("EnvVars() succeeded unexpectedly: [%s] variable=%s value=%s", envVars[0], r[0].Var, r[0].Value)
+	}
+
+	envVars = []string{"=foo="}
+	r, err = EnvVars(envVars)
+	if err == nil {
+		t.Fatalf("EnvVars() succeeded unexpectedly: [%s] variable=%s value=%s", envVars[0], r[0].Var, r[0].Value)
+	}
+}
+
 func TestMain(m *testing.M) {
 	/* Create temp bundle directory if necessary */
 	err := os.MkdirAll(tempBundlePath, dirMode)


### PR DESCRIPTION
This converts an OCI Process.Env slice into a vc.EnvVar one.

This is needed by https://github.com/clearcontainers/runtime/pull/53

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>