### PR TITLE
container: Add public function to retrieve container process

### DIFF
--- a/container.go
+++ b/container.go
@@ -92,6 +92,11 @@ func (c *Container) ID() string {
 	return c.id
 }
 
+// Process returns the container process.
+func (c *Container) Process() Process {
+	return c.process
+}
+
 // GetToken returns the token related to this container's process.
 func (c *Container) GetToken() string {
 	return c.process.Token


### PR DESCRIPTION
Programs using virtcontainers library will sometimes need to get
the process related to a container in case they have retrieved this
container. Process being a private field in the container structure,
we have to create a new public function to return it.