### PR TITLE
Deal with URLs related to proxy

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -124,7 +124,7 @@ type agent interface {
 	stop(pod Pod) error
 
 	// exec will tell the agent to run a command in an already running container.
-	exec(pod Pod, c Container, cmd Cmd) (*Process, error)
+	exec(pod *Pod, c Container, cmd Cmd) (*Process, error)
 
 	// startPod will tell the agent to start all containers related to the Pod.
 	startPod(pod Pod) error
@@ -133,7 +133,7 @@ type agent interface {
 	stopPod(pod Pod) error
 
 	// createContainer will tell the agent to create a container related to a Pod.
-	createContainer(pod Pod, c *Container) error
+	createContainer(pod *Pod, c *Container) error
 
 	// startContainer will tell the agent to start a container related to a Pod.
 	startContainer(pod Pod, c Container) error

--- a/api_test.go
+++ b/api_test.go
@@ -516,7 +516,7 @@ func TestCreateContainerSuccessful(t *testing.T) {
 
 	contConfig := newTestContainerConfigNoop(contID)
 
-	c, err := CreateContainer(p.id, contConfig)
+	_, c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -550,7 +550,7 @@ func TestCreateContainerFailingNoPod(t *testing.T) {
 
 	contConfig := newTestContainerConfigNoop(contID)
 
-	c, err := CreateContainer(p.id, contConfig)
+	_, c, err := CreateContainer(p.id, contConfig)
 	if c != nil || err == nil {
 		t.Fatal(err)
 	}
@@ -573,7 +573,7 @@ func TestDeleteContainerSuccessful(t *testing.T) {
 
 	contConfig := newTestContainerConfigNoop(contID)
 
-	c, err := CreateContainer(p.id, contConfig)
+	_, c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -637,7 +637,7 @@ func TestStartContainerNoopAgentSuccessful(t *testing.T) {
 	}
 	contConfig := newTestContainerConfigNoop(contID)
 
-	c, err := CreateContainer(p.id, contConfig)
+	_, c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -703,7 +703,7 @@ func TestStartContainerFailingPodNotStarted(t *testing.T) {
 
 	contConfig := newTestContainerConfigNoop(contID)
 
-	c, err := CreateContainer(p.id, contConfig)
+	_, c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -731,7 +731,7 @@ func TestStopContainerNoopAgentSuccessful(t *testing.T) {
 
 	contConfig := newTestContainerConfigNoop(contID)
 
-	c, err := CreateContainer(p.id, contConfig)
+	_, c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -778,7 +778,7 @@ func TestStartStopContainerHyperstartAgentSuccessful(t *testing.T) {
 
 	contConfig := newTestContainerConfigNoop(contID)
 
-	c, err := CreateContainer(p.id, contConfig)
+	_, c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -888,7 +888,7 @@ func TestStopContainerFailingContNotStarted(t *testing.T) {
 
 	contConfig := newTestContainerConfigNoop(contID)
 
-	c, err := CreateContainer(p.id, contConfig)
+	_, c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -916,7 +916,7 @@ func TestEnterContainerNoopAgentSuccessful(t *testing.T) {
 
 	contConfig := newTestContainerConfigNoop(contID)
 
-	c, err := CreateContainer(p.id, contConfig)
+	_, c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -934,7 +934,7 @@ func TestEnterContainerNoopAgentSuccessful(t *testing.T) {
 
 	cmd := newBasicTestCmd()
 
-	c, _, err = EnterContainer(p.id, contID, cmd)
+	_, c, _, err = EnterContainer(p.id, contID, cmd)
 	if c == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -965,7 +965,7 @@ func TestEnterContainerHyperstartAgentSuccessful(t *testing.T) {
 
 	contConfig := newTestContainerConfigNoop(contID)
 
-	_, err = CreateContainer(p.id, contConfig)
+	_, _, err = CreateContainer(p.id, contConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -983,7 +983,7 @@ func TestEnterContainerHyperstartAgentSuccessful(t *testing.T) {
 
 	cmd := newBasicTestCmd()
 
-	_, _, err = EnterContainer(p.id, contID, cmd)
+	_, _, _, err = EnterContainer(p.id, contID, cmd)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1008,7 +1008,7 @@ func TestEnterContainerFailingNoPod(t *testing.T) {
 
 	cmd := newBasicTestCmd()
 
-	c, _, err := EnterContainer(testPodID, contID, cmd)
+	_, c, _, err := EnterContainer(testPodID, contID, cmd)
 	if c != nil || err == nil {
 		t.Fatal()
 	}
@@ -1031,7 +1031,7 @@ func TestEnterContainerFailingNoContainer(t *testing.T) {
 
 	cmd := newBasicTestCmd()
 
-	c, _, err := EnterContainer(p.id, contID, cmd)
+	_, c, _, err := EnterContainer(p.id, contID, cmd)
 	if c != nil || err == nil {
 		t.Fatal()
 	}
@@ -1048,7 +1048,7 @@ func TestEnterContainerFailingContNotStarted(t *testing.T) {
 
 	contConfig := newTestContainerConfigNoop(contID)
 
-	c, err := CreateContainer(p.id, contConfig)
+	_, c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -1061,7 +1061,7 @@ func TestEnterContainerFailingContNotStarted(t *testing.T) {
 
 	cmd := newBasicTestCmd()
 
-	c, _, err = EnterContainer(p.id, contID, cmd)
+	_, c, _, err = EnterContainer(p.id, contID, cmd)
 	if c != nil || err == nil {
 		t.Fatal()
 	}
@@ -1084,7 +1084,7 @@ func TestStatusContainerSuccessful(t *testing.T) {
 
 	contConfig := newTestContainerConfigNoop(contID)
 
-	c, err := CreateContainer(p.id, contConfig)
+	_, c, err := CreateContainer(p.id, contConfig)
 	if c == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -1236,7 +1236,7 @@ func createStartStopDeleteContainers(b *testing.B, podConfig PodConfig, contConf
 
 	// Create containers
 	for _, contConfig := range contConfigs {
-		_, err := CreateContainer(p.id, contConfig)
+		_, _, err := CreateContainer(p.id, contConfig)
 		if err != nil {
 			b.Logf("Could not create container %s: %s", contConfig.ID, err)
 		}

--- a/container.go
+++ b/container.go
@@ -251,7 +251,7 @@ func createContainer(pod *Pod, contConfig ContainerConfig) (*Container, error) {
 	// specific case.
 	pod.containers = append(pod.containers, c)
 
-	if err := c.pod.agent.createContainer(*pod, c); err != nil {
+	if err := c.pod.agent.createContainer(pod, c); err != nil {
 		return nil, err
 	}
 
@@ -378,7 +378,7 @@ func (c *Container) enter(cmd Cmd) (*Process, error) {
 		return nil, fmt.Errorf("Container not running, impossible to enter")
 	}
 
-	process, err := c.pod.agent.exec(*(c.pod), *c, cmd)
+	process, err := c.pod.agent.exec(c.pod, *c, cmd)
 	if err != nil {
 		return nil, err
 	}

--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -462,7 +462,7 @@ func createContainer(context *cli.Context) error {
 		Cmd:         cmd,
 	}
 
-	c, err := vc.CreateContainer(context.String("pod-id"), containerConfig)
+	_, c, err := vc.CreateContainer(context.String("pod-id"), containerConfig)
 	if err != nil {
 		return fmt.Errorf("Could not create container: %s", err)
 	}
@@ -519,7 +519,7 @@ func enterContainer(context *cli.Context) error {
 		WorkDir: "/",
 	}
 
-	c, _, err := vc.EnterContainer(context.String("pod-id"), context.String("id"), cmd)
+	_, c, _, err := vc.EnterContainer(context.String("pod-id"), context.String("id"), cmd)
 	if err != nil {
 		return fmt.Errorf("Could not enter container: %s", err)
 	}

--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -59,7 +59,7 @@ var podConfigFlags = []cli.Flag{
 	},
 
 	cli.StringFlag{
-		Name:  "proxy-sock",
+		Name:  "proxy-url",
 		Value: "",
 		Usage: "the agent's proxy socket path",
 	},
@@ -142,7 +142,7 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 	hyperCtlSockName := context.String("hyper-ctl-sock-name")
 	hyperTtySockName := context.String("hyper-tty-sock-name")
 	hyperPauseBinPath := context.String("pause-path")
-	proxyRuntimeSocket := context.String("proxy-sock")
+	proxyURL := context.String("proxy-url")
 	vmVCPUs := context.Uint("vm-vcpus")
 	vmMemory := context.Uint("vm-memory")
 	agentType, ok := context.Generic("agent").(*vc.AgentType)
@@ -215,7 +215,7 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 	switch *proxyType {
 	case vc.CCProxyType:
 		proxyConfig = vc.CCProxyConfig{
-			RuntimeSocketPath: proxyRuntimeSocket,
+			URL: proxyURL,
 		}
 
 	default:

--- a/noop_agent.go
+++ b/noop_agent.go
@@ -41,7 +41,7 @@ func (n *noopAgent) stop(pod Pod) error {
 }
 
 // exec is the Noop agent command execution implementation. It does nothing.
-func (n *noopAgent) exec(pod Pod, c Container, cmd Cmd) (*Process, error) {
+func (n *noopAgent) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
 	return nil, nil
 }
 
@@ -56,7 +56,7 @@ func (n *noopAgent) stopPod(pod Pod) error {
 }
 
 // createContainer is the Noop agent Container creation implementation. It does nothing.
-func (n *noopAgent) createContainer(pod Pod, c *Container) error {
+func (n *noopAgent) createContainer(pod *Pod, c *Container) error {
 	return nil
 }
 

--- a/noop_agent_test.go
+++ b/noop_agent_test.go
@@ -42,7 +42,7 @@ func TestNoopAgentStartAgent(t *testing.T) {
 
 func TestNoopAgentExec(t *testing.T) {
 	n := &noopAgent{}
-	pod := Pod{}
+	pod := &Pod{}
 	container := Container{}
 	cmd := Cmd{}
 
@@ -83,7 +83,7 @@ func TestNoopAgentStopAgent(t *testing.T) {
 
 func TestNoopAgentCreateContainer(t *testing.T) {
 	n := &noopAgent{}
-	pod := Pod{}
+	pod := &Pod{}
 	container := &Container{}
 
 	err := n.createContainer(pod, container)

--- a/noop_proxy.go
+++ b/noop_proxy.go
@@ -18,9 +18,11 @@ package virtcontainers
 
 type noopProxy struct{}
 
+var noopProxyURL = "noopProxyURL"
+
 // register is the proxy register implementation for testing purpose.
 // It does nothing.
-func (p *noopProxy) register(pod Pod) ([]ProxyInfo, error) {
+func (p *noopProxy) register(pod Pod) ([]ProxyInfo, string, error) {
 	var proxyInfos []ProxyInfo
 
 	for i := 0; i < len(pod.containers); i++ {
@@ -29,7 +31,7 @@ func (p *noopProxy) register(pod Pod) ([]ProxyInfo, error) {
 		proxyInfos = append(proxyInfos, proxyInfo)
 	}
 
-	return proxyInfos, nil
+	return proxyInfos, noopProxyURL, nil
 }
 
 // unregister is the proxy unregister implementation for testing purpose.
@@ -40,8 +42,8 @@ func (p *noopProxy) unregister(pod Pod) error {
 
 // connect is the proxy connect implementation for testing purpose.
 // It does nothing.
-func (p *noopProxy) connect(pod Pod, createToken bool) (ProxyInfo, error) {
-	return ProxyInfo{}, nil
+func (p *noopProxy) connect(pod Pod, createToken bool) (ProxyInfo, string, error) {
+	return ProxyInfo{}, noopProxyURL, nil
 }
 
 // disconnect is the proxy disconnect implementation for testing purpose.

--- a/pod.go
+++ b/pod.go
@@ -336,7 +336,7 @@ type Pod struct {
 	runPath    string
 	configPath string
 
-	controlSocket string
+	url string
 
 	state State
 
@@ -346,6 +346,11 @@ type Pod struct {
 // ID returns the pod identifier string.
 func (p *Pod) ID() string {
 	return p.id
+}
+
+// URL returns the pod URL for any runtime to connect to the proxy.
+func (p *Pod) URL() string {
+	return p.url
 }
 
 // GetContainers returns a container config list.

--- a/proxy.go
+++ b/proxy.go
@@ -92,7 +92,6 @@ func newProxyConfig(config PodConfig) interface{} {
 // Each ProxyInfo relates to a process running inside a container.
 type ProxyInfo struct {
 	Token string
-	URL   string
 
 	// Keep for legacy, will be removed when new proxy is ready.
 	StdioID  uint64
@@ -103,7 +102,7 @@ type ProxyInfo struct {
 type proxy interface {
 	// register connects and registers the proxy to the given VM.
 	// It also returns information related to containers workloads.
-	register(pod Pod) ([]ProxyInfo, error)
+	register(pod Pod) ([]ProxyInfo, string, error)
 
 	// unregister unregisters and disconnects the proxy from the given VM.
 	unregister(pod Pod) error
@@ -114,7 +113,7 @@ type proxy interface {
 	// createToken is intended to be true in case we don't want
 	// the proxy to create a new token, but instead only get a handle
 	// to be able to communicate with the agent inside the VM.
-	connect(pod Pod, createToken bool) (ProxyInfo, error)
+	connect(pod Pod, createToken bool) (ProxyInfo, string, error)
 
 	// disconnect disconnects from the proxy.
 	disconnect() error

--- a/sshd.go
+++ b/sshd.go
@@ -135,7 +135,7 @@ func (s *sshd) stop(pod Pod) error {
 }
 
 // exec is the agent command execution implementation for sshd.
-func (s *sshd) exec(pod Pod, c Container, cmd Cmd) (*Process, error) {
+func (s *sshd) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
 	session, err := s.client.NewSession()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create session")
@@ -165,7 +165,7 @@ func (s *sshd) stopPod(pod Pod) error {
 }
 
 // createContainer is the agent Container creation implementation for sshd.
-func (s *sshd) createContainer(pod Pod, c *Container) error {
+func (s *sshd) createContainer(pod *Pod, c *Container) error {
 	return nil
 }
 


### PR DESCRIPTION
Every time a runtime wants to start a shim, it needs a URL to know where to connect to the proxy. Through this PR, virtcontainers provide the way to get this URL from the Pod handler.
Also, at the time a runtime loads the proxy configuration, it will provide virtcontainers a URL that has to be parsed properly to know how to connect to the proxy. This PR also handles this.