### PR TITLE
pkg: oci: Return OCI spec structure from PodConfig()

### DIFF
--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -128,18 +128,18 @@ func networkConfig(ocispec spec.Spec) (vc.NetworkConfig, error) {
 
 // PodConfig converts an OCI compatible runtime configuration file
 // to a virtcontainers pod configuration structure.
-func PodConfig(runtime RuntimeConfig, bundlePath, cid, console string) (*vc.PodConfig, error) {
+func PodConfig(runtime RuntimeConfig, bundlePath, cid, console string) (*vc.PodConfig, *spec.Spec, error) {
 	configPath := filepath.Join(bundlePath, "config.json")
 	log.Debugf("converting %s", configPath)
 
 	configByte, err := ioutil.ReadFile(configPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var ocispec spec.Spec
 	if err = json.Unmarshal(configByte, &ocispec); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	rootfs := filepath.Join(bundlePath, ocispec.Root.Path)
@@ -162,7 +162,7 @@ func PodConfig(runtime RuntimeConfig, bundlePath, cid, console string) (*vc.PodC
 
 	networkConfig, err := networkConfig(ocispec)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	podConfig := vc.PodConfig{
@@ -189,7 +189,7 @@ func PodConfig(runtime RuntimeConfig, bundlePath, cid, console string) (*vc.PodC
 		Annotations: map[string]string{ociConfigPathKey: configPath},
 	}
 
-	return &podConfig, nil
+	return &podConfig, &ocispec, nil
 }
 
 // StatusToOCIState translates a virtcontainers pod status into an OCI state.

--- a/pkg/oci/utils_test.go
+++ b/pkg/oci/utils_test.go
@@ -102,7 +102,7 @@ func TestMinimalPodConfig(t *testing.T) {
 		Annotations: map[string]string{ociConfigPathKey: configPath},
 	}
 
-	podConfig, err := PodConfig(runtimeConfig, tempBundlePath, containerID, consolePath)
+	podConfig, _, err := PodConfig(runtimeConfig, tempBundlePath, containerID, consolePath)
 	if err != nil {
 		t.Fatalf("Could not create Pod configuration %v", err)
 	}


### PR DESCRIPTION
OCI spec structure can be needed by the runtime in order to reuse
some data not stored inside PodConfig, but without unmarshalling
the JSON config file again.