### PR TITLE
pod: Enable pod console traces

### DIFF
--- a/cc_proxy.go
+++ b/cc_proxy.go
@@ -105,7 +105,11 @@ func (p *ccProxy) register(pod Pod) ([]ProxyInfo, string, error) {
 		return []ProxyInfo{}, "", fmt.Errorf("Wrong agent config type, should be HyperConfig type")
 	}
 
-	_, err = p.client.Hello(pod.id, hyperConfig.SockCtlName, hyperConfig.SockTtyName, nil)
+	helloOptions := &api.HelloOptions{
+		Console: pod.config.Console,
+	}
+
+	_, err = p.client.Hello(pod.id, hyperConfig.SockCtlName, hyperConfig.SockTtyName, helloOptions)
 	if err != nil {
 		return []ProxyInfo{}, "", err
 	}

--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -243,6 +243,8 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 		ProxyConfig: proxyConfig,
 
 		Containers: []vc.ContainerConfig{},
+
+		Console: "/tmp/virtcontainers/console.sock",
 	}
 
 	return podConfig, nil

--- a/pod.go
+++ b/pod.go
@@ -273,6 +273,10 @@ type PodConfig struct {
 	// Annotations keys must be unique strings an must be name-spaced
 	// with e.g. reverse domain notation (org.clearlinux.key).
 	Annotations map[string]string
+
+	// Console is a console path provided by the caller to create
+	// a console connected to the VM.
+	Console string
 }
 
 // valid checks that the pod configuration is valid.


### PR DESCRIPTION
We had no way to get logs printed inside the VM by our hyperstart
agent because we were missing several parts to be connected properly.

This patch enables the proxy to retrieve hyperstart logs coming from
inside the VM through a new console socket created by the hypervisor.

First it adds a new Console field to the PodConfig so as to be able
to share this socket path with other components such as proxy or
agent implementations.

Then we have to change systemd.unit parameter from "container.target"
to "cc-agent.target" because we need hyperstart output to be
redirected to the right console.

At last, the hypervisor implementation has to create a console socket
from the console path provided by the PodConfig.