### PR TITLE
Check podID and containerID function arguments

### DIFF
--- a/api.go
+++ b/api.go
@@ -88,6 +88,10 @@ func CreatePod(podConfig PodConfig) (*Pod, error) {
 // DeletePod is the virtcontainers pod deletion entry point.
 // DeletePod will stop an already running container and then delete it.
 func DeletePod(podID string) (*Pod, error) {
+	if podID == "" {
+		return nil, ErrNeedPodID
+	}
+
 	lockFile, err := lockPod(podID)
 	if err != nil {
 		return nil, err
@@ -137,6 +141,10 @@ func DeletePod(podID string) (*Pod, error) {
 // pod and all its containers.
 // It returns the pod ID.
 func StartPod(podID string) (*Pod, error) {
+	if podID == "" {
+		return nil, ErrNeedPodID
+	}
+
 	lockFile, err := lockPod(podID)
 	if err != nil {
 		return nil, err
@@ -180,6 +188,10 @@ func StartPod(podID string) (*Pod, error) {
 // StopPod is the virtcontainers pod stopping entry point.
 // StopPod will talk to the given agent to stop an existing pod and destroy all containers within that pod.
 func StopPod(podID string) (*Pod, error) {
+	if podID == "" {
+		return nil, ErrNeedPod
+	}
+
 	lockFile, err := lockPod(podID)
 	if err != nil {
 		return nil, err
@@ -328,6 +340,10 @@ func ListPod() ([]PodStatus, error) {
 
 // StatusPod is the virtcontainers pod status entry point.
 func StatusPod(podID string) (PodStatus, error) {
+	if podID == "" {
+		return PodStatus{}, ErrNeedPodID
+	}
+
 	pod, err := fetchPod(podID)
 	if err != nil {
 		return PodStatus{}, err
@@ -359,6 +375,10 @@ func StatusPod(podID string) (PodStatus, error) {
 // CreateContainer is the virtcontainers container creation entry point.
 // CreateContainer creates a container on a given pod.
 func CreateContainer(podID string, containerConfig ContainerConfig) (*Pod, *Container, error) {
+	if podID == "" {
+		return nil, nil, ErrNeedPodID
+	}
+
 	lockFile, err := lockPod(podID)
 	if err != nil {
 		return nil, nil, err
@@ -401,6 +421,14 @@ func CreateContainer(podID string, containerConfig ContainerConfig) (*Pod, *Cont
 // DeleteContainer deletes a Container from a Pod. If the container is running,
 // it needs to be stopped first.
 func DeleteContainer(podID, containerID string) (*Container, error) {
+	if podID == "" {
+		return nil, ErrNeedPodID
+	}
+
+	if containerID == "" {
+		return nil, ErrNeedContainerID
+	}
+
 	lockFile, err := lockPod(podID)
 	if err != nil {
 		return nil, err
@@ -447,6 +475,14 @@ func DeleteContainer(podID, containerID string) (*Container, error) {
 // StartContainer is the virtcontainers container starting entry point.
 // StartContainer starts an already created container.
 func StartContainer(podID, containerID string) (*Container, error) {
+	if podID == "" {
+		return nil, ErrNeedPodID
+	}
+
+	if containerID == "" {
+		return nil, ErrNeedContainerID
+	}
+
 	lockFile, err := lockPod(podID)
 	if err != nil {
 		return nil, err
@@ -482,6 +518,14 @@ func StartContainer(podID, containerID string) (*Container, error) {
 // StopContainer is the virtcontainers container stopping entry point.
 // StopContainer stops an already running container.
 func StopContainer(podID, containerID string) (*Container, error) {
+	if podID == "" {
+		return nil, ErrNeedPodID
+	}
+
+	if containerID == "" {
+		return nil, ErrNeedContainerID
+	}
+
 	lockFile, err := lockPod(podID)
 	if err != nil {
 		return nil, err
@@ -517,6 +561,14 @@ func StopContainer(podID, containerID string) (*Container, error) {
 // EnterContainer is the virtcontainers container command execution entry point.
 // EnterContainer enters an already running container and runs a given command.
 func EnterContainer(podID, containerID string, cmd Cmd) (*Pod, *Container, *Process, error) {
+	if podID == "" {
+		return nil, nil, nil, ErrNeedPodID
+	}
+
+	if containerID == "" {
+		return nil, nil, nil, ErrNeedContainerID
+	}
+
 	lockFile, err := lockPod(podID)
 	if err != nil {
 		return nil, nil, nil, err
@@ -551,6 +603,14 @@ func EnterContainer(podID, containerID string, cmd Cmd) (*Pod, *Container, *Proc
 // StatusContainer is the virtcontainers container status entry point.
 // StatusContainer returns a detailed container status.
 func StatusContainer(podID, containerID string) (ContainerStatus, error) {
+	if podID == "" {
+		return ContainerStatus{}, ErrNeedPodID
+	}
+
+	if containerID == "" {
+		return ContainerStatus{}, ErrNeedContainerID
+	}
+
 	var contStatus ContainerStatus
 
 	pod, err := fetchPod(podID)
@@ -575,6 +635,14 @@ func StatusContainer(podID, containerID string) (ContainerStatus, error) {
 // KillContainer is the virtcontainers entry point to send a signal
 // to a container running inside a pod.
 func KillContainer(podID, containerID string, signal syscall.Signal) error {
+	if podID == "" {
+		return ErrNeedPodID
+	}
+
+	if containerID == "" {
+		return ErrNeedContainerID
+	}
+
 	lockFile, err := lockPod(podID)
 	if err != nil {
 		return err

--- a/api_test.go
+++ b/api_test.go
@@ -26,6 +26,7 @@ import (
 
 const (
 	testHyperstartPauseBinName = "pause"
+	containerID                = "1"
 )
 
 func newBasicTestCmd() Cmd {
@@ -48,7 +49,7 @@ func newBasicTestCmd() Cmd {
 func newTestPodConfigNoop() PodConfig {
 	// Define the container command and bundle.
 	container := ContainerConfig{
-		ID:     "1",
+		ID:     containerID,
 		RootFs: filepath.Join(testDir, testBundle),
 		Cmd:    newBasicTestCmd(),
 	}
@@ -61,6 +62,7 @@ func newTestPodConfigNoop() PodConfig {
 	}
 
 	podConfig := PodConfig{
+		ID:               testPodID,
 		HypervisorType:   MockHypervisor,
 		HypervisorConfig: hypervisorConfig,
 
@@ -75,7 +77,7 @@ func newTestPodConfigNoop() PodConfig {
 func newTestPodConfigHyperstartAgent() PodConfig {
 	// Define the container command and bundle.
 	container := ContainerConfig{
-		ID:     "1",
+		ID:     containerID,
 		RootFs: filepath.Join(testDir, testBundle),
 		Cmd:    newBasicTestCmd(),
 	}
@@ -96,6 +98,7 @@ func newTestPodConfigHyperstartAgent() PodConfig {
 	}
 
 	podConfig := PodConfig{
+		ID:               testPodID,
 		HypervisorType:   MockHypervisor,
 		HypervisorConfig: hypervisorConfig,
 
@@ -111,7 +114,7 @@ func newTestPodConfigHyperstartAgent() PodConfig {
 func newTestPodConfigHyperstartAgentCNINetwork() PodConfig {
 	// Define the container command and bundle.
 	container := ContainerConfig{
-		ID:     "1",
+		ID:     containerID,
 		RootFs: filepath.Join(testDir, testBundle),
 		Cmd:    newBasicTestCmd(),
 	}
@@ -136,6 +139,7 @@ func newTestPodConfigHyperstartAgentCNINetwork() PodConfig {
 	}
 
 	podConfig := PodConfig{
+		ID:               testPodID,
 		HypervisorType:   MockHypervisor,
 		HypervisorConfig: hypervisorConfig,
 
@@ -154,7 +158,7 @@ func newTestPodConfigHyperstartAgentCNINetwork() PodConfig {
 func newTestPodConfigHyperstartAgentCNMNetwork() PodConfig {
 	// Define the container command and bundle.
 	container := ContainerConfig{
-		ID:     "1",
+		ID:     containerID,
 		RootFs: filepath.Join(testDir, testBundle),
 		Cmd:    newBasicTestCmd(),
 	}
@@ -190,6 +194,7 @@ func newTestPodConfigHyperstartAgentCNMNetwork() PodConfig {
 	}
 
 	podConfig := PodConfig{
+		ID:    testPodID,
 		Hooks: hooks,
 
 		HypervisorType:   MockHypervisor,
@@ -208,6 +213,8 @@ func newTestPodConfigHyperstartAgentCNMNetwork() PodConfig {
 }
 
 func TestCreatePodNoopAgentSuccessful(t *testing.T) {
+	cleanUp()
+
 	config := newTestPodConfigNoop()
 
 	p, err := CreatePod(config)
@@ -223,6 +230,8 @@ func TestCreatePodNoopAgentSuccessful(t *testing.T) {
 }
 
 func TestCreatePodHyperstartAgentSuccessful(t *testing.T) {
+	cleanUp()
+
 	config := newTestPodConfigHyperstartAgent()
 
 	p, err := CreatePod(config)
@@ -238,6 +247,8 @@ func TestCreatePodHyperstartAgentSuccessful(t *testing.T) {
 }
 
 func TestCreatePodFailing(t *testing.T) {
+	cleanUp()
+
 	config := PodConfig{}
 
 	p, err := CreatePod(config)
@@ -247,6 +258,8 @@ func TestCreatePodFailing(t *testing.T) {
 }
 
 func TestDeletePodNoopAgentSuccessful(t *testing.T) {
+	cleanUp()
+
 	config := newTestPodConfigNoop()
 
 	p, err := CreatePod(config)
@@ -272,6 +285,8 @@ func TestDeletePodNoopAgentSuccessful(t *testing.T) {
 }
 
 func TestDeletePodHyperstartAgentSuccessful(t *testing.T) {
+	cleanUp()
+
 	config := newTestPodConfigHyperstartAgent()
 
 	p, err := CreatePod(config)
@@ -297,6 +312,8 @@ func TestDeletePodHyperstartAgentSuccessful(t *testing.T) {
 }
 
 func TestDeletePodFailing(t *testing.T) {
+	cleanUp()
+
 	podDir := filepath.Join(configStoragePath, testPodID)
 	os.Remove(podDir)
 
@@ -307,6 +324,8 @@ func TestDeletePodFailing(t *testing.T) {
 }
 
 func TestStartPodNoopAgentSuccessful(t *testing.T) {
+	cleanUp()
+
 	config := newTestPodConfigNoop()
 
 	p, _, err := createAndStartPod(config)
@@ -316,6 +335,8 @@ func TestStartPodNoopAgentSuccessful(t *testing.T) {
 }
 
 func TestStartPodHyperstartAgentSuccessful(t *testing.T) {
+	cleanUp()
+
 	if os.Geteuid() != 0 {
 		t.Skip(testDisabledAsNonRoot)
 	}
@@ -346,6 +367,8 @@ func TestStartPodHyperstartAgentSuccessful(t *testing.T) {
 }
 
 func TestStartPodFailing(t *testing.T) {
+	cleanUp()
+
 	podDir := filepath.Join(configStoragePath, testPodID)
 	os.Remove(podDir)
 
@@ -356,6 +379,8 @@ func TestStartPodFailing(t *testing.T) {
 }
 
 func TestStopPodNoopAgentSuccessful(t *testing.T) {
+	cleanUp()
+
 	config := newTestPodConfigNoop()
 
 	p, _, err := createAndStartPod(config)
@@ -373,6 +398,8 @@ func TestStopPodHyperstartAgentSuccessful(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip(testDisabledAsNonRoot)
 	}
+
+	cleanUp()
 
 	config := newTestPodConfigHyperstartAgent()
 
@@ -403,6 +430,8 @@ func TestStopPodHyperstartAgentSuccessful(t *testing.T) {
 }
 
 func TestStopPodFailing(t *testing.T) {
+	cleanUp()
+
 	podDir := filepath.Join(configStoragePath, testPodID)
 	os.Remove(podDir)
 
@@ -413,6 +442,8 @@ func TestStopPodFailing(t *testing.T) {
 }
 
 func TestRunPodNoopAgentSuccessful(t *testing.T) {
+	cleanUp()
+
 	config := newTestPodConfigNoop()
 
 	p, err := RunPod(config)
@@ -431,6 +462,8 @@ func TestRunPodHyperstartAgentSuccessful(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip(testDisabledAsNonRoot)
 	}
+
+	cleanUp()
 
 	config := newTestPodConfigHyperstartAgent()
 
@@ -464,6 +497,8 @@ func TestRunPodHyperstartAgentSuccessful(t *testing.T) {
 }
 
 func TestRunPodFailing(t *testing.T) {
+	cleanUp()
+
 	config := PodConfig{}
 
 	p, err := RunPod(config)
@@ -473,6 +508,8 @@ func TestRunPodFailing(t *testing.T) {
 }
 
 func TestListPodSuccessful(t *testing.T) {
+	cleanUp()
+
 	os.RemoveAll(configStoragePath)
 
 	config := newTestPodConfigNoop()
@@ -489,6 +526,8 @@ func TestListPodSuccessful(t *testing.T) {
 }
 
 func TestListPodFailing(t *testing.T) {
+	cleanUp()
+
 	os.RemoveAll(configStoragePath)
 
 	_, err := ListPod()
@@ -498,6 +537,8 @@ func TestListPodFailing(t *testing.T) {
 }
 
 func TestStatusPodSuccessful(t *testing.T) {
+	cleanUp()
+
 	config := newTestPodConfigNoop()
 
 	p, err := CreatePod(config)
@@ -512,6 +553,8 @@ func TestStatusPodSuccessful(t *testing.T) {
 }
 
 func TestListPodFailingFetchPodConfig(t *testing.T) {
+	cleanUp()
+
 	config := newTestPodConfigNoop()
 
 	p, err := CreatePod(config)
@@ -529,6 +572,8 @@ func TestListPodFailingFetchPodConfig(t *testing.T) {
 }
 
 func TestListPodFailingFetchPodState(t *testing.T) {
+	cleanUp()
+
 	config := newTestPodConfigNoop()
 
 	p, err := CreatePod(config)
@@ -556,6 +601,8 @@ func newTestContainerConfigNoop(contID string) ContainerConfig {
 }
 
 func TestCreateContainerSuccessful(t *testing.T) {
+	cleanUp()
+
 	contID := "100"
 	config := newTestPodConfigNoop()
 
@@ -585,6 +632,8 @@ func TestCreateContainerSuccessful(t *testing.T) {
 }
 
 func TestCreateContainerFailingNoPod(t *testing.T) {
+	cleanUp()
+
 	contID := "100"
 	config := newTestPodConfigNoop()
 
@@ -613,6 +662,8 @@ func TestCreateContainerFailingNoPod(t *testing.T) {
 }
 
 func TestDeleteContainerSuccessful(t *testing.T) {
+	cleanUp()
+
 	contID := "100"
 	config := newTestPodConfigNoop()
 
@@ -652,6 +703,8 @@ func TestDeleteContainerSuccessful(t *testing.T) {
 }
 
 func TestDeleteContainerFailingNoPod(t *testing.T) {
+	cleanUp()
+
 	podDir := filepath.Join(configStoragePath, testPodID)
 	contID := "100"
 	os.RemoveAll(podDir)
@@ -663,6 +716,8 @@ func TestDeleteContainerFailingNoPod(t *testing.T) {
 }
 
 func TestDeleteContainerFailingNoContainer(t *testing.T) {
+	cleanUp()
+
 	contID := "100"
 	config := newTestPodConfigNoop()
 
@@ -684,6 +739,8 @@ func TestDeleteContainerFailingNoContainer(t *testing.T) {
 }
 
 func TestStartContainerNoopAgentSuccessful(t *testing.T) {
+	cleanUp()
+
 	contID := "100"
 	config := newTestPodConfigNoop()
 
@@ -711,6 +768,8 @@ func TestStartContainerNoopAgentSuccessful(t *testing.T) {
 }
 
 func TestStartContainerFailingNoPod(t *testing.T) {
+	cleanUp()
+
 	podDir := filepath.Join(configStoragePath, testPodID)
 	contID := "100"
 	os.RemoveAll(podDir)
@@ -722,6 +781,8 @@ func TestStartContainerFailingNoPod(t *testing.T) {
 }
 
 func TestStartContainerFailingNoContainer(t *testing.T) {
+	cleanUp()
+
 	contID := "100"
 	config := newTestPodConfigNoop()
 
@@ -743,6 +804,8 @@ func TestStartContainerFailingNoContainer(t *testing.T) {
 }
 
 func TestStartContainerFailingPodNotStarted(t *testing.T) {
+	cleanUp()
+
 	contID := "100"
 	config := newTestPodConfigNoop()
 
@@ -777,6 +840,8 @@ func TestStartContainerFailingPodNotStarted(t *testing.T) {
 }
 
 func TestStopContainerNoopAgentSuccessful(t *testing.T) {
+	cleanUp()
+
 	contID := "100"
 	config := newTestPodConfigNoop()
 
@@ -813,6 +878,8 @@ func TestStartStopContainerHyperstartAgentSuccessful(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip(testDisabledAsNonRoot)
 	}
+
+	cleanUp()
 
 	contID := "100"
 	config := newTestPodConfigHyperstartAgent()
@@ -867,6 +934,8 @@ func TestStartStopPodHyperstartAgentSuccessfulWithCNINetwork(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip(testDisabledAsNonRoot)
 	}
+
+	cleanUp()
 
 	config := newTestPodConfigHyperstartAgentCNINetwork()
 
@@ -940,6 +1009,8 @@ func TestStartStopPodHyperstartAgentSuccessfulWithCNMNetwork(t *testing.T) {
 }
 
 func TestStopContainerFailingNoPod(t *testing.T) {
+	cleanUp()
+
 	podDir := filepath.Join(configStoragePath, testPodID)
 	contID := "100"
 	os.RemoveAll(podDir)
@@ -951,6 +1022,8 @@ func TestStopContainerFailingNoPod(t *testing.T) {
 }
 
 func TestStopContainerFailingNoContainer(t *testing.T) {
+	cleanUp()
+
 	contID := "100"
 	config := newTestPodConfigNoop()
 
@@ -972,6 +1045,8 @@ func TestStopContainerFailingNoContainer(t *testing.T) {
 }
 
 func TestStopContainerFailingContNotStarted(t *testing.T) {
+	cleanUp()
+
 	contID := "100"
 	config := newTestPodConfigNoop()
 
@@ -1000,6 +1075,8 @@ func TestStopContainerFailingContNotStarted(t *testing.T) {
 }
 
 func TestEnterContainerNoopAgentSuccessful(t *testing.T) {
+	cleanUp()
+
 	contID := "100"
 	config := newTestPodConfigNoop()
 
@@ -1038,6 +1115,8 @@ func TestEnterContainerHyperstartAgentSuccessful(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip(testDisabledAsNonRoot)
 	}
+
+	cleanUp()
 
 	contID := "100"
 	config := newTestPodConfigHyperstartAgent()
@@ -1096,6 +1175,8 @@ func TestEnterContainerHyperstartAgentSuccessful(t *testing.T) {
 }
 
 func TestEnterContainerFailingNoPod(t *testing.T) {
+	cleanUp()
+
 	podDir := filepath.Join(configStoragePath, testPodID)
 	contID := "100"
 	os.RemoveAll(podDir)
@@ -1109,6 +1190,8 @@ func TestEnterContainerFailingNoPod(t *testing.T) {
 }
 
 func TestEnterContainerFailingNoContainer(t *testing.T) {
+	cleanUp()
+
 	contID := "100"
 	config := newTestPodConfigNoop()
 
@@ -1132,6 +1215,8 @@ func TestEnterContainerFailingNoContainer(t *testing.T) {
 }
 
 func TestEnterContainerFailingContNotStarted(t *testing.T) {
+	cleanUp()
+
 	contID := "100"
 	config := newTestPodConfigNoop()
 
@@ -1162,6 +1247,8 @@ func TestEnterContainerFailingContNotStarted(t *testing.T) {
 }
 
 func TestStatusContainerSuccessful(t *testing.T) {
+	cleanUp()
+
 	contID := "100"
 	config := newTestPodConfigNoop()
 
@@ -1196,6 +1283,8 @@ func TestStatusContainerSuccessful(t *testing.T) {
 }
 
 func TestStatusContainerFailing(t *testing.T) {
+	cleanUp()
+
 	contID := "100"
 	config := newTestPodConfigNoop()
 
@@ -1228,6 +1317,7 @@ func createNewPodConfig(hType HypervisorType, aType AgentType, aConfig interface
 	}
 
 	return PodConfig{
+		ID:               testPodID,
 		HypervisorType:   hType,
 		HypervisorConfig: hypervisorConfig,
 

--- a/cnm.go
+++ b/cnm.go
@@ -162,6 +162,7 @@ func (n *cnm) init(config *NetworkConfig) error {
 	if config == nil {
 		return fmt.Errorf("config cannot be empty")
 	}
+
 	if config.NetNSPath == "" {
 		path, err := createNetNS()
 		if err != nil {
@@ -179,6 +180,7 @@ func (n *cnm) run(networkNSPath string, cb func() error) error {
 	if networkNSPath == "" {
 		return fmt.Errorf("networkNSPath cannot be empty")
 	}
+
 	return doNetNS(networkNSPath, func(_ ns.NetNS) error {
 		return cb()
 	})

--- a/cnm.go
+++ b/cnm.go
@@ -159,6 +159,9 @@ func (n *cnm) createEndpointsFromScan(networkNSPath string) ([]Endpoint, error) 
 
 // init initializes the network, setting a new network namespace for the CNM network.
 func (n *cnm) init(config *NetworkConfig) error {
+	if config == nil {
+		return fmt.Errorf("config cannot be empty")
+	}
 	if config.NetNSPath == "" {
 		path, err := createNetNS()
 		if err != nil {
@@ -173,6 +176,9 @@ func (n *cnm) init(config *NetworkConfig) error {
 
 // run runs a callback in the specified network namespace.
 func (n *cnm) run(networkNSPath string, cb func() error) error {
+	if networkNSPath == "" {
+		return fmt.Errorf("networkNSPath cannot be empty")
+	}
 	return doNetNS(networkNSPath, func(_ ns.NetNS) error {
 		return cb()
 	})

--- a/container.go
+++ b/container.go
@@ -56,6 +56,10 @@ type ContainerConfig struct {
 
 // valid checks that the container configuration is valid.
 func (containerConfig *ContainerConfig) valid() bool {
+	if containerConfig == nil {
+		return false
+	}
+
 	if containerConfig.ID == "" {
 		return false
 	}
@@ -121,6 +125,14 @@ func (c *Container) fetchProcess() (Process, error) {
 
 // fetchContainer fetches a container config from a pod ID and returns a Container.
 func fetchContainer(pod *Pod, containerID string) (*Container, error) {
+	if pod == nil {
+		return nil, ErrNeedPod
+	}
+
+	if containerID == "" {
+		return nil, ErrNeedContainerID
+	}
+
 	fs := filesystem{}
 	config, err := fs.fetchContainerConfig(pod.id, containerID)
 	if err != nil {
@@ -144,6 +156,10 @@ func (c *Container) storeContainer() error {
 }
 
 func (c *Container) setContainerState(state stateString) error {
+	if state == "" {
+		return ErrNeedState
+	}
+
 	c.state = State{
 		State: state,
 	}
@@ -172,6 +188,10 @@ func (c *Container) createContainersDirs() error {
 }
 
 func createContainers(pod *Pod, contConfigs []ContainerConfig) ([]*Container, error) {
+	if pod == nil {
+		return nil, ErrNeedPod
+	}
+
 	var containers []*Container
 
 	for _, contConfig := range contConfigs {
@@ -209,6 +229,10 @@ func createContainers(pod *Pod, contConfigs []ContainerConfig) ([]*Container, er
 }
 
 func createContainer(pod *Pod, contConfig ContainerConfig) (*Container, error) {
+	if pod == nil {
+		return nil, ErrNeedPod
+	}
+
 	if contConfig.valid() == false {
 		return nil, fmt.Errorf("Invalid container configuration")
 	}
@@ -283,6 +307,10 @@ func (c *Container) delete() error {
 // for and is only used to make the returned error as descriptive as
 // possible.
 func (c *Container) fetchState(cmd string) (State, error) {
+	if cmd == "" {
+		return State{}, fmt.Errorf("Cmd cannot be empty")
+	}
+
 	state, err := c.pod.storage.fetchPodState(c.pod.id)
 	if err != nil {
 		return State{}, err

--- a/container.go
+++ b/container.go
@@ -21,8 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
-
-	"github.com/01org/ciao/ssntp/uuid"
 )
 
 // Process gathers data related to a container process.
@@ -59,7 +57,7 @@ type ContainerConfig struct {
 // valid checks that the container configuration is valid.
 func (containerConfig *ContainerConfig) valid() bool {
 	if containerConfig.ID == "" {
-		containerConfig.ID = uuid.Generate().String()
+		return false
 	}
 
 	return true

--- a/errors.go
+++ b/errors.go
@@ -22,6 +22,9 @@ import (
 
 // common error objects used for argument checking
 var (
+	ErrNeedPod         = errors.New("Pod must be specified")
 	ErrNeedPodID       = errors.New("Pod ID cannot be empty")
 	ErrNeedContainerID = errors.New("Container ID cannot be empty")
+	ErrNeedFile        = errors.New("File cannot be empty")
+	ErrNeedState       = errors.New("State cannot be empty")
 )

--- a/filesystem.go
+++ b/filesystem.go
@@ -24,7 +24,10 @@ import (
 	"path/filepath"
 )
 
-// podResource is an int representing a pod resource type
+// podResource is an int representing a pod resource type.
+//
+// Note that some are specific to the pod itself and others can apply to
+// pods and containers.
 type podResource int
 
 const (
@@ -34,13 +37,13 @@ const (
 	// stateFileType represents a state file type
 	stateFileType
 
-	// networkFileType represents a network file type
+	// networkFileType represents a network file type (pod only)
 	networkFileType
 
 	// processFileType represents a process file type
 	processFileType
 
-	// lockFileType represents a lock file type
+	// lockFileType represents a lock file type (pod only)
 	lockFileType
 )
 

--- a/filesystem.go
+++ b/filesystem.go
@@ -145,8 +145,12 @@ func (fs *filesystem) createAllResources(pod Pod) (err error) {
 	return nil
 }
 
-func (fs *filesystem) storeFile(path string, data interface{}) error {
-	f, err := os.Create(path)
+func (fs *filesystem) storeFile(file string, data interface{}) error {
+	if file == "" {
+		return ErrNeedFile
+	}
+
+	f, err := os.Create(file)
 	if err != nil {
 		return err
 	}
@@ -161,8 +165,12 @@ func (fs *filesystem) storeFile(path string, data interface{}) error {
 	return nil
 }
 
-func (fs *filesystem) fetchFile(path string, data interface{}) error {
-	fileData, err := ioutil.ReadFile(path)
+func (fs *filesystem) fetchFile(file string, data interface{}) error {
+	if file == "" {
+		return ErrNeedFile
+	}
+
+	fileData, err := ioutil.ReadFile(file)
 	if err != nil {
 		return err
 	}
@@ -175,12 +183,32 @@ func (fs *filesystem) fetchFile(path string, data interface{}) error {
 	return nil
 }
 
-func resourceDir(podID, containerID string, resource podResource) (string, error) {
-	var path string
+// resourceNeedsContainerID determines if the specified
+// podResource needs a containerID. Since some podResources can
+// be used for both pods and containers, it is necessary to specify
+// whether the resource is being used in a pod-specific context using
+// the podSpecific parameter.
+func resourceNeedsContainerID(podSpecific bool, resource podResource) bool {
 
-	if podID == "" {
-		return "", fmt.Errorf("PodID cannot be empty")
+	switch resource {
+	case lockFileType, networkFileType:
+		// pod-specific resources
+		return false
+	default:
+		return !podSpecific
 	}
+}
+
+func resourceDir(podSpecific bool, podID, containerID string, resource podResource) (string, error) {
+	if podID == "" {
+		return "", ErrNeedPodID
+	}
+
+	if resourceNeedsContainerID(podSpecific, resource) == true && containerID == "" {
+		return "", ErrNeedContainerID
+	}
+
+	var path string
 
 	switch resource {
 	case configFileType:
@@ -198,14 +226,18 @@ func resourceDir(podID, containerID string, resource podResource) (string, error
 	return dirPath, nil
 }
 
-func (fs *filesystem) resourceURI(podID, containerID string, resource podResource) (string, string, error) {
-	var filename string
-
+// If podSpecific is true, the resource is being applied for an empty
+// pod (meaning containerID may be blank).
+// Note that this function defers determining if containerID can be
+// blank to resourceDIR()
+func (fs *filesystem) resourceURI(podSpecific bool, podID, containerID string, resource podResource) (string, string, error) {
 	if podID == "" {
-		return "", "", fmt.Errorf("Pod ID cannot be empty")
+		return "", "", ErrNeedPodID
 	}
 
-	dirPath, err := resourceDir(podID, containerID, resource)
+	var filename string
+
+	dirPath, err := resourceDir(podSpecific, podID, containerID, resource)
 	if err != nil {
 		return "", "", err
 	}
@@ -233,25 +265,47 @@ func (fs *filesystem) resourceURI(podID, containerID string, resource podResourc
 }
 
 func (fs *filesystem) containerURI(podID, containerID string, resource podResource) (string, string, error) {
-	if containerID == "" {
-		return "", "", fmt.Errorf("Container ID cannot be empty")
+	if podID == "" {
+		return "", "", ErrNeedPodID
 	}
 
-	return fs.resourceURI(podID, containerID, resource)
+	if containerID == "" {
+		return "", "", ErrNeedContainerID
+	}
+
+	return fs.resourceURI(false, podID, containerID, resource)
 }
 
 func (fs *filesystem) podURI(podID string, resource podResource) (string, string, error) {
-	return fs.resourceURI(podID, "", resource)
+	return fs.resourceURI(true, podID, "", resource)
 }
 
-func (fs *filesystem) storeResource(podID, containerID string, resource podResource, data interface{}) error {
+// commonResourceChecks performs basic checks common to both setting and
+// getting a podResource.
+func (fs *filesystem) commonResourceChecks(podSpecific bool, podID, containerID string, resource podResource) error {
+	if podID == "" {
+		return ErrNeedPodID
+	}
+
+	if resourceNeedsContainerID(podSpecific, resource) == true && containerID == "" {
+		return ErrNeedContainerID
+	}
+
+	return nil
+}
+
+func (fs *filesystem) storeResource(podSpecific bool, podID, containerID string, resource podResource, data interface{}) error {
+	if err := fs.commonResourceChecks(podSpecific, podID, containerID, resource); err != nil {
+		return err
+	}
+
 	switch file := data.(type) {
 	case PodConfig, ContainerConfig:
 		if resource != configFileType {
 			return fmt.Errorf("Invalid pod resource")
 		}
 
-		configFile, _, err := fs.resourceURI(podID, containerID, configFileType)
+		configFile, _, err := fs.resourceURI(podSpecific, podID, containerID, configFileType)
 		if err != nil {
 			return err
 		}
@@ -263,7 +317,7 @@ func (fs *filesystem) storeResource(podID, containerID string, resource podResou
 			return fmt.Errorf("Invalid pod resource")
 		}
 
-		stateFile, _, err := fs.resourceURI(podID, containerID, stateFileType)
+		stateFile, _, err := fs.resourceURI(podSpecific, podID, containerID, stateFileType)
 		if err != nil {
 			return err
 		}
@@ -275,7 +329,8 @@ func (fs *filesystem) storeResource(podID, containerID string, resource podResou
 			return fmt.Errorf("Invalid pod resource")
 		}
 
-		networkFile, _, err := fs.resourceURI(podID, containerID, networkFileType)
+		// pod only resource
+		networkFile, _, err := fs.resourceURI(true, podID, containerID, networkFileType)
 		if err != nil {
 			return err
 		}
@@ -287,7 +342,7 @@ func (fs *filesystem) storeResource(podID, containerID string, resource podResou
 			return fmt.Errorf("Invalid pod resource")
 		}
 
-		processFile, _, err := fs.resourceURI(podID, containerID, processFileType)
+		processFile, _, err := fs.resourceURI(podSpecific, podID, containerID, processFileType)
 		if err != nil {
 			return err
 		}
@@ -299,8 +354,12 @@ func (fs *filesystem) storeResource(podID, containerID string, resource podResou
 	}
 }
 
-func (fs *filesystem) fetchResource(podID, containerID string, resource podResource) (interface{}, error) {
-	path, _, err := fs.resourceURI(podID, containerID, resource)
+func (fs *filesystem) fetchResource(podSpecific bool, podID, containerID string, resource podResource) (interface{}, error) {
+	if err := fs.commonResourceChecks(podSpecific, podID, containerID, resource); err != nil {
+		return nil, err
+	}
+
+	path, _, err := fs.resourceURI(podSpecific, podID, containerID, resource)
 	if err != nil {
 		return nil, err
 	}
@@ -357,11 +416,11 @@ func (fs *filesystem) fetchResource(podID, containerID string, resource podResou
 }
 
 func (fs *filesystem) storePodResource(podID string, resource podResource, data interface{}) error {
-	return fs.storeResource(podID, "", resource, data)
+	return fs.storeResource(true, podID, "", resource, data)
 }
 
 func (fs *filesystem) fetchPodConfig(podID string) (PodConfig, error) {
-	data, err := fs.fetchResource(podID, "", configFileType)
+	data, err := fs.fetchResource(true, podID, "", configFileType)
 	if err != nil {
 		return PodConfig{}, err
 	}
@@ -375,7 +434,7 @@ func (fs *filesystem) fetchPodConfig(podID string) (PodConfig, error) {
 }
 
 func (fs *filesystem) fetchPodState(podID string) (State, error) {
-	data, err := fs.fetchResource(podID, "", stateFileType)
+	data, err := fs.fetchResource(true, podID, "", stateFileType)
 	if err != nil {
 		return State{}, err
 	}
@@ -389,7 +448,7 @@ func (fs *filesystem) fetchPodState(podID string) (State, error) {
 }
 
 func (fs *filesystem) fetchPodNetwork(podID string) (NetworkNamespace, error) {
-	data, err := fs.fetchResource(podID, "", networkFileType)
+	data, err := fs.fetchResource(true, podID, "", networkFileType)
 	if err != nil {
 		return NetworkNamespace{}, err
 	}
@@ -427,19 +486,27 @@ func (fs *filesystem) deletePodResources(podID string, resources []podResource) 
 }
 
 func (fs *filesystem) storeContainerResource(podID, containerID string, resource podResource, data interface{}) error {
-	if containerID == "" {
-		return fmt.Errorf("Container ID cannot be empty")
+	if podID == "" {
+		return ErrNeedPodID
 	}
 
-	return fs.storeResource(podID, containerID, resource, data)
+	if containerID == "" {
+		return ErrNeedContainerID
+	}
+
+	return fs.storeResource(false, podID, containerID, resource, data)
 }
 
 func (fs *filesystem) fetchContainerConfig(podID, containerID string) (ContainerConfig, error) {
-	if containerID == "" {
-		return ContainerConfig{}, fmt.Errorf("Container ID cannot be empty")
+	if podID == "" {
+		return ContainerConfig{}, ErrNeedPodID
 	}
 
-	data, err := fs.fetchResource(podID, containerID, configFileType)
+	if containerID == "" {
+		return ContainerConfig{}, ErrNeedContainerID
+	}
+
+	data, err := fs.fetchResource(false, podID, containerID, configFileType)
 	if err != nil {
 		return ContainerConfig{}, err
 	}
@@ -453,11 +520,15 @@ func (fs *filesystem) fetchContainerConfig(podID, containerID string) (Container
 }
 
 func (fs *filesystem) fetchContainerState(podID, containerID string) (State, error) {
-	if containerID == "" {
-		return State{}, fmt.Errorf("Container ID cannot be empty")
+	if podID == "" {
+		return State{}, ErrNeedPodID
 	}
 
-	data, err := fs.fetchResource(podID, containerID, stateFileType)
+	if containerID == "" {
+		return State{}, ErrNeedContainerID
+	}
+
+	data, err := fs.fetchResource(false, podID, containerID, stateFileType)
 	if err != nil {
 		return State{}, err
 	}
@@ -471,11 +542,15 @@ func (fs *filesystem) fetchContainerState(podID, containerID string) (State, err
 }
 
 func (fs *filesystem) fetchContainerProcess(podID, containerID string) (Process, error) {
-	if containerID == "" {
-		return Process{}, fmt.Errorf("Container ID cannot be empty")
+	if podID == "" {
+		return Process{}, ErrNeedPodID
 	}
 
-	data, err := fs.fetchResource(podID, containerID, processFileType)
+	if containerID == "" {
+		return Process{}, ErrNeedContainerID
+	}
+
+	data, err := fs.fetchResource(false, podID, containerID, processFileType)
 	if err != nil {
 		return Process{}, err
 	}

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -326,25 +326,31 @@ func TestFilesystemFetchContainerConfigFailingPodIDEmpty(t *testing.T) {
 }
 
 func TestFilesystemResourceDirFailingPodIDEmpty(t *testing.T) {
-	_, err := resourceDir("", "", configFileType)
-	if err == nil {
-		t.Fatal()
+	for _, b := range []bool{true, false} {
+		_, err := resourceDir(b, "", "", configFileType)
+		if err == nil {
+			t.Fatal()
+		}
 	}
 }
 
 func TestFilesystemResourceDirFailingInvalidResource(t *testing.T) {
-	_, err := resourceDir(testPodID, "100", podResource(-1))
-	if err == nil {
-		t.Fatal()
+	for _, b := range []bool{true, false} {
+		_, err := resourceDir(b, testPodID, "100", podResource(-1))
+		if err == nil {
+			t.Fatal()
+		}
 	}
 }
 
 func TestFilesystemResourceURIFailingResourceDir(t *testing.T) {
 	fs := &filesystem{}
 
-	_, _, err := fs.resourceURI(testPodID, "100", podResource(-1))
-	if err == nil {
-		t.Fatal()
+	for _, b := range []bool{true, false} {
+		_, _, err := fs.resourceURI(b, testPodID, "100", podResource(-1))
+		if err == nil {
+			t.Fatal()
+		}
 	}
 }
 
@@ -352,9 +358,11 @@ func TestFilesystemStoreResourceFailingPodConfigStateFileType(t *testing.T) {
 	fs := &filesystem{}
 	data := PodConfig{}
 
-	err := fs.storeResource(testPodID, "100", stateFileType, data)
-	if err == nil {
-		t.Fatal()
+	for _, b := range []bool{true, false} {
+		err := fs.storeResource(b, testPodID, "100", stateFileType, data)
+		if err == nil {
+			t.Fatal()
+		}
 	}
 }
 
@@ -362,9 +370,11 @@ func TestFilesystemStoreResourceFailingContainerConfigStateFileType(t *testing.T
 	fs := &filesystem{}
 	data := ContainerConfig{}
 
-	err := fs.storeResource(testPodID, "100", stateFileType, data)
-	if err == nil {
-		t.Fatal()
+	for _, b := range []bool{true, false} {
+		err := fs.storeResource(b, testPodID, "100", stateFileType, data)
+		if err == nil {
+			t.Fatal()
+		}
 	}
 }
 
@@ -372,9 +382,11 @@ func TestFilesystemStoreResourceFailingPodConfigResourceURI(t *testing.T) {
 	fs := &filesystem{}
 	data := PodConfig{}
 
-	err := fs.storeResource("", "100", configFileType, data)
-	if err == nil {
-		t.Fatal()
+	for _, b := range []bool{true, false} {
+		err := fs.storeResource(b, "", "100", configFileType, data)
+		if err == nil {
+			t.Fatal()
+		}
 	}
 }
 
@@ -382,9 +394,11 @@ func TestFilesystemStoreResourceFailingContainerConfigResourceURI(t *testing.T) 
 	fs := &filesystem{}
 	data := ContainerConfig{}
 
-	err := fs.storeResource("", "100", configFileType, data)
-	if err == nil {
-		t.Fatal()
+	for _, b := range []bool{true, false} {
+		err := fs.storeResource(b, "", "100", configFileType, data)
+		if err == nil {
+			t.Fatal()
+		}
 	}
 }
 
@@ -392,9 +406,11 @@ func TestFilesystemStoreResourceFailingStateConfigFileType(t *testing.T) {
 	fs := &filesystem{}
 	data := State{}
 
-	err := fs.storeResource(testPodID, "100", configFileType, data)
-	if err == nil {
-		t.Fatal()
+	for _, b := range []bool{true, false} {
+		err := fs.storeResource(b, testPodID, "100", configFileType, data)
+		if err == nil {
+			t.Fatal()
+		}
 	}
 }
 
@@ -402,9 +418,11 @@ func TestFilesystemStoreResourceFailingStateResourceURI(t *testing.T) {
 	fs := &filesystem{}
 	data := State{}
 
-	err := fs.storeResource("", "100", stateFileType, data)
-	if err == nil {
-		t.Fatal()
+	for _, b := range []bool{true, false} {
+		err := fs.storeResource(b, "", "100", stateFileType, data)
+		if err == nil {
+			t.Fatal()
+		}
 	}
 }
 
@@ -412,17 +430,21 @@ func TestFilesystemStoreResourceFailingWrongDataType(t *testing.T) {
 	fs := &filesystem{}
 	data := TestNoopStructure{}
 
-	err := fs.storeResource(testPodID, "100", configFileType, data)
-	if err == nil {
-		t.Fatal()
+	for _, b := range []bool{true, false} {
+		err := fs.storeResource(b, testPodID, "100", configFileType, data)
+		if err == nil {
+			t.Fatal()
+		}
 	}
 }
 
 func TestFilesystemFetchResourceFailingWrongResourceType(t *testing.T) {
 	fs := &filesystem{}
 
-	_, err := fs.fetchResource(testPodID, "100", lockFileType)
-	if err == nil {
-		t.Fatal()
+	for _, b := range []bool{true, false} {
+		_, err := fs.fetchResource(b, testPodID, "100", lockFileType)
+		if err == nil {
+			t.Fatal()
+		}
 	}
 }

--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -652,7 +652,7 @@ var createContainerCommand = cli.Command{
 		cli.StringFlag{
 			Name:  "id",
 			Value: "",
-			Usage: "the container identifier",
+			Usage: "the container identifier (default: auto-generated)",
 		},
 		cli.StringFlag{
 			Name:  "pod-id",

--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/01org/ciao/ssntp/uuid"
 	"github.com/Sirupsen/logrus"
 	"github.com/urfave/cli"
 
@@ -39,6 +40,12 @@ var podConfigFlags = []cli.Flag{
 		Name:  "agent",
 		Value: new(vc.AgentType),
 		Usage: "the guest agent",
+	},
+
+	cli.StringFlag{
+		Name:  "id",
+		Value: "",
+		Usage: "the pod identifier (default: auto-generated)",
 	},
 
 	cli.GenericFlag{
@@ -228,7 +235,14 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 		Memory: vmMemory,
 	}
 
+	id := context.String("id")
+	if id == "" {
+		// auto-generate pod name
+		id = uuid.Generate().String()
+	}
+
 	podConfig := vc.PodConfig{
+		ID:       id,
 		VMConfig: vmConfig,
 
 		HypervisorType:   vc.QemuHypervisor,
@@ -535,8 +549,14 @@ func createContainer(context *cli.Context) error {
 		interactive = true
 	}
 
+	id := context.String("id")
+	if id == "" {
+		// auto-generate container name
+		id = uuid.Generate().String()
+	}
+
 	containerConfig := vc.ContainerConfig{
-		ID:          context.String("id"),
+		ID:          id,
 		RootFs:      context.String("rootfs"),
 		Interactive: interactive,
 		Console:     console,

--- a/hook_test.go
+++ b/hook_test.go
@@ -70,6 +70,8 @@ func testRunHook(t *testing.T, timeout int) {
 }
 
 func TestRunHook(t *testing.T) {
+	cleanUp()
+
 	testRunHook(t, 0)
 }
 

--- a/pod.go
+++ b/pod.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 	"syscall"
 	"time"
-
-	"github.com/01org/ciao/ssntp/uuid"
 )
 
 // controlSocket is the pod control socket.
@@ -281,7 +279,7 @@ func (podConfig *PodConfig) valid() bool {
 	}
 
 	if podConfig.ID == "" {
-		podConfig.ID = uuid.Generate().String()
+		return false
 	}
 
 	return true

--- a/pod_test.go
+++ b/pod_test.go
@@ -94,11 +94,9 @@ func TestCreatePodEmtpyID(t *testing.T) {
 	hConfig := newHypervisorConfig(nil, nil)
 
 	p, err := testCreatePod(t, "", MockHypervisor, hConfig, NoopAgentType, NoopNetworkModel, NetworkConfig{}, nil, nil)
-	if err != nil {
-		t.Fatal(err)
+	if err == nil {
+		t.Fatalf("Expected pod with empty ID to fail, but got pod %v", p)
 	}
-
-	t.Logf("Got new ID %s", p.id)
 }
 
 func testPodStateTransition(t *testing.T, state stateString, newState stateString) error {

--- a/sshd.go
+++ b/sshd.go
@@ -51,6 +51,10 @@ func (c SshdConfig) validate() bool {
 }
 
 func publicKeyAuth(file string) (ssh.AuthMethod, error) {
+	if file == "" {
+		return nil, ErrNeedFile
+	}
+
 	privateBytes, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to load private key")
@@ -65,6 +69,10 @@ func publicKeyAuth(file string) (ssh.AuthMethod, error) {
 }
 
 func execCmd(session *ssh.Session, cmd string) error {
+	if session == nil {
+		return fmt.Errorf("session cannot be empty")
+	}
+
 	stdout, err := session.CombinedOutput(cmd)
 
 	if err != nil {
@@ -78,6 +86,14 @@ func execCmd(session *ssh.Session, cmd string) error {
 
 // init is the agent initialization implementation for sshd.
 func (s *sshd) init(pod *Pod, config interface{}) error {
+	if pod == nil {
+		return ErrNeedPod
+	}
+
+	if config == nil {
+		return fmt.Errorf("config cannot be empty")
+	}
+
 	c := config.(SshdConfig)
 	if c.validate() == false {
 		return fmt.Errorf("Invalid configuration")
@@ -91,6 +107,10 @@ func (s *sshd) init(pod *Pod, config interface{}) error {
 
 // start is the agent starting implementation for sshd.
 func (s *sshd) start(pod *Pod) error {
+	if pod == nil {
+		return ErrNeedPod
+	}
+
 	if s.client != nil {
 		session, err := s.client.NewSession()
 		if err == nil {
@@ -136,6 +156,10 @@ func (s *sshd) stop(pod Pod) error {
 
 // exec is the agent command execution implementation for sshd.
 func (s *sshd) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
+	if pod == nil {
+		return nil, ErrNeedPod
+	}
+
 	session, err := s.client.NewSession()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create session")

--- a/virtcontainers_test.go
+++ b/virtcontainers_test.go
@@ -47,6 +47,23 @@ var testQemuPath = ""
 var testHyperstartCtlSocket = ""
 var testHyperstartTtySocket = ""
 
+// cleanUp Removes any stale pod/container state that can affect
+// the next test to run.
+func cleanUp() {
+	for _, dir := range []string{testDir, defaultSharedDir} {
+		os.RemoveAll(dir)
+		os.MkdirAll(dir, dirMode)
+	}
+
+	os.Mkdir(filepath.Join(testDir, testBundle), dirMode)
+
+	_, err := os.Create(filepath.Join(testDir, testImage))
+	if err != nil {
+		fmt.Println("Could not recreate test image:", err)
+		os.Exit(1)
+	}
+}
+
 // TestMain is the common main function used by ALL the test functions
 // for this package.
 func TestMain(m *testing.M) {


### PR DESCRIPTION
This branch switches the logic around so that rather than passing blank `podID` and `containerID`'s around and then magically expanding them at quite a low level, the `podID` and `containerID` are set as soon as possible by `virtc`. This allows all functions to validate the parameters are not blank and return an error if they are [1].

The logic is complicated by the fact that in certain contexts -- for example when creating particular `podResource`'s -- `containerID` *may* be blank. To handle this, I've created a new function called `resourceNeedsContainerID()`.

Note that this is a proof-of-concept branch - the tests have not been updated so will fail.

------
[1] - This allows "fail-fast" behaviour which is less confusing when attempting to debug issues.