### PR TITLE
virtc: Check mandatory command-line arguments.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"errors"
+)
+
+// common error objects used for argument checking
+var (
+	ErrNeedPodID       = errors.New("Pod ID cannot be empty")
+	ErrNeedContainerID = errors.New("Container ID cannot be empty")
+)


### PR DESCRIPTION
Ensure that all mandatory arguments are checked early.

Note that urfave/cli doesn't actually provide such a feature. The
approach taken attempts to avoid duplicated code by checking centrally,
rather than peppering checks on podID and containerID in lots of
functions.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>