### PR TITLE
pkg: cni: Fix unit testing after CNI plugins update

### DIFF
--- a/pkg/cni/cni_test.go
+++ b/pkg/cni/cni_test.go
@@ -358,7 +358,7 @@ func TestRemoveNetworkSuccessful(t *testing.T) {
 	}
 }
 
-func TestRemoveNetworkFailureNetworkDoesNotExist(t *testing.T) {
+func TestRemoveNetworkSuccessfulNetworkDoesNotExist(t *testing.T) {
 	createLoNetworkNoName(t)
 	defer removeLoNetwork(t)
 	createDefNetworkNoName(t)
@@ -378,8 +378,10 @@ func TestRemoveNetworkFailureNetworkDoesNotExist(t *testing.T) {
 	}
 
 	err = netPlugin.RemoveNetwork("testPodID", testNetNsPath, "testIfName")
-	if err == nil {
-		t.Fatal("Should fail because network not previously added")
+	if err != nil {
+		// CNI specification says that no error should be returned
+		// in case we try to tear down a non-existing network.
+		t.Fatalf("Should pass because network not previously added: %s", err)
 	}
 }
 


### PR DESCRIPTION
In order to follow more closely the CNI specification, some recent changes have been added to the CNI plugins so that they are not failing anymore in case we try to tear down a non existing network.
This patch fixes the unit test which was expecting to see a failure. Now, we are expecting a success in removing a network that we've never created before.

This PR fixes issue #166 