### PR TITLE
epause: remove SIGKILL handler

### DIFF
--- a/pause/pause.c
+++ b/pause/pause.c
@@ -29,7 +29,6 @@ int main() {
 		return 1;
 	if (signal(SIGTERM, sigdown) == SIG_ERR)
 		return 2;
-	signal(SIGKILL, sigdown);
 	for (;;) pause();
 	fprintf(stderr, "error: infinite loop terminated\n");
 	return 42;


### PR DESCRIPTION
signal SIGKILL (as well as SIGSTOP) cannot be caught or ignored. And we
should remove this.

Signed-off-by: WANG Chao <chao.wang@ucloud.cn>