### PR TITLE
Duplicate hyperstart API

### DIFF
--- a/pkg/hyperstart/hyperstart_test.go
+++ b/pkg/hyperstart/hyperstart_test.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package hyperstart
+package hyperstart_test
 
 import (
 	"math"
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	hyper "github.com/containers/virtcontainers/pkg/hyperstart/api"
+	. "github.com/containers/virtcontainers/pkg/hyperstart"
 	"github.com/containers/virtcontainers/pkg/hyperstart/mock"
 )
 
@@ -34,22 +34,7 @@ const (
 )
 
 func connectHyperstartNoMulticast(h *Hyperstart) error {
-	var err error
-
-	h.ctl, err = net.Dial(h.sockType, h.ctlSerial)
-	if err != nil {
-		return err
-	}
-	h.ctlState.open()
-
-	h.io, err = net.Dial(h.sockType, h.ioSerial)
-	if err != nil {
-		h.ctl.Close()
-		return err
-	}
-	h.ioState.open()
-
-	return nil
+	return h.OpenSocketsNoMulticast()
 }
 
 func connectHyperstart(h *Hyperstart) error {
@@ -67,11 +52,7 @@ func connectMockHyperstart(t *testing.T, multiCast bool) (*mock.Hyperstart, *Hyp
 
 	ctlSock, ioSock := mockHyper.GetSocketPaths()
 
-	h := &Hyperstart{
-		ctlSerial: ctlSock,
-		ioSerial:  ioSock,
-		sockType:  testSockType,
-	}
+	h := NewHyperstart(ctlSock, ioSock, testSockType)
 
 	var err error
 	if multiCast {
@@ -92,16 +73,22 @@ func TestNewHyperstart(t *testing.T) {
 	ioSock := "/tmp/test_tty.sock"
 	sockType := "test_unix"
 
-	expectedOut := &Hyperstart{
-		ctlSerial: ctlSock,
-		ioSerial:  ioSock,
-		sockType:  sockType,
-	}
-
 	h := NewHyperstart(ctlSock, ioSock, sockType)
 
-	if reflect.DeepEqual(h, expectedOut) == false {
-		t.Fatal()
+	resultCtlSockPath := h.GetCtlSockPath()
+	resultIoSockPath := h.GetIoSockPath()
+	resultSockType := h.GetSockType()
+
+	if resultCtlSockPath != ctlSock {
+		t.Fatalf("CTL sock result %s should be the same than %s", resultCtlSockPath, ctlSock)
+	}
+
+	if resultIoSockPath != ioSock {
+		t.Fatalf("IO sock result %s should be the same than %s", resultIoSockPath, ioSock)
+	}
+
+	if resultSockType != sockType {
+		t.Fatalf("Sock type result %s should be the same than %s", resultSockType, sockType)
 	}
 }
 
@@ -113,11 +100,7 @@ func TestOpenSockets(t *testing.T) {
 
 	ctlSock, ioSock := mockHyper.GetSocketPaths()
 
-	h := &Hyperstart{
-		ctlSerial: ctlSock,
-		ioSerial:  ioSock,
-		sockType:  testSockType,
-	}
+	h := NewHyperstart(ctlSock, ioSock, testSockType)
 
 	err := h.OpenSockets()
 	if err != nil {
@@ -155,10 +138,10 @@ func TestSetDeadline(t *testing.T) {
 		t.Fatal()
 	}
 
-	mockHyper.SendMessage(hyper.Ready, []byte{})
+	mockHyper.SendMessage(ReadyCode, []byte{})
 
 	buf := make([]byte, 512)
-	_, err = h.ctl.Read(buf)
+	_, err = h.GetCtlSock().Read(buf)
 	if err != nil {
 		t.Fatal()
 	}
@@ -170,7 +153,7 @@ func TestSetDeadline(t *testing.T) {
 
 	time.Sleep(timeoutDuration)
 
-	_, err = h.ctl.Read(buf)
+	_, err = h.GetCtlSock().Read(buf)
 	netErr, ok := err.(net.Error)
 	if ok && netErr.Timeout() == false {
 		t.Fatal()
@@ -240,14 +223,14 @@ func TestReadCtlMessage(t *testing.T) {
 	defer mockHyper.Stop()
 	defer disconnectHyperstart(h)
 
-	expected := &hyper.DecodedMessage{
-		Code:    hyper.Ready,
+	expected := &DecodedMessage{
+		Code:    ReadyCode,
 		Message: []byte{},
 	}
 
 	mockHyper.SendMessage(int(expected.Code), expected.Message)
 
-	reply, err := ReadCtlMessage(h.ctl)
+	reply, err := ReadCtlMessage(h.GetCtlSock())
 	if err != nil {
 		t.Fatal()
 	}
@@ -265,27 +248,27 @@ func TestWriteCtlMessage(t *testing.T) {
 	defer mockHyper.Stop()
 	defer disconnectHyperstart(h)
 
-	msg := hyper.DecodedMessage{
-		Code:    hyper.Ping,
+	msg := DecodedMessage{
+		Code:    PingCode,
 		Message: []byte{},
 	}
 
-	err = h.WriteCtlMessage(h.ctl, &msg)
+	err = h.WriteCtlMessage(h.GetCtlSock(), &msg)
 	if err != nil {
 		t.Fatal()
 	}
 
 	for {
-		reply, err := ReadCtlMessage(h.ctl)
+		reply, err := ReadCtlMessage(h.GetCtlSock())
 		if err != nil {
 			t.Fatal()
 		}
 
-		if reply.Code == hyper.Next {
+		if reply.Code == NextCode {
 			continue
 		}
 
-		err = h.checkReturnedCode(reply.Code, hyper.Ack)
+		err = h.CheckReturnedCode(reply.Code, AckCode)
 		if err != nil {
 			t.Fatal()
 		}
@@ -333,7 +316,7 @@ func TestReadIoMessageWithConn(t *testing.T) {
 
 	mockHyper.SendIo(testSequence, []byte(testMessage))
 
-	msg, err := ReadIoMessageWithConn(h.io)
+	msg, err := ReadIoMessageWithConn(h.GetIoSock())
 	if err != nil {
 		t.Fatal()
 	}
@@ -351,7 +334,7 @@ func TestSendIoMessage(t *testing.T) {
 	defer mockHyper.Stop()
 	defer disconnectHyperstart(h)
 
-	msg := &hyper.TtyMessage{
+	msg := &TtyMessage{
 		Session: testSequence,
 		Message: []byte(testMessage),
 	}
@@ -364,7 +347,7 @@ func TestSendIoMessage(t *testing.T) {
 	buf := make([]byte, 512)
 	n, seqRecv := mockHyper.ReadIo(buf)
 
-	if seqRecv != testSequence || string(buf[ttyHdrSize:n]) != testMessage {
+	if seqRecv != testSequence || string(buf[TtyHdrSize:n]) != testMessage {
 		t.Fatal()
 	}
 }
@@ -377,12 +360,12 @@ func TestSendIoMessageWithConn(t *testing.T) {
 	defer mockHyper.Stop()
 	defer disconnectHyperstart(h)
 
-	msg := &hyper.TtyMessage{
+	msg := &TtyMessage{
 		Session: testSequence,
 		Message: []byte(testMessage),
 	}
 
-	err = SendIoMessageWithConn(h.io, msg)
+	err = SendIoMessageWithConn(h.GetIoSock(), msg)
 	if err != nil {
 		t.Fatal()
 	}
@@ -390,92 +373,96 @@ func TestSendIoMessageWithConn(t *testing.T) {
 	buf := make([]byte, 512)
 	n, seqRecv := mockHyper.ReadIo(buf)
 
-	if seqRecv != testSequence || string(buf[ttyHdrSize:n]) != testMessage {
+	if seqRecv != testSequence || string(buf[TtyHdrSize:n]) != testMessage {
 		t.Fatal()
 	}
 }
 
 func testCodeFromCmd(t *testing.T, cmd string, expected uint32) {
-	code, err := codeFromCmd(cmd)
+	h := &Hyperstart{}
+
+	code, err := h.CodeFromCmd(cmd)
 	if err != nil || code != expected {
 		t.Fatal()
 	}
 }
 
 func TestCodeFromCmdVersion(t *testing.T) {
-	testCodeFromCmd(t, Version, hyper.Version)
+	testCodeFromCmd(t, Version, VersionCode)
 }
 
 func TestCodeFromCmdStartPod(t *testing.T) {
-	testCodeFromCmd(t, StartPod, hyper.StartPod)
+	testCodeFromCmd(t, StartPod, StartPodCode)
 }
 
 func TestCodeFromCmdDestroyPod(t *testing.T) {
-	testCodeFromCmd(t, DestroyPod, hyper.DestroyPod)
+	testCodeFromCmd(t, DestroyPod, DestroyPodCode)
 }
 
 func TestCodeFromCmdExecCmd(t *testing.T) {
-	testCodeFromCmd(t, ExecCmd, hyper.ExecCmd)
+	testCodeFromCmd(t, ExecCmd, ExecCmdCode)
 }
 
 func TestCodeFromCmdReady(t *testing.T) {
-	testCodeFromCmd(t, Ready, hyper.Ready)
+	testCodeFromCmd(t, Ready, ReadyCode)
 }
 
 func TestCodeFromCmdAck(t *testing.T) {
-	testCodeFromCmd(t, Ack, hyper.Ack)
+	testCodeFromCmd(t, Ack, AckCode)
 }
 
 func TestCodeFromCmdError(t *testing.T) {
-	testCodeFromCmd(t, Error, hyper.Error)
+	testCodeFromCmd(t, Error, ErrorCode)
 }
 
 func TestCodeFromCmdWinSize(t *testing.T) {
-	testCodeFromCmd(t, WinSize, hyper.Winsize)
+	testCodeFromCmd(t, WinSize, WinsizeCode)
 }
 
 func TestCodeFromCmdPing(t *testing.T) {
-	testCodeFromCmd(t, Ping, hyper.Ping)
+	testCodeFromCmd(t, Ping, PingCode)
 }
 
 func TestCodeFromCmdNext(t *testing.T) {
-	testCodeFromCmd(t, Next, hyper.Next)
+	testCodeFromCmd(t, Next, NextCode)
 }
 
 func TestCodeFromCmdWriteFile(t *testing.T) {
-	testCodeFromCmd(t, WriteFile, hyper.WriteFile)
+	testCodeFromCmd(t, WriteFile, WriteFileCode)
 }
 
 func TestCodeFromCmdReadFile(t *testing.T) {
-	testCodeFromCmd(t, ReadFile, hyper.ReadFile)
+	testCodeFromCmd(t, ReadFile, ReadFileCode)
 }
 
 func TestCodeFromCmdNewContainer(t *testing.T) {
-	testCodeFromCmd(t, NewContainer, hyper.NewContainer)
+	testCodeFromCmd(t, NewContainer, NewContainerCode)
 }
 
 func TestCodeFromCmdKillContainer(t *testing.T) {
-	testCodeFromCmd(t, KillContainer, hyper.KillContainer)
+	testCodeFromCmd(t, KillContainer, KillContainerCode)
 }
 
 func TestCodeFromCmdOnlineCPUMem(t *testing.T) {
-	testCodeFromCmd(t, OnlineCPUMem, hyper.OnlineCPUMem)
+	testCodeFromCmd(t, OnlineCPUMem, OnlineCPUMemCode)
 }
 
 func TestCodeFromCmdSetupInterface(t *testing.T) {
-	testCodeFromCmd(t, SetupInterface, hyper.SetupInterface)
+	testCodeFromCmd(t, SetupInterface, SetupInterfaceCode)
 }
 
 func TestCodeFromCmdSetupRoute(t *testing.T) {
-	testCodeFromCmd(t, SetupRoute, hyper.SetupRoute)
+	testCodeFromCmd(t, SetupRoute, SetupRouteCode)
 }
 
 func TestCodeFromCmdRemoveContainer(t *testing.T) {
-	testCodeFromCmd(t, RemoveContainer, hyper.RemoveContainer)
+	testCodeFromCmd(t, RemoveContainer, RemoveContainerCode)
 }
 
 func TestCodeFromCmdUnknown(t *testing.T) {
-	code, err := codeFromCmd("unknown")
+	h := &Hyperstart{}
+
+	code, err := h.CodeFromCmd("unknown")
 	if err == nil || code != math.MaxUint32 {
 		t.Fatal()
 	}
@@ -484,14 +471,14 @@ func TestCodeFromCmdUnknown(t *testing.T) {
 func testCheckReturnedCode(t *testing.T, code, refCode uint32) {
 	h := &Hyperstart{}
 
-	err := h.checkReturnedCode(code, refCode)
+	err := h.CheckReturnedCode(code, refCode)
 	if err != nil {
 		t.Fatal()
 	}
 }
 
 func TestCheckReturnedCodeList(t *testing.T) {
-	for _, code := range codeList {
+	for _, code := range CodeList {
 		testCheckReturnedCode(t, code, code)
 	}
 }
@@ -499,18 +486,18 @@ func TestCheckReturnedCodeList(t *testing.T) {
 func testCheckReturnedCodeFailure(t *testing.T, code, refCode uint32) {
 	h := &Hyperstart{}
 
-	err := h.checkReturnedCode(code, refCode)
+	err := h.CheckReturnedCode(code, refCode)
 	if err == nil {
 		t.Fatal()
 	}
 }
 
 func TestCheckReturnedCodeListWrong(t *testing.T) {
-	for _, code := range codeList {
-		if code != hyper.Ready {
-			testCheckReturnedCodeFailure(t, code, hyper.Ready)
+	for _, code := range CodeList {
+		if code != ReadyCode {
+			testCheckReturnedCodeFailure(t, code, ReadyCode)
 		} else {
-			testCheckReturnedCodeFailure(t, code, hyper.Ping)
+			testCheckReturnedCodeFailure(t, code, PingCode)
 		}
 	}
 }
@@ -523,7 +510,7 @@ func TestWaitForReady(t *testing.T) {
 	defer mockHyper.Stop()
 	defer disconnectHyperstart(h)
 
-	mockHyper.SendMessage(int(hyper.Ready), []byte{})
+	mockHyper.SendMessage(int(ReadyCode), []byte{})
 
 	err = h.WaitForReady()
 	if err != nil {
@@ -539,7 +526,7 @@ func TestWaitForReadyError(t *testing.T) {
 	defer mockHyper.Stop()
 	defer disconnectHyperstart(h)
 
-	mockHyper.SendMessage(int(hyper.Error), []byte{})
+	mockHyper.SendMessage(int(ErrorCode), []byte{})
 
 	err = h.WaitForReady()
 	if err == nil {
@@ -563,6 +550,7 @@ var cmdList = []string{
 	OnlineCPUMem,
 	SetupInterface,
 	SetupRoute,
+	RemoveContainer,
 }
 
 func testSendCtlMessage(t *testing.T, cmd string) {
@@ -578,7 +566,7 @@ func testSendCtlMessage(t *testing.T, cmd string) {
 		t.Fatal()
 	}
 
-	if msg.Code != hyper.Ack {
+	if msg.Code != AckCode {
 		t.Fatal()
 	}
 }

--- a/pkg/hyperstart/hyperstart_test.go
+++ b/pkg/hyperstart/hyperstart_test.go
@@ -23,8 +23,8 @@ import (
 	"testing"
 	"time"
 
+	hyper "github.com/containers/virtcontainers/pkg/hyperstart/api"
 	"github.com/containers/virtcontainers/pkg/hyperstart/mock"
-	hyper "github.com/hyperhq/runv/hyperstart/api/json"
 )
 
 const (
@@ -155,7 +155,7 @@ func TestSetDeadline(t *testing.T) {
 		t.Fatal()
 	}
 
-	mockHyper.SendMessage(hyper.INIT_READY, []byte{})
+	mockHyper.SendMessage(hyper.Ready, []byte{})
 
 	buf := make([]byte, 512)
 	_, err = h.ctl.Read(buf)
@@ -241,7 +241,7 @@ func TestReadCtlMessage(t *testing.T) {
 	defer disconnectHyperstart(h)
 
 	expected := &hyper.DecodedMessage{
-		Code:    hyper.INIT_READY,
+		Code:    hyper.Ready,
 		Message: []byte{},
 	}
 
@@ -266,7 +266,7 @@ func TestWriteCtlMessage(t *testing.T) {
 	defer disconnectHyperstart(h)
 
 	msg := hyper.DecodedMessage{
-		Code:    hyper.INIT_PING,
+		Code:    hyper.Ping,
 		Message: []byte{},
 	}
 
@@ -281,11 +281,11 @@ func TestWriteCtlMessage(t *testing.T) {
 			t.Fatal()
 		}
 
-		if reply.Code == hyper.INIT_NEXT {
+		if reply.Code == hyper.Next {
 			continue
 		}
 
-		err = h.checkReturnedCode(reply.Code, hyper.INIT_ACK)
+		err = h.checkReturnedCode(reply.Code, hyper.Ack)
 		if err != nil {
 			t.Fatal()
 		}
@@ -403,71 +403,75 @@ func testCodeFromCmd(t *testing.T, cmd string, expected uint32) {
 }
 
 func TestCodeFromCmdVersion(t *testing.T) {
-	testCodeFromCmd(t, Version, hyper.INIT_VERSION)
+	testCodeFromCmd(t, Version, hyper.Version)
 }
 
 func TestCodeFromCmdStartPod(t *testing.T) {
-	testCodeFromCmd(t, StartPod, hyper.INIT_STARTPOD)
+	testCodeFromCmd(t, StartPod, hyper.StartPod)
 }
 
 func TestCodeFromCmdDestroyPod(t *testing.T) {
-	testCodeFromCmd(t, DestroyPod, hyper.INIT_DESTROYPOD)
+	testCodeFromCmd(t, DestroyPod, hyper.DestroyPod)
 }
 
 func TestCodeFromCmdExecCmd(t *testing.T) {
-	testCodeFromCmd(t, ExecCmd, hyper.INIT_EXECCMD)
+	testCodeFromCmd(t, ExecCmd, hyper.ExecCmd)
 }
 
 func TestCodeFromCmdReady(t *testing.T) {
-	testCodeFromCmd(t, Ready, hyper.INIT_READY)
+	testCodeFromCmd(t, Ready, hyper.Ready)
 }
 
 func TestCodeFromCmdAck(t *testing.T) {
-	testCodeFromCmd(t, Ack, hyper.INIT_ACK)
+	testCodeFromCmd(t, Ack, hyper.Ack)
 }
 
 func TestCodeFromCmdError(t *testing.T) {
-	testCodeFromCmd(t, Error, hyper.INIT_ERROR)
+	testCodeFromCmd(t, Error, hyper.Error)
 }
 
 func TestCodeFromCmdWinSize(t *testing.T) {
-	testCodeFromCmd(t, WinSize, hyper.INIT_WINSIZE)
+	testCodeFromCmd(t, WinSize, hyper.Winsize)
 }
 
 func TestCodeFromCmdPing(t *testing.T) {
-	testCodeFromCmd(t, Ping, hyper.INIT_PING)
+	testCodeFromCmd(t, Ping, hyper.Ping)
 }
 
 func TestCodeFromCmdNext(t *testing.T) {
-	testCodeFromCmd(t, Next, hyper.INIT_NEXT)
+	testCodeFromCmd(t, Next, hyper.Next)
 }
 
 func TestCodeFromCmdWriteFile(t *testing.T) {
-	testCodeFromCmd(t, WriteFile, hyper.INIT_WRITEFILE)
+	testCodeFromCmd(t, WriteFile, hyper.WriteFile)
 }
 
 func TestCodeFromCmdReadFile(t *testing.T) {
-	testCodeFromCmd(t, ReadFile, hyper.INIT_READFILE)
+	testCodeFromCmd(t, ReadFile, hyper.ReadFile)
 }
 
 func TestCodeFromCmdNewContainer(t *testing.T) {
-	testCodeFromCmd(t, NewContainer, hyper.INIT_NEWCONTAINER)
+	testCodeFromCmd(t, NewContainer, hyper.NewContainer)
 }
 
 func TestCodeFromCmdKillContainer(t *testing.T) {
-	testCodeFromCmd(t, KillContainer, hyper.INIT_KILLCONTAINER)
+	testCodeFromCmd(t, KillContainer, hyper.KillContainer)
 }
 
 func TestCodeFromCmdOnlineCPUMem(t *testing.T) {
-	testCodeFromCmd(t, OnlineCPUMem, hyper.INIT_ONLINECPUMEM)
+	testCodeFromCmd(t, OnlineCPUMem, hyper.OnlineCPUMem)
 }
 
 func TestCodeFromCmdSetupInterface(t *testing.T) {
-	testCodeFromCmd(t, SetupInterface, hyper.INIT_SETUPINTERFACE)
+	testCodeFromCmd(t, SetupInterface, hyper.SetupInterface)
 }
 
 func TestCodeFromCmdSetupRoute(t *testing.T) {
-	testCodeFromCmd(t, SetupRoute, hyper.INIT_SETUPROUTE)
+	testCodeFromCmd(t, SetupRoute, hyper.SetupRoute)
+}
+
+func TestCodeFromCmdRemoveContainer(t *testing.T) {
+	testCodeFromCmd(t, RemoveContainer, hyper.RemoveContainer)
 }
 
 func TestCodeFromCmdUnknown(t *testing.T) {
@@ -503,10 +507,10 @@ func testCheckReturnedCodeFailure(t *testing.T, code, refCode uint32) {
 
 func TestCheckReturnedCodeListWrong(t *testing.T) {
 	for _, code := range codeList {
-		if code != hyper.INIT_READY {
-			testCheckReturnedCodeFailure(t, code, hyper.INIT_READY)
+		if code != hyper.Ready {
+			testCheckReturnedCodeFailure(t, code, hyper.Ready)
 		} else {
-			testCheckReturnedCodeFailure(t, code, hyper.INIT_PING)
+			testCheckReturnedCodeFailure(t, code, hyper.Ping)
 		}
 	}
 }
@@ -519,7 +523,7 @@ func TestWaitForReady(t *testing.T) {
 	defer mockHyper.Stop()
 	defer disconnectHyperstart(h)
 
-	mockHyper.SendMessage(int(hyper.INIT_READY), []byte{})
+	mockHyper.SendMessage(int(hyper.Ready), []byte{})
 
 	err = h.WaitForReady()
 	if err != nil {
@@ -535,7 +539,7 @@ func TestWaitForReadyError(t *testing.T) {
 	defer mockHyper.Stop()
 	defer disconnectHyperstart(h)
 
-	mockHyper.SendMessage(int(hyper.INIT_ERROR), []byte{})
+	mockHyper.SendMessage(int(hyper.Error), []byte{})
 
 	err = h.WaitForReady()
 	if err == nil {
@@ -574,7 +578,7 @@ func testSendCtlMessage(t *testing.T, cmd string) {
 		t.Fatal()
 	}
 
-	if msg.Code != hyper.INIT_ACK {
+	if msg.Code != hyper.Ack {
 		t.Fatal()
 	}
 }

--- a/pkg/hyperstart/mock/hyperstart.go
+++ b/pkg/hyperstart/mock/hyperstart.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"testing"
 
-	hyper "github.com/hyperhq/runv/hyperstart/api/json"
+	hyper "github.com/containers/virtcontainers/pkg/hyperstart"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -52,24 +52,24 @@ const (
 )
 
 var codeList = map[int]string{
-	hyper.INIT_VERSION:         Version,
-	hyper.INIT_STARTPOD:        StartPod,
-	hyper.INIT_DESTROYPOD:      DestroyPod,
-	hyper.INIT_EXECCMD:         ExecCmd,
-	hyper.INIT_READY:           Ready,
-	hyper.INIT_ACK:             Ack,
-	hyper.INIT_ERROR:           Error,
-	hyper.INIT_WINSIZE:         WinSize,
-	hyper.INIT_PING:            Ping,
-	hyper.INIT_NEXT:            Next,
-	hyper.INIT_WRITEFILE:       WriteFile,
-	hyper.INIT_READFILE:        ReadFile,
-	hyper.INIT_NEWCONTAINER:    NewContainer,
-	hyper.INIT_KILLCONTAINER:   KillContainer,
-	hyper.INIT_REMOVECONTAINER: RemoveContainer,
-	hyper.INIT_ONLINECPUMEM:    OnlineCPUMem,
-	hyper.INIT_SETUPINTERFACE:  SetupInterface,
-	hyper.INIT_SETUPROUTE:      SetupRoute,
+	hyper.VersionCode:         Version,
+	hyper.StartPodCode:        StartPod,
+	hyper.DestroyPodCode:      DestroyPod,
+	hyper.ExecCmdCode:         ExecCmd,
+	hyper.ReadyCode:           Ready,
+	hyper.AckCode:             Ack,
+	hyper.ErrorCode:           Error,
+	hyper.WinsizeCode:         WinSize,
+	hyper.PingCode:            Ping,
+	hyper.NextCode:            Next,
+	hyper.WriteFileCode:       WriteFile,
+	hyper.ReadFileCode:        ReadFile,
+	hyper.NewContainerCode:    NewContainer,
+	hyper.KillContainerCode:   KillContainer,
+	hyper.OnlineCPUMemCode:    OnlineCPUMem,
+	hyper.SetupInterfaceCode:  SetupInterface,
+	hyper.SetupRouteCode:      SetupRoute,
+	hyper.RemoveContainerCode: RemoveContainer,
 }
 
 // Hyperstart is an object mocking the hyperstart agent.
@@ -194,7 +194,7 @@ func (h *Hyperstart) readCtl(data []byte) error {
 func (h *Hyperstart) ackData(nBytes int) {
 	data := make([]byte, 4)
 	binary.BigEndian.PutUint32(data[:], uint32(nBytes))
-	h.SendMessage(hyper.INIT_NEXT, data)
+	h.SendMessage(hyper.NextCode, data)
 }
 
 func (h *Hyperstart) readMessage() (int, []byte, error) {
@@ -255,7 +255,7 @@ func (h *Hyperstart) handleCtl() {
 		// hyperstart to fail and test the reaction of proxy/clients
 		h.logf("ctl: <-- command %s executed successfully\n", cmdName)
 
-		h.SendMessage(hyper.INIT_ACK, nil)
+		h.SendMessage(hyper.AckCode, nil)
 
 	}
 

--- a/pkg/hyperstart/multicast.go
+++ b/pkg/hyperstart/multicast.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 
 	"github.com/golang/glog"
-	hyper "github.com/hyperhq/runv/hyperstart/api/json"
 )
 
 type ctlDataType string
@@ -34,18 +33,18 @@ const (
 )
 
 type multicast struct {
-	bufReplies []*hyper.DecodedMessage
-	reply      []chan *hyper.DecodedMessage
-	event      map[string]chan *hyper.DecodedMessage
+	bufReplies []*DecodedMessage
+	reply      []chan *DecodedMessage
+	event      map[string]chan *DecodedMessage
 	ctl        net.Conn
 	sync.Mutex
 }
 
 func newMulticast(ctlConn net.Conn) *multicast {
 	return &multicast{
-		bufReplies: []*hyper.DecodedMessage{},
-		reply:      []chan *hyper.DecodedMessage{},
-		event:      make(map[string]chan *hyper.DecodedMessage),
+		bufReplies: []*DecodedMessage{},
+		reply:      []chan *DecodedMessage{},
+		event:      make(map[string]chan *DecodedMessage),
 		ctl:        ctlConn,
 	}
 }
@@ -76,8 +75,8 @@ func (m *multicast) buildEventID(containerID, processID string) string {
 	return fmt.Sprintf("%s-%s", containerID, processID)
 }
 
-func (m *multicast) sendEvent(msg *hyper.DecodedMessage) error {
-	var paeData hyper.ProcessAsyncEvent
+func (m *multicast) sendEvent(msg *DecodedMessage) error {
+	var paeData PAECommand
 
 	err := json.Unmarshal(msg.Message, paeData)
 	if err != nil {
@@ -97,7 +96,7 @@ func (m *multicast) sendEvent(msg *hyper.DecodedMessage) error {
 	return nil
 }
 
-func (m *multicast) sendReply(msg *hyper.DecodedMessage) error {
+func (m *multicast) sendReply(msg *DecodedMessage) error {
 	m.Lock()
 	if len(m.reply) == 0 {
 		m.bufReplies = append(m.bufReplies, msg)
@@ -118,7 +117,7 @@ func (m *multicast) sendReply(msg *hyper.DecodedMessage) error {
 	return nil
 }
 
-func (m *multicast) processBufferedReply(channel chan *hyper.DecodedMessage) {
+func (m *multicast) processBufferedReply(channel chan *DecodedMessage) {
 	m.Lock()
 
 	if len(m.bufReplies) == 0 {
@@ -140,21 +139,21 @@ func (m *multicast) processBufferedReply(channel chan *hyper.DecodedMessage) {
 	channel <- msg
 }
 
-func (m *multicast) write(msg *hyper.DecodedMessage) error {
+func (m *multicast) write(msg *DecodedMessage) error {
 	switch msg.Code {
-	case hyper.INIT_NEXT:
+	case NextCode:
 		return nil
-	case hyper.INIT_PROCESSASYNCEVENT:
+	case ProcessAsyncEventCode:
 		return m.sendEvent(msg)
 	default:
 		return m.sendReply(msg)
 	}
 }
 
-func (m *multicast) listen(containerID, processID string, dataType ctlDataType) (chan *hyper.DecodedMessage, error) {
+func (m *multicast) listen(containerID, processID string, dataType ctlDataType) (chan *DecodedMessage, error) {
 	switch dataType {
 	case replyType:
-		newChan := make(chan *hyper.DecodedMessage)
+		newChan := make(chan *DecodedMessage)
 
 		go m.processBufferedReply(newChan)
 
@@ -167,7 +166,7 @@ func (m *multicast) listen(containerID, processID string, dataType ctlDataType) 
 			return nil, fmt.Errorf("Channel already assigned for ID %s", uniqueID)
 		}
 
-		m.event[uniqueID] = make(chan *hyper.DecodedMessage)
+		m.event[uniqueID] = make(chan *DecodedMessage)
 
 		return m.event[uniqueID], nil
 	default:

--- a/pkg/hyperstart/types.go
+++ b/pkg/hyperstart/types.go
@@ -1,0 +1,210 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package hyperstart
+
+import (
+	"syscall"
+)
+
+// Defines all available commands to communicate with hyperstart agent.
+const (
+	VersionCode = iota
+	StartPodCode
+	GetPodDeprecatedCode
+	StopPodDeprecatedCode
+	DestroyPodCode
+	RestartContainerDeprecatedCode
+	ExecCmdCode
+	FinishCmdDeprecatedCode
+	ReadyCode
+	AckCode
+	ErrorCode
+	WinsizeCode
+	PingCode
+	FinishPodDeprecatedCode
+	NextCode
+	WriteFileCode
+	ReadFileCode
+	NewContainerCode
+	KillContainerCode
+	OnlineCPUMemCode
+	SetupInterfaceCode
+	SetupRouteCode
+	RemoveContainerCode
+	ProcessAsyncEventCode
+)
+
+// FileCommand is the structure corresponding to the format expected by
+// hyperstart to interact with files.
+type FileCommand struct {
+	Container string `json:"container"`
+	File      string `json:"file"`
+}
+
+// KillCommand is the structure corresponding to the format expected by
+// hyperstart to kill a container on the guest.
+type KillCommand struct {
+	Container string         `json:"container"`
+	Signal    syscall.Signal `json:"signal"`
+}
+
+// ExecCommand is the structure corresponding to the format expected by
+// hyperstart to execute a command on the guest.
+type ExecCommand struct {
+	Container string  `json:"container,omitempty"`
+	Process   Process `json:"process"`
+}
+
+// RemoveCommand is the structure corresponding to the format expected by
+// hyperstart to remove a container on the guest.
+type RemoveCommand struct {
+	Container string `json:"container"`
+}
+
+// PAECommand is the structure hyperstart can expects to
+// receive after a process has been started/executed on a container.
+type PAECommand struct {
+	Container string `json:"container"`
+	Process   string `json:"process"`
+	Event     string `json:"event"`
+	Info      string `json:"info,omitempty"`
+	Status    int    `json:"status,omitempty"`
+}
+
+// DecodedMessage is the structure holding messages coming from CTL channel.
+type DecodedMessage struct {
+	Code    uint32
+	Message []byte
+}
+
+// TtyMessage is the structure holding messages coming from TTY channel.
+type TtyMessage struct {
+	Session uint64
+	Message []byte
+}
+
+// WindowSizeMessage is the structure corresponding to the format expected by
+// hyperstart to resize a container's window.
+type WindowSizeMessage struct {
+	Container string `json:"container"`
+	Process   string `json:"process"`
+	Row       uint16 `json:"row"`
+	Column    uint16 `json:"column"`
+}
+
+// VolumeDescriptor describes a volume related to a container.
+type VolumeDescriptor struct {
+	Device       string `json:"device"`
+	Addr         string `json:"addr,omitempty"`
+	Mount        string `json:"mount"`
+	Fstype       string `json:"fstype,omitempty"`
+	ReadOnly     bool   `json:"readOnly"`
+	DockerVolume bool   `json:"dockerVolume"`
+}
+
+// FsmapDescriptor describes a filesystem map related to a container.
+type FsmapDescriptor struct {
+	Source       string `json:"source"`
+	Path         string `json:"path"`
+	ReadOnly     bool   `json:"readOnly"`
+	DockerVolume bool   `json:"dockerVolume"`
+}
+
+// EnvironmentVar holds an environment variable and its value.
+type EnvironmentVar struct {
+	Env   string `json:"env"`
+	Value string `json:"value"`
+}
+
+// Rlimit describes a resource limit.
+type Rlimit struct {
+	// Type of the rlimit to set
+	Type string `json:"type"`
+	// Hard is the hard limit for the specified type
+	Hard uint64 `json:"hard"`
+	// Soft is the soft limit for the specified type
+	Soft uint64 `json:"soft"`
+}
+
+// Process describes a process running on a container inside a pod.
+type Process struct {
+	User             string   `json:"user,omitempty"`
+	Group            string   `json:"group,omitempty"`
+	AdditionalGroups []string `json:"additionalGroups,omitempty"`
+	// Terminal creates an interactive terminal for the process.
+	Terminal bool `json:"terminal"`
+	// Sequeue number for stdin and stdout
+	Stdio uint64 `json:"stdio,omitempty"`
+	// Sequeue number for stderr if it is not shared with stdout
+	Stderr uint64 `json:"stderr,omitempty"`
+	// Args specifies the binary and arguments for the application to execute.
+	Args []string `json:"args"`
+	// Envs populates the process environment for the process.
+	Envs []EnvironmentVar `json:"envs,omitempty"`
+	// Workdir is the current working directory for the process and must be
+	// relative to the container's root.
+	Workdir string `json:"workdir"`
+	// Rlimits specifies rlimit options to apply to the process.
+	Rlimits []Rlimit `json:"rlimits,omitempty"`
+}
+
+// Container describes a container running on a pod.
+type Container struct {
+	ID            string              `json:"id"`
+	Rootfs        string              `json:"rootfs"`
+	Fstype        string              `json:"fstype,omitempty"`
+	Image         string              `json:"image"`
+	Addr          string              `json:"addr,omitempty"`
+	Volumes       []*VolumeDescriptor `json:"volumes,omitempty"`
+	Fsmap         []*FsmapDescriptor  `json:"fsmap,omitempty"`
+	Sysctl        map[string]string   `json:"sysctl,omitempty"`
+	Process       *Process            `json:"process"`
+	RestartPolicy string              `json:"restartPolicy"`
+	Initialize    bool                `json:"initialize"`
+}
+
+// IPAddress describes an IP address and its network mask.
+type IPAddress struct {
+	IPAddress string `json:"ipAddress"`
+	NetMask   string `json:"netMask"`
+}
+
+// NetworkIface describes a network interface to setup on the host.
+type NetworkIface struct {
+	Device      string      `json:"device,omitempty"`
+	NewDevice   string      `json:"newDeviceName,omitempty"`
+	IPAddresses []IPAddress `json:"ipAddresses"`
+	MTU         string      `json:"mtu"`
+	MACAddr     string      `json:"macAddr"`
+}
+
+// Route describes a route to setup on the host.
+type Route struct {
+	Dest    string `json:"dest"`
+	Gateway string `json:"gateway,omitempty"`
+	Device  string `json:"device,omitempty"`
+}
+
+// Pod describes the pod configuration to start inside the VM.
+type Pod struct {
+	Hostname   string         `json:"hostname"`
+	Containers []Container    `json:"containers,omitempty"`
+	Interfaces []NetworkIface `json:"interfaces,omitempty"`
+	DNS        []string       `json:"dns,omitempty"`
+	Routes     []Route        `json:"routes,omitempty"`
+	ShareDir   string         `json:"shareDir"`
+}


### PR DESCRIPTION
This PR adds a new package to virtcontainers: pkg/hyperstart/api. This package duplicates/modify structures initially provided by github.com/hyperhq/runv/hyperstart/api/json, in order to prevent issues related to upstream modification of this package.
That way, the package provided provided by hyperstart can change according to the changes made to the binary, there is no way it can break our virtcontainers library. The clearcontainers/proxy will also rely on this new package.