### PR TITLE
travis: Add go_import_path directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
 - 1.7
 - 1.8
 - tip
+go_import_path: github.com/containers/virtcontainers
 
 env:
 - COVERALLS_TOKEN=3NUr5Z9zvjIoGRlKi6WIA3Q9em3x22rZp


### PR DESCRIPTION
Travis didn't pass when running from a forked repo:

  $ sudo env "PATH=$PATH" bash $GOPATH/src/github.com/containers/virtcontainers/ci/ci-setup.sh
  bash: /home/travis/gopath/src/github.com/containers/virtcontainers/ci/ci-setup.sh: No such file or directory

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>