### PR TITLE
virtcontainers: Replace glog by logrus logger

### DIFF
--- a/cni.go
+++ b/cni.go
@@ -17,9 +17,9 @@
 package virtcontainers
 
 import (
+	log "github.com/Sirupsen/logrus"
 	"github.com/containernetworking/cni/pkg/ns"
 	cniPlugin "github.com/containers/virtcontainers/pkg/cni"
-	"github.com/golang/glog"
 )
 
 // cni is a network implementation for the CNI plugin.
@@ -39,7 +39,7 @@ func (n *cni) addVirtInterfaces(networkNS *NetworkNamespace) error {
 
 		networkNS.Endpoints[idx].Properties = *result
 
-		glog.Infof("AddNetwork results %v\n", *result)
+		log.Infof("AddNetwork results %v\n", *result)
 	}
 
 	return nil

--- a/container.go
+++ b/container.go
@@ -23,7 +23,7 @@ import (
 	"syscall"
 
 	"github.com/01org/ciao/ssntp/uuid"
-	"github.com/golang/glog"
+	log "github.com/Sirupsen/logrus"
 )
 
 // Process gathers data related to a container process.
@@ -130,7 +130,7 @@ func fetchContainer(pod *Pod, containerID string) (*Container, error) {
 		return nil, err
 	}
 
-	glog.Infof("Info structure:\n%+v\n", config)
+	log.Infof("Info structure:\n%+v\n", config)
 
 	return createContainer(pod, config)
 }

--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -17,14 +17,13 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"os/user"
 	"strings"
 	"text/tabwriter"
 
-	"github.com/golang/glog"
+	log "github.com/Sirupsen/logrus"
 	"github.com/urfave/cli"
 
 	vc "github.com/containers/virtcontainers"
@@ -760,58 +759,7 @@ var statusContainerCommand = cli.Command{
 	},
 }
 
-func glogFlagShim(fakeVals map[string]string) {
-	flag.VisitAll(func(fl *flag.Flag) {
-		if val, ok := fakeVals[fl.Name]; ok {
-			fl.Value.Set(val)
-		}
-	})
-}
-
-func glogShim(c *cli.Context) {
-	_ = flag.CommandLine.Parse([]string{})
-	glogFlagShim(map[string]string{
-		"v":                fmt.Sprint(c.Int("v")),
-		"logtostderr":      fmt.Sprint(c.Bool("logtostderr")),
-		"stderrthreshold":  fmt.Sprint(c.Int("stderrthreshold")),
-		"alsologtostderr":  fmt.Sprint(c.Bool("alsologtostderr")),
-		"vmodule":          c.String("vmodule"),
-		"log_dir":          c.String("log_dir"),
-		"log_backtrace_at": c.String("log_backtrace_at"),
-	})
-}
-
-var glogFlags = []cli.Flag{
-	cli.IntFlag{
-		Name: "v", Value: 0, Usage: "log level for V logs",
-	},
-	cli.BoolFlag{
-		Name: "logtostderr", Usage: "log to standard error instead of files",
-	},
-	cli.IntFlag{
-		Name:  "stderrthreshold",
-		Usage: "logs at or above this threshold go to stderr",
-	},
-	cli.BoolFlag{
-		Name: "alsologtostderr", Usage: "log to standard error as well as files",
-	},
-	cli.StringFlag{
-		Name:  "vmodule",
-		Usage: "comma-separated list of pattern=N settings for file-filtered logging",
-	},
-	cli.StringFlag{
-		Name: "log_dir", Usage: "If non-empty, write log files in this directory",
-	},
-	cli.StringFlag{
-		Name:  "log_backtrace_at",
-		Usage: "when logging hits line file:N, emit a stack trace",
-		Value: ":0",
-	},
-}
-
 func main() {
-	flag.Parse()
-
 	cli.VersionFlag = cli.BoolFlag{
 		Name:  "version",
 		Usage: "print the version",
@@ -849,14 +797,8 @@ func main() {
 		},
 	}
 
-	virtc.Flags = append(virtc.Flags, glogFlags...)
-	virtc.Action = func(c *cli.Context) error {
-		glogShim(c)
-		return nil
-	}
-
 	err := virtc.Run(os.Args)
 	if err != nil {
-		glog.Fatal(err)
+		log.Fatal(err)
 	}
 }

--- a/hook.go
+++ b/hook.go
@@ -24,7 +24,7 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/golang/glog"
+	log "github.com/Sirupsen/logrus"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -102,7 +102,7 @@ func (h *Hooks) preStartHooks() error {
 	for _, hook := range h.PreStartHooks {
 		err := hook.runHook()
 		if err != nil {
-			glog.Errorf("PreStartHook error: %s\n", err)
+			log.Errorf("PreStartHook error: %s\n", err)
 			return err
 		}
 	}
@@ -120,7 +120,7 @@ func (h *Hooks) postStartHooks() error {
 		if err != nil {
 			// In case of post start hook, the error is not fatal,
 			// just need to be logged.
-			glog.Infof("PostStartHook error: %s\n", err)
+			log.Infof("PostStartHook error: %s\n", err)
 		}
 	}
 
@@ -137,7 +137,7 @@ func (h *Hooks) postStopHooks() error {
 		if err != nil {
 			// In case of post stop hook, the error is not fatal,
 			// just need to be logged.
-			glog.Infof("PostStopHook error: %s\n", err)
+			log.Infof("PostStopHook error: %s\n", err)
 		}
 	}
 

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -22,8 +22,7 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/golang/glog"
-
+	log "github.com/Sirupsen/logrus"
 	"github.com/containers/virtcontainers/pkg/hyperstart"
 )
 
@@ -54,7 +53,7 @@ type HyperConfig struct {
 
 func (c *HyperConfig) validate(pod Pod) bool {
 	if len(c.Sockets) == 0 {
-		glog.Infof("No sockets from configuration\n")
+		log.Infof("No sockets from configuration\n")
 
 		podSocketPaths := []string{
 			fmt.Sprintf(defaultSockPathTemplates[0], pod.id),
@@ -83,7 +82,7 @@ func (c *HyperConfig) validate(pod Pod) bool {
 		c.PauseBinPath = filepath.Join(defaultPauseBinDir, pauseBinName)
 	}
 
-	glog.Infof("Hyperstart config %v\n", c)
+	log.Infof("Hyperstart config %v\n", c)
 
 	return true
 }

--- a/pkg/hyperstart/multicast.go
+++ b/pkg/hyperstart/multicast.go
@@ -22,7 +22,7 @@ import (
 	"net"
 	"sync"
 
-	"github.com/golang/glog"
+	log "github.com/Sirupsen/logrus"
 )
 
 type ctlDataType string
@@ -56,13 +56,13 @@ func startCtlMonitor(ctlConn net.Conn) *multicast {
 		for {
 			msg, err := ReadCtlMessage(ctlMulticast.ctl)
 			if err != nil {
-				glog.Infof("Read on CTL channel ended: %s\n", err)
+				log.Infof("Read on CTL channel ended: %s\n", err)
 				break
 			}
 
 			err = ctlMulticast.write(msg)
 			if err != nil {
-				glog.Errorf("Multicaster write error: %s\n", err)
+				log.Errorf("Multicaster write error: %s\n", err)
 				break
 			}
 		}

--- a/pod.go
+++ b/pod.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/01org/ciao/ssntp/uuid"
-	"github.com/golang/glog"
+	log "github.com/Sirupsen/logrus"
 )
 
 // controlSocket is the pod control socket.
@@ -504,7 +504,7 @@ func fetchPod(podID string) (*Pod, error) {
 		return nil, err
 	}
 
-	glog.Infof("Info structure:\n%+v\n", config)
+	log.Infof("Info structure:\n%+v\n", config)
 
 	return createPod(config)
 }
@@ -595,7 +595,7 @@ func (p *Pod) startVM() error {
 		return err
 	}
 
-	glog.Infof("VM started\n")
+	log.Infof("VM started\n")
 
 	return nil
 }
@@ -619,7 +619,7 @@ func (p *Pod) start() error {
 		return err
 	}
 
-	glog.Infof("Started Pod %s\n", p.ID())
+	log.Infof("Started Pod %s\n", p.ID())
 
 	return nil
 }


### PR DESCRIPTION
Glog causes some data race with project using our library and glog at the same time. For that reason, it is safer to move to logrus logger, which is more flexible and which does not cause such issues.