### PR TITLE
ci: Fix the build because of cni build name change

### DIFF
--- a/ci/ci-setup.sh
+++ b/ci/ci-setup.sh
@@ -65,7 +65,7 @@ make
 cp pause /tmp/bundles/pause_bundle/rootfs/bin/
 popd
 pushd cni
-./build
+./build.sh
 cp ./bin/bridge /tmp/cni/bin/cni-bridge
 cp ./bin/loopback /tmp/cni/bin/loopback
 cp ./bin/host-local /tmp/cni/bin/host-local


### PR DESCRIPTION
The build script from CNI supposed building all the plugins we need has been renamed from "build" to "build.sh". We have to fix that in our CI script in order to let our build properly pass.