### PR TITLE
Improve logging

### DIFF
--- a/api.go
+++ b/api.go
@@ -19,7 +19,16 @@ package virtcontainers
 import (
 	"os"
 	"syscall"
+
+	"github.com/Sirupsen/logrus"
 )
+
+var virtLog = logrus.New()
+
+// SetLog sets the logger for virtcontainers package.
+func SetLog(logger *logrus.Logger) {
+	virtLog = logger
+}
 
 // CreatePod is the virtcontainers pod creation entry point.
 // CreatePod creates a pod and its containers. It does not start them.

--- a/cni.go
+++ b/cni.go
@@ -17,7 +17,6 @@
 package virtcontainers
 
 import (
-	log "github.com/Sirupsen/logrus"
 	"github.com/containernetworking/cni/pkg/ns"
 	cniPlugin "github.com/containers/virtcontainers/pkg/cni"
 )
@@ -39,7 +38,7 @@ func (n *cni) addVirtInterfaces(networkNS *NetworkNamespace) error {
 
 		networkNS.Endpoints[idx].Properties = *result
 
-		log.Infof("AddNetwork results %v\n", *result)
+		virtLog.Infof("AddNetwork results %v", *result)
 	}
 
 	return nil

--- a/container.go
+++ b/container.go
@@ -23,7 +23,6 @@ import (
 	"syscall"
 
 	"github.com/01org/ciao/ssntp/uuid"
-	log "github.com/Sirupsen/logrus"
 )
 
 // Process gathers data related to a container process.
@@ -130,7 +129,7 @@ func fetchContainer(pod *Pod, containerID string) (*Container, error) {
 		return nil, err
 	}
 
-	log.Infof("Info structure:\n%+v\n", config)
+	virtLog.Infof("Info structure: %+v", config)
 
 	return createContainer(pod, config)
 }

--- a/hook.go
+++ b/hook.go
@@ -24,7 +24,6 @@ import (
 	"os/exec"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -102,7 +101,7 @@ func (h *Hooks) preStartHooks() error {
 	for _, hook := range h.PreStartHooks {
 		err := hook.runHook()
 		if err != nil {
-			log.Errorf("PreStartHook error: %s\n", err)
+			virtLog.Errorf("PreStartHook error: %s", err)
 			return err
 		}
 	}
@@ -120,7 +119,7 @@ func (h *Hooks) postStartHooks() error {
 		if err != nil {
 			// In case of post start hook, the error is not fatal,
 			// just need to be logged.
-			log.Infof("PostStartHook error: %s\n", err)
+			virtLog.Infof("PostStartHook error: %s", err)
 		}
 	}
 
@@ -137,7 +136,7 @@ func (h *Hooks) postStopHooks() error {
 		if err != nil {
 			// In case of post stop hook, the error is not fatal,
 			// just need to be logged.
-			log.Infof("PostStopHook error: %s\n", err)
+			virtLog.Infof("PostStopHook error: %s", err)
 		}
 	}
 

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 	"syscall"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/containers/virtcontainers/pkg/hyperstart"
 )
 
@@ -53,7 +52,7 @@ type HyperConfig struct {
 
 func (c *HyperConfig) validate(pod Pod) bool {
 	if len(c.Sockets) == 0 {
-		log.Infof("No sockets from configuration\n")
+		virtLog.Infof("No sockets from configuration")
 
 		podSocketPaths := []string{
 			fmt.Sprintf(defaultSockPathTemplates[0], pod.id),
@@ -82,7 +81,7 @@ func (c *HyperConfig) validate(pod Pod) bool {
 		c.PauseBinPath = filepath.Join(defaultPauseBinDir, pauseBinName)
 	}
 
-	log.Infof("Hyperstart config %v\n", c)
+	virtLog.Infof("Hyperstart config %v", c)
 
 	return true
 }

--- a/pkg/hyperstart/hyperstart.go
+++ b/pkg/hyperstart/hyperstart.go
@@ -24,6 +24,8 @@ import (
 	"net"
 	"sync"
 	"time"
+
+	"github.com/Sirupsen/logrus"
 )
 
 // Control command IDs
@@ -125,6 +127,13 @@ type Hyperstart struct {
 	ctlMulticast *multicast
 
 	ctlChDone chan interface{}
+}
+
+var hyperLog = logrus.New()
+
+// SetLog sets the logger for hyperstart package.
+func SetLog(logger *logrus.Logger) {
+	hyperLog = logger
 }
 
 // NewHyperstart returns a new hyperstart structure.

--- a/pkg/hyperstart/multicast.go
+++ b/pkg/hyperstart/multicast.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"net"
 	"sync"
-
-	log "github.com/Sirupsen/logrus"
 )
 
 type ctlDataType string
@@ -56,13 +54,13 @@ func startCtlMonitor(ctlConn net.Conn, done chan<- interface{}) *multicast {
 		for {
 			msg, err := ReadCtlMessage(ctlMulticast.ctl)
 			if err != nil {
-				log.Infof("Read on CTL channel ended: %s\n", err)
+				hyperLog.Infof("Read on CTL channel ended: %s", err)
 				break
 			}
 
 			err = ctlMulticast.write(msg)
 			if err != nil {
-				log.Errorf("Multicaster write error: %s\n", err)
+				hyperLog.Errorf("Multicaster write error: %s", err)
 				break
 			}
 		}

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -23,7 +23,7 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	vc "github.com/containers/virtcontainers"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -50,6 +50,13 @@ type RuntimeConfig struct {
 	ProxyConfig interface{}
 
 	Console string
+}
+
+var ociLog = logrus.New()
+
+// SetLog sets the logger for oci package.
+func SetLog(logger *logrus.Logger) {
+	ociLog = logger
 }
 
 func cmdEnvs(spec spec.Spec, envs []vc.EnvVar) []vc.EnvVar {
@@ -132,7 +139,7 @@ func networkConfig(ocispec spec.Spec) (vc.NetworkConfig, error) {
 // to a virtcontainers pod configuration structure.
 func PodConfig(runtime RuntimeConfig, bundlePath, cid, console string) (*vc.PodConfig, *spec.Spec, error) {
 	configPath := filepath.Join(bundlePath, "config.json")
-	log.Debugf("converting %s", configPath)
+	ociLog.Debugf("converting %s", configPath)
 
 	configByte, err := ioutil.ReadFile(configPath)
 	if err != nil {
@@ -145,7 +152,7 @@ func PodConfig(runtime RuntimeConfig, bundlePath, cid, console string) (*vc.PodC
 	}
 
 	rootfs := filepath.Join(bundlePath, ocispec.Root.Path)
-	log.Debugf("container rootfs: %s", rootfs)
+	ociLog.Debugf("container rootfs: %s", rootfs)
 
 	cmd := vc.Cmd{
 		Args:    ocispec.Process.Args,

--- a/pod.go
+++ b/pod.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/01org/ciao/ssntp/uuid"
-	log "github.com/Sirupsen/logrus"
 )
 
 // controlSocket is the pod control socket.
@@ -500,7 +499,7 @@ func fetchPod(podID string) (*Pod, error) {
 		return nil, err
 	}
 
-	log.Infof("Info structure:\n%+v\n", config)
+	virtLog.Infof("Info structure: %+v", config)
 
 	return createPod(config)
 }
@@ -591,7 +590,7 @@ func (p *Pod) startVM() error {
 		return err
 	}
 
-	log.Infof("VM started\n")
+	virtLog.Infof("VM started")
 
 	return nil
 }
@@ -615,7 +614,7 @@ func (p *Pod) start() error {
 		return err
 	}
 
-	log.Infof("Started Pod %s\n", p.ID())
+	virtLog.Infof("Started Pod %s", p.ID())
 
 	return nil
 }

--- a/qemu.go
+++ b/qemu.go
@@ -28,7 +28,6 @@ import (
 
 	ciaoQemu "github.com/01org/ciao/qemu"
 	"github.com/01org/ciao/ssntp/uuid"
-	log "github.com/Sirupsen/logrus"
 )
 
 type qmpChannel struct {
@@ -85,15 +84,15 @@ func (l qmpLogger) V(level int32) bool {
 }
 
 func (l qmpLogger) Infof(format string, v ...interface{}) {
-	log.Infof(format, v...)
+	virtLog.Infof(format, v...)
 }
 
 func (l qmpLogger) Warningf(format string, v ...interface{}) {
-	log.Warnf(format, v...)
+	virtLog.Warnf(format, v...)
 }
 
 func (l qmpLogger) Errorf(format string, v ...interface{}) {
-	log.Errorf(format, v...)
+	virtLog.Errorf(format, v...)
 }
 
 var kernelDefaultParams = []Param{
@@ -368,18 +367,18 @@ func (q *qemu) qmpMonitor(connectedCh chan struct{}) {
 	cfg := ciaoQemu.QMPConfig{Logger: qmpLogger{}}
 	qmp, ver, err := ciaoQemu.QMPStart(q.qmpMonitorCh.ctx, q.qmpMonitorCh.path, cfg, q.qmpMonitorCh.disconnectCh)
 	if err != nil {
-		log.Errorf("Failed to connect to QEMU instance %v", err)
+		virtLog.Errorf("Failed to connect to QEMU instance %v", err)
 		return
 	}
 
 	q.qmpMonitorCh.qmp = qmp
 
-	log.Infof("QMP version %d.%d.%d", ver.Major, ver.Minor, ver.Micro)
-	log.Infof("QMP capabilities %s", ver.Capabilities)
+	virtLog.Infof("QMP version %d.%d.%d", ver.Major, ver.Minor, ver.Micro)
+	virtLog.Infof("QMP capabilities %s", ver.Capabilities)
 
 	err = q.qmpMonitorCh.qmp.ExecuteQMPCapabilities(q.qmpMonitorCh.ctx)
 	if err != nil {
-		log.Errorf("Unable to send qmp_capabilities command: %v", err)
+		virtLog.Errorf("Unable to send qmp_capabilities command: %v", err)
 		return
 	}
 
@@ -527,13 +526,13 @@ func (q *qemu) stopPod() error {
 
 	qmp, _, err := ciaoQemu.QMPStart(q.qmpControlCh.ctx, q.qmpControlCh.path, cfg, q.qmpControlCh.disconnectCh)
 	if err != nil {
-		log.Errorf("Failed to connect to QEMU instance %v", err)
+		virtLog.Errorf("Failed to connect to QEMU instance %v", err)
 		return err
 	}
 
 	err = qmp.ExecuteQMPCapabilities(q.qmpMonitorCh.ctx)
 	if err != nil {
-		log.Errorf("Failed to negotiate capabilities with QEMU %v", err)
+		virtLog.Errorf("Failed to negotiate capabilities with QEMU %v", err)
 		return err
 	}
 


### PR DESCRIPTION
Because virtcontainers and its packages are all packages, we wanted to be able to specify from the caller (such as the runtime) a different logger than the default one.