### PR TITLE
Make pod console path internal

### DIFF
--- a/cc_proxy.go
+++ b/cc_proxy.go
@@ -89,7 +89,7 @@ func (p *ccProxy) register(pod Pod) ([]ProxyInfo, string, error) {
 	}
 
 	registerVMOptions := &client.RegisterVMOptions{
-		Console:      pod.config.Console,
+		Console:      pod.hypervisor.getPodConsole(pod.id),
 		NumIOStreams: len(pod.containers),
 	}
 

--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -242,8 +242,6 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 		ProxyConfig: proxyConfig,
 
 		Containers: []vc.ContainerConfig{},
-
-		Console: "/tmp/virtcontainers/console.sock",
 	}
 
 	return podConfig, nil

--- a/hypervisor.go
+++ b/hypervisor.go
@@ -172,4 +172,5 @@ type hypervisor interface {
 	startPod(startCh, stopCh chan struct{}) error
 	stopPod() error
 	addDevice(devInfo interface{}, devType deviceType) error
+	getPodConsole(podID string) string
 }

--- a/mock_hypervisor.go
+++ b/mock_hypervisor.go
@@ -45,3 +45,7 @@ func (m *mockHypervisor) stopPod() error {
 func (m *mockHypervisor) addDevice(devInfo interface{}, devType deviceType) error {
 	return nil
 }
+
+func (m *mockHypervisor) getPodConsole(podID string) string {
+	return ""
+}

--- a/mock_hypervisor_test.go
+++ b/mock_hypervisor_test.go
@@ -92,3 +92,13 @@ func TestMockHypervisorAddDevice(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestMockHypervisorGetPodConsole(t *testing.T) {
+	var m *mockHypervisor
+
+	expected := ""
+
+	if result := m.getPodConsole("testPodID"); result != expected {
+		t.Fatalf("Got %s\nExpecting %s", result, expected)
+	}
+}

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -189,8 +189,6 @@ func PodConfig(runtime RuntimeConfig, bundlePath, cid, console string) (*vc.PodC
 
 		Containers: []vc.ContainerConfig{containerConfig},
 
-		Console: runtime.Console,
-
 		Annotations: map[string]string{ociConfigPathKey: configPath},
 	}
 

--- a/pkg/oci/utils_test.go
+++ b/pkg/oci/utils_test.go
@@ -100,8 +100,6 @@ func TestMinimalPodConfig(t *testing.T) {
 
 		Containers: []vc.ContainerConfig{expectedContainerConfig},
 
-		Console: consolePath,
-
 		Annotations: map[string]string{ociConfigPathKey: configPath},
 	}
 

--- a/pod.go
+++ b/pod.go
@@ -273,10 +273,6 @@ type PodConfig struct {
 	// Annotations keys must be unique strings an must be name-spaced
 	// with e.g. reverse domain notation (org.clearlinux.key).
 	Annotations map[string]string
-
-	// Console is a console path provided by the caller to create
-	// a console connected to the VM.
-	Console string
 }
 
 // valid checks that the pod configuration is valid.

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -19,6 +19,7 @@ package virtcontainers
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -245,7 +246,6 @@ func TestQemuAppendConsoles(t *testing.T) {
 	podID := "testPodID"
 	cID1 := "100"
 	cID2 := "200"
-	podConsolePath := "testPodConsolePath"
 	contConsolePath := "testContConsolePath"
 
 	expectedOut := []ciaoQemu.Device{
@@ -258,7 +258,7 @@ func TestQemuAppendConsoles(t *testing.T) {
 			Backend:  ciaoQemu.Socket,
 			DeviceID: "console0",
 			ID:       "charconsole0",
-			Path:     podConsolePath,
+			Path:     filepath.Join(runStoragePath, podID, defaultConsole),
 		},
 		ciaoQemu.CharDevice{
 			Driver:   ciaoQemu.Console,
@@ -292,7 +292,6 @@ func TestQemuAppendConsoles(t *testing.T) {
 	podConfig := PodConfig{
 		ID:         podID,
 		Containers: containers,
-		Console:    podConsolePath,
 	}
 
 	testQemuAppend(t, podConfig, expectedOut, consoleDev)
@@ -479,4 +478,14 @@ func TestQemuAddDeviceSerialPordDev(t *testing.T) {
 	}
 
 	testQemuAddDevice(t, socket, serialPortDev, expectedOut)
+}
+
+func TestQemuGetPodConsole(t *testing.T) {
+	q := &qemu{}
+	podID := "testPodID"
+	expected := filepath.Join(runStoragePath, podID, defaultConsole)
+
+	if result := q.getPodConsole(podID); result != expected {
+		t.Fatalf("Got %s\nExpecting %s", result, expected)
+	}
 }


### PR DESCRIPTION
There is no reason to configure the pod console path from the PodConfig because it is used only internally by the proxy and it is created by the hypervisor. That's why this PR takes care of removing the Console field from PodConfig, and provide an internal way for both hypervisor and proxy to be able to get this console path.