### PR TITLE
virtc: Add cc-shim support

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -1377,6 +1377,11 @@ func createAndStartPod(config PodConfig) (pod *Pod, podDir string,
 		return nil, "", err
 	}
 
+	// Start the VM
+	if err := pod.startVM(); err != nil {
+		return nil, "", err
+	}
+
 	// Start pod
 	pod, err = StartPod(pod.id)
 	if pod == nil || err != nil {

--- a/container.go
+++ b/container.go
@@ -115,6 +115,11 @@ func (c *Container) SetPid(pid int) error {
 	return c.storeProcess()
 }
 
+// URL returns the URL related to the pod.
+func (c *Container) URL() string {
+	return c.pod.URL()
+}
+
 func (c *Container) storeProcess() error {
 	return c.pod.storage.storeContainerProcess(c.podID, c.id, c.process)
 }

--- a/hack/virtc/README.md
+++ b/hack/virtc/README.md
@@ -75,6 +75,29 @@ I0410 08:58:49.059044    5384 proxy.go:566] proxy started
 ```
 The proxy socket specified in the example log output has to be used as `virtc`'s `--proxy-url` option.
 
+### Get cc-shim (optional)
+
+If you plan to start `virtc` with the hyperstart agent (implying the use of `cc-proxy` as a proxy), you will have the possibility to enable [cc-shim](https://github.com/clearcontainers/shim) in order to interact with the process running inside your container. First, you will have to perform extra steps to setup your environment.
+
+```
+$ go get github.com/clearcontainers/shim
+$ make
+$ sudo make install
+```
+
+The shim will be installed at the following location: `/usr/libexec/cc-shim`. There will be two cases where you will be able to enable `cc-shim`:
+
+_Start a new container_
+
+```
+# ./virtc container start --id=1 --pod-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 --cc-shim --cc-shim-path="/usr/libexec/cc-shim"
+```
+_Execute a new process on a running container_
+```
+# ./virtc container enter --id=1 --pod-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 --cmd="/bin/ifconfig" --cc-shim --cc-shim-path="/usr/libexec/cc-shim"
+```
+Notice that in both cases, the `--pod-id` and `--id` options have been defined when creating a pod and a container respectively. 
+
 ### Run virtc
 
 All following commands __MUST__ be run as root. By default, and unless you decide to modify it and rebuild it, `virtc` starts empty pods (no container started).

--- a/pod_test.go
+++ b/pod_test.go
@@ -453,7 +453,8 @@ func TestPodSetPodStateFailingStorePodResource(t *testing.T) {
 		storage: fs,
 	}
 
-	err := pod.setPodState(StateReady)
+	pod.state.State = StateReady
+	err := pod.setPodState(pod.state)
 	if err == nil {
 		t.Fatal()
 	}


### PR DESCRIPTION
This PR modifies slightly virtcontainers structures Pod and Process to have something working both with virtc CLI and OCI runtime.
This enables the support for cc-shim inside virtc so that we can use the entire chain (shim+proxy) with virtc CLI.