### PR TITLE
pkg: oci: fix container rootfs path

### DIFF
--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -151,7 +151,10 @@ func PodConfig(runtime RuntimeConfig, bundlePath, cid, console string) (*vc.PodC
 		return nil, nil, err
 	}
 
-	rootfs := filepath.Join(bundlePath, ocispec.Root.Path)
+	rootfs := ocispec.Root.Path
+	if !filepath.IsAbs(rootfs) {
+		rootfs = filepath.Join(bundlePath, ocispec.Root.Path)
+	}
 	ociLog.Debugf("container rootfs: %s", rootfs)
 
 	cmd := vc.Cmd{
@@ -164,7 +167,7 @@ func PodConfig(runtime RuntimeConfig, bundlePath, cid, console string) (*vc.PodC
 
 	containerConfig := vc.ContainerConfig{
 		ID:          cid,
-		RootFs:      ocispec.Root.Path,
+		RootFs:      rootfs,
 		Interactive: ocispec.Process.Terminal,
 		Console:     console,
 		Cmd:         cmd,

--- a/pkg/oci/utils_test.go
+++ b/pkg/oci/utils_test.go
@@ -78,7 +78,7 @@ func TestMinimalPodConfig(t *testing.T) {
 
 	expectedContainerConfig := vc.ContainerConfig{
 		ID:          containerID,
-		RootFs:      "rootfs",
+		RootFs:      path.Join(tempBundlePath, "rootfs"),
 		Interactive: true,
 		Console:     consolePath,
 		Cmd:         expectedCmd,


### PR DESCRIPTION
As OCI spec stated, ocispec.Root.Path is either an absolute path or a
relative path to the bundle.

Signed-off-by: WANG Chao <chao.wang@ucloud.cn>