### PR TITLE
cnm: Fix sporadic netns issue related to wrong thread ID

### DIFF
--- a/api.go
+++ b/api.go
@@ -18,10 +18,15 @@ package virtcontainers
 
 import (
 	"os"
+	"runtime"
 	"syscall"
 
 	"github.com/Sirupsen/logrus"
 )
+
+func init() {
+	runtime.LockOSThread()
+}
 
 var virtLog = logrus.New()
 

--- a/cnm.go
+++ b/cnm.go
@@ -181,7 +181,7 @@ func (n *cnm) run(networkNSPath string, cb func() error) error {
 		return fmt.Errorf("networkNSPath cannot be empty")
 	}
 
-	return doNetNS(networkNSPath, func(_ ns.NetNS) error {
+	return safeDoNetNS(networkNSPath, func(_ ns.NetNS) error {
 		return cb()
 	})
 }


### PR DESCRIPTION
Starting "docker run" commands with 3.0 runtime, we have detected some sporadic issues related to the thread ID. In case the thread ID is different from the process ID, if we set the current process
to a given network namespace, Docker CNM plugin cannot reach this network namespace because it will find the one tied to the process ID. There is only one case where this is working, we need the thread ID being the same than process ID.

The way to achieve this, we call runtime.LockOSThread() so that the main thread does not end up executed by another thread.

Then, the other issue is about using go routines when you call LockOSThread(). In that case, the go routine will be automatically assigned a different thread ID. And in our case, we are calling Do()
function which is using a go routine to switch to the specified netns. That means we have switched a different pair PID/TID to the netns, and Docker CNM plugin won't be able to reach the network namespace.

That's why the second part of the patch is about writing a Do() but safe from the usage of any go routine. That way, we are always in the same pair PID/TID when switching the current process to the netns, making Docker finding the right netns all the time.

Notice that LockOSThread() is called from init() function so that we make sure this function is executed before the main() function of the consumer of our virtcontainers library. That's the way we ensure that
PID will always be equal to TID.