### PR TITLE
cc_proxy: Don't provide a token for the pause container

### DIFF
--- a/cc_proxy.go
+++ b/cc_proxy.go
@@ -209,9 +209,7 @@ func (p *ccProxy) sendCmd(cmd interface{}) (interface{}, error) {
 	}
 
 	var tokens []string
-	if proxyCmd.token == "" {
-		tokens = nil
-	} else {
+	if proxyCmd.token != "" {
 		tokens = append(tokens, proxyCmd.token)
 	}
 

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -365,7 +365,7 @@ func (h *hyper) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
 
 // startPod is the agent Pod starting implementation for hyperstart.
 func (h *hyper) startPod(pod Pod) error {
-	proxyInfo, _, err := h.proxy.connect(pod, true)
+	_, _, err := h.proxy.connect(pod, false)
 	if err != nil {
 		return err
 	}
@@ -392,7 +392,7 @@ func (h *hyper) startPod(pod Pod) error {
 		return err
 	}
 
-	if err := h.startPauseContainer(pod.id, proxyInfo.Token); err != nil {
+	if err := h.startPauseContainer(pod.id); err != nil {
 		return err
 	}
 
@@ -442,7 +442,7 @@ func (h *hyper) stopPod(pod Pod) error {
 }
 
 // startPauseContainer starts a specific container running the pause binary provided.
-func (h *hyper) startPauseContainer(podID, token string) error {
+func (h *hyper) startPauseContainer(podID string) error {
 	cmd := Cmd{
 		Args:    []string{fmt.Sprintf("./%s", pauseBinName)},
 		Envs:    []EnvVar{},
@@ -468,7 +468,6 @@ func (h *hyper) startPauseContainer(podID, token string) error {
 	proxyCmd := hyperstartProxyCmd{
 		cmd:     hyperstart.NewContainer,
 		message: container,
-		token:   token,
 	}
 
 	if _, err := h.proxy.sendCmd(proxyCmd); err != nil {


### PR DESCRIPTION
Because we don't need to send/receive any IO to/from the pause container workload, there is no point in passing a token to the proxy.
That way, the proxy does not wait for a token to be provided, and therefore it does not expect a shim to connect.