### PR TITLE
errors: Make the standard errors private.

### DIFF
--- a/api.go
+++ b/api.go
@@ -94,7 +94,7 @@ func CreatePod(podConfig PodConfig) (*Pod, error) {
 // DeletePod will stop an already running container and then delete it.
 func DeletePod(podID string) (*Pod, error) {
 	if podID == "" {
-		return nil, ErrNeedPodID
+		return nil, errNeedPodID
 	}
 
 	lockFile, err := lockPod(podID)
@@ -147,7 +147,7 @@ func DeletePod(podID string) (*Pod, error) {
 // It returns the pod ID.
 func StartPod(podID string) (*Pod, error) {
 	if podID == "" {
-		return nil, ErrNeedPodID
+		return nil, errNeedPodID
 	}
 
 	lockFile, err := lockPod(podID)
@@ -194,7 +194,7 @@ func StartPod(podID string) (*Pod, error) {
 // StopPod will talk to the given agent to stop an existing pod and destroy all containers within that pod.
 func StopPod(podID string) (*Pod, error) {
 	if podID == "" {
-		return nil, ErrNeedPod
+		return nil, errNeedPod
 	}
 
 	lockFile, err := lockPod(podID)
@@ -346,7 +346,7 @@ func ListPod() ([]PodStatus, error) {
 // StatusPod is the virtcontainers pod status entry point.
 func StatusPod(podID string) (PodStatus, error) {
 	if podID == "" {
-		return PodStatus{}, ErrNeedPodID
+		return PodStatus{}, errNeedPodID
 	}
 
 	pod, err := fetchPod(podID)
@@ -381,7 +381,7 @@ func StatusPod(podID string) (PodStatus, error) {
 // CreateContainer creates a container on a given pod.
 func CreateContainer(podID string, containerConfig ContainerConfig) (*Pod, *Container, error) {
 	if podID == "" {
-		return nil, nil, ErrNeedPodID
+		return nil, nil, errNeedPodID
 	}
 
 	lockFile, err := lockPod(podID)
@@ -427,11 +427,11 @@ func CreateContainer(podID string, containerConfig ContainerConfig) (*Pod, *Cont
 // it needs to be stopped first.
 func DeleteContainer(podID, containerID string) (*Container, error) {
 	if podID == "" {
-		return nil, ErrNeedPodID
+		return nil, errNeedPodID
 	}
 
 	if containerID == "" {
-		return nil, ErrNeedContainerID
+		return nil, errNeedContainerID
 	}
 
 	lockFile, err := lockPod(podID)
@@ -481,11 +481,11 @@ func DeleteContainer(podID, containerID string) (*Container, error) {
 // StartContainer starts an already created container.
 func StartContainer(podID, containerID string) (*Container, error) {
 	if podID == "" {
-		return nil, ErrNeedPodID
+		return nil, errNeedPodID
 	}
 
 	if containerID == "" {
-		return nil, ErrNeedContainerID
+		return nil, errNeedContainerID
 	}
 
 	lockFile, err := lockPod(podID)
@@ -524,11 +524,11 @@ func StartContainer(podID, containerID string) (*Container, error) {
 // StopContainer stops an already running container.
 func StopContainer(podID, containerID string) (*Container, error) {
 	if podID == "" {
-		return nil, ErrNeedPodID
+		return nil, errNeedPodID
 	}
 
 	if containerID == "" {
-		return nil, ErrNeedContainerID
+		return nil, errNeedContainerID
 	}
 
 	lockFile, err := lockPod(podID)
@@ -567,11 +567,11 @@ func StopContainer(podID, containerID string) (*Container, error) {
 // EnterContainer enters an already running container and runs a given command.
 func EnterContainer(podID, containerID string, cmd Cmd) (*Pod, *Container, *Process, error) {
 	if podID == "" {
-		return nil, nil, nil, ErrNeedPodID
+		return nil, nil, nil, errNeedPodID
 	}
 
 	if containerID == "" {
-		return nil, nil, nil, ErrNeedContainerID
+		return nil, nil, nil, errNeedContainerID
 	}
 
 	lockFile, err := lockPod(podID)
@@ -609,11 +609,11 @@ func EnterContainer(podID, containerID string, cmd Cmd) (*Pod, *Container, *Proc
 // StatusContainer returns a detailed container status.
 func StatusContainer(podID, containerID string) (ContainerStatus, error) {
 	if podID == "" {
-		return ContainerStatus{}, ErrNeedPodID
+		return ContainerStatus{}, errNeedPodID
 	}
 
 	if containerID == "" {
-		return ContainerStatus{}, ErrNeedContainerID
+		return ContainerStatus{}, errNeedContainerID
 	}
 
 	var contStatus ContainerStatus
@@ -641,11 +641,11 @@ func StatusContainer(podID, containerID string) (ContainerStatus, error) {
 // to a container running inside a pod.
 func KillContainer(podID, containerID string, signal syscall.Signal) error {
 	if podID == "" {
-		return ErrNeedPodID
+		return errNeedPodID
 	}
 
 	if containerID == "" {
-		return ErrNeedContainerID
+		return errNeedContainerID
 	}
 
 	lockFile, err := lockPod(podID)

--- a/container.go
+++ b/container.go
@@ -131,11 +131,11 @@ func (c *Container) fetchProcess() (Process, error) {
 // fetchContainer fetches a container config from a pod ID and returns a Container.
 func fetchContainer(pod *Pod, containerID string) (*Container, error) {
 	if pod == nil {
-		return nil, ErrNeedPod
+		return nil, errNeedPod
 	}
 
 	if containerID == "" {
-		return nil, ErrNeedContainerID
+		return nil, errNeedContainerID
 	}
 
 	fs := filesystem{}
@@ -162,7 +162,7 @@ func (c *Container) storeContainer() error {
 
 func (c *Container) setContainerState(state stateString) error {
 	if state == "" {
-		return ErrNeedState
+		return errNeedState
 	}
 
 	c.state = State{
@@ -194,7 +194,7 @@ func (c *Container) createContainersDirs() error {
 
 func createContainers(pod *Pod, contConfigs []ContainerConfig) ([]*Container, error) {
 	if pod == nil {
-		return nil, ErrNeedPod
+		return nil, errNeedPod
 	}
 
 	var containers []*Container
@@ -235,7 +235,7 @@ func createContainers(pod *Pod, contConfigs []ContainerConfig) ([]*Container, er
 
 func createContainer(pod *Pod, contConfig ContainerConfig) (*Container, error) {
 	if pod == nil {
-		return nil, ErrNeedPod
+		return nil, errNeedPod
 	}
 
 	if contConfig.valid() == false {

--- a/errors.go
+++ b/errors.go
@@ -22,9 +22,9 @@ import (
 
 // common error objects used for argument checking
 var (
-	ErrNeedPod         = errors.New("Pod must be specified")
-	ErrNeedPodID       = errors.New("Pod ID cannot be empty")
-	ErrNeedContainerID = errors.New("Container ID cannot be empty")
-	ErrNeedFile        = errors.New("File cannot be empty")
-	ErrNeedState       = errors.New("State cannot be empty")
+	errNeedPod         = errors.New("Pod must be specified")
+	errNeedPodID       = errors.New("Pod ID cannot be empty")
+	errNeedContainerID = errors.New("Container ID cannot be empty")
+	errNeedFile        = errors.New("File cannot be empty")
+	errNeedState       = errors.New("State cannot be empty")
 )

--- a/filesystem.go
+++ b/filesystem.go
@@ -150,7 +150,7 @@ func (fs *filesystem) createAllResources(pod Pod) (err error) {
 
 func (fs *filesystem) storeFile(file string, data interface{}) error {
 	if file == "" {
-		return ErrNeedFile
+		return errNeedFile
 	}
 
 	f, err := os.Create(file)
@@ -170,7 +170,7 @@ func (fs *filesystem) storeFile(file string, data interface{}) error {
 
 func (fs *filesystem) fetchFile(file string, data interface{}) error {
 	if file == "" {
-		return ErrNeedFile
+		return errNeedFile
 	}
 
 	fileData, err := ioutil.ReadFile(file)
@@ -204,11 +204,11 @@ func resourceNeedsContainerID(podSpecific bool, resource podResource) bool {
 
 func resourceDir(podSpecific bool, podID, containerID string, resource podResource) (string, error) {
 	if podID == "" {
-		return "", ErrNeedPodID
+		return "", errNeedPodID
 	}
 
 	if resourceNeedsContainerID(podSpecific, resource) == true && containerID == "" {
-		return "", ErrNeedContainerID
+		return "", errNeedContainerID
 	}
 
 	var path string
@@ -235,7 +235,7 @@ func resourceDir(podSpecific bool, podID, containerID string, resource podResour
 // blank to resourceDIR()
 func (fs *filesystem) resourceURI(podSpecific bool, podID, containerID string, resource podResource) (string, string, error) {
 	if podID == "" {
-		return "", "", ErrNeedPodID
+		return "", "", errNeedPodID
 	}
 
 	var filename string
@@ -269,11 +269,11 @@ func (fs *filesystem) resourceURI(podSpecific bool, podID, containerID string, r
 
 func (fs *filesystem) containerURI(podID, containerID string, resource podResource) (string, string, error) {
 	if podID == "" {
-		return "", "", ErrNeedPodID
+		return "", "", errNeedPodID
 	}
 
 	if containerID == "" {
-		return "", "", ErrNeedContainerID
+		return "", "", errNeedContainerID
 	}
 
 	return fs.resourceURI(false, podID, containerID, resource)
@@ -287,11 +287,11 @@ func (fs *filesystem) podURI(podID string, resource podResource) (string, string
 // getting a podResource.
 func (fs *filesystem) commonResourceChecks(podSpecific bool, podID, containerID string, resource podResource) error {
 	if podID == "" {
-		return ErrNeedPodID
+		return errNeedPodID
 	}
 
 	if resourceNeedsContainerID(podSpecific, resource) == true && containerID == "" {
-		return ErrNeedContainerID
+		return errNeedContainerID
 	}
 
 	return nil
@@ -490,11 +490,11 @@ func (fs *filesystem) deletePodResources(podID string, resources []podResource) 
 
 func (fs *filesystem) storeContainerResource(podID, containerID string, resource podResource, data interface{}) error {
 	if podID == "" {
-		return ErrNeedPodID
+		return errNeedPodID
 	}
 
 	if containerID == "" {
-		return ErrNeedContainerID
+		return errNeedContainerID
 	}
 
 	return fs.storeResource(false, podID, containerID, resource, data)
@@ -502,11 +502,11 @@ func (fs *filesystem) storeContainerResource(podID, containerID string, resource
 
 func (fs *filesystem) fetchContainerConfig(podID, containerID string) (ContainerConfig, error) {
 	if podID == "" {
-		return ContainerConfig{}, ErrNeedPodID
+		return ContainerConfig{}, errNeedPodID
 	}
 
 	if containerID == "" {
-		return ContainerConfig{}, ErrNeedContainerID
+		return ContainerConfig{}, errNeedContainerID
 	}
 
 	data, err := fs.fetchResource(false, podID, containerID, configFileType)
@@ -524,11 +524,11 @@ func (fs *filesystem) fetchContainerConfig(podID, containerID string) (Container
 
 func (fs *filesystem) fetchContainerState(podID, containerID string) (State, error) {
 	if podID == "" {
-		return State{}, ErrNeedPodID
+		return State{}, errNeedPodID
 	}
 
 	if containerID == "" {
-		return State{}, ErrNeedContainerID
+		return State{}, errNeedContainerID
 	}
 
 	data, err := fs.fetchResource(false, podID, containerID, stateFileType)
@@ -546,11 +546,11 @@ func (fs *filesystem) fetchContainerState(podID, containerID string) (State, err
 
 func (fs *filesystem) fetchContainerProcess(podID, containerID string) (Process, error) {
 	if podID == "" {
-		return Process{}, ErrNeedPodID
+		return Process{}, errNeedPodID
 	}
 
 	if containerID == "" {
-		return Process{}, ErrNeedContainerID
+		return Process{}, errNeedContainerID
 	}
 
 	data, err := fs.fetchResource(false, podID, containerID, processFileType)

--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -35,6 +36,11 @@ var virtcLog = logrus.New()
 
 var listFormat = "%s\t%s\t%s\t%s\n"
 var statusFormat = "%s\t%s\n"
+
+var (
+	errNeedContainerID = errors.New("Container ID cannot be empty")
+	errNeedPodID       = errors.New("Pod ID cannot be empty")
+)
 
 var podConfigFlags = []cli.Flag{
 	cli.GenericFlag{
@@ -333,7 +339,7 @@ func checkRequiredPodArgs(context *cli.Context) error {
 
 	id := context.String("id")
 	if id == "" {
-		return vc.ErrNeedPodID
+		return errNeedPodID
 	}
 
 	return nil
@@ -352,7 +358,7 @@ func checkRequiredContainerArgs(context *cli.Context) error {
 
 	podID := context.String("pod-id")
 	if podID == "" {
-		return vc.ErrNeedPodID
+		return errNeedPodID
 	}
 
 	rootfs := context.String("rootfs")
@@ -362,7 +368,7 @@ func checkRequiredContainerArgs(context *cli.Context) error {
 
 	id := context.String("id")
 	if id == "" {
-		return vc.ErrNeedContainerID
+		return errNeedContainerID
 	}
 
 	return nil

--- a/pod.go
+++ b/pod.go
@@ -300,7 +300,7 @@ func (podConfig *PodConfig) valid() bool {
 // lock locks any pod to prevent it from being accessed by other processes.
 func lockPod(podID string) (*os.File, error) {
 	if podID == "" {
-		return nil, ErrNeedPodID
+		return nil, errNeedPodID
 	}
 
 	fs := filesystem{}
@@ -511,7 +511,7 @@ func (p *Pod) storePod() error {
 // fetchPod fetches a pod config from a pod ID and returns a pod.
 func fetchPod(podID string) (*Pod, error) {
 	if podID == "" {
-		return nil, ErrNeedPodID
+		return nil, errNeedPodID
 	}
 
 	fs := filesystem{}
@@ -732,7 +732,7 @@ func (p *Pod) endSession() error {
 
 func (p *Pod) setContainerState(containerID string, state stateString) error {
 	if containerID == "" {
-		return ErrNeedContainerID
+		return errNeedContainerID
 	}
 
 	contState := State{
@@ -749,7 +749,7 @@ func (p *Pod) setContainerState(containerID string, state stateString) error {
 
 func (p *Pod) setContainersState(state stateString) error {
 	if state == "" {
-		return ErrNeedState
+		return errNeedState
 	}
 
 	for _, container := range p.config.Containers {
@@ -764,7 +764,7 @@ func (p *Pod) setContainersState(state stateString) error {
 
 func (p *Pod) deleteContainerState(containerID string) error {
 	if containerID == "" {
-		return ErrNeedContainerID
+		return errNeedContainerID
 	}
 
 	err := p.storage.deleteContainerResources(p.id, containerID, []podResource{stateFileType})
@@ -788,7 +788,7 @@ func (p *Pod) deleteContainersState() error {
 
 func (p *Pod) checkContainerState(containerID string, expectedState stateString) error {
 	if containerID == "" {
-		return ErrNeedContainerID
+		return errNeedContainerID
 	}
 
 	if expectedState == "" {
@@ -809,7 +809,7 @@ func (p *Pod) checkContainerState(containerID string, expectedState stateString)
 
 func (p *Pod) checkContainersState(state stateString) error {
 	if state == "" {
-		return ErrNeedState
+		return errNeedState
 	}
 
 	for _, container := range p.config.Containers {

--- a/sshd.go
+++ b/sshd.go
@@ -52,7 +52,7 @@ func (c SshdConfig) validate() bool {
 
 func publicKeyAuth(file string) (ssh.AuthMethod, error) {
 	if file == "" {
-		return nil, ErrNeedFile
+		return nil, errNeedFile
 	}
 
 	privateBytes, err := ioutil.ReadFile(file)
@@ -87,7 +87,7 @@ func execCmd(session *ssh.Session, cmd string) error {
 // init is the agent initialization implementation for sshd.
 func (s *sshd) init(pod *Pod, config interface{}) error {
 	if pod == nil {
-		return ErrNeedPod
+		return errNeedPod
 	}
 
 	if config == nil {
@@ -108,7 +108,7 @@ func (s *sshd) init(pod *Pod, config interface{}) error {
 // start is the agent starting implementation for sshd.
 func (s *sshd) start(pod *Pod) error {
 	if pod == nil {
-		return ErrNeedPod
+		return errNeedPod
 	}
 
 	if s.client != nil {
@@ -157,7 +157,7 @@ func (s *sshd) stop(pod Pod) error {
 // exec is the agent command execution implementation for sshd.
 func (s *sshd) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
 	if pod == nil {
-		return nil, ErrNeedPod
+		return nil, errNeedPod
 	}
 
 	session, err := s.client.NewSession()


### PR DESCRIPTION
Only expose the minimum set of standard errors
("virtc" uses ErrNeedPodID and ErrNeedContainerID).

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>