### PR TITLE
Move generic code out of hyperstart agent implementation

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -124,7 +124,7 @@ type agent interface {
 	stop(pod Pod) error
 
 	// exec will tell the agent to run a command in an already running container.
-	exec(pod *Pod, c Container, cmd Cmd) (*Process, error)
+	exec(pod *Pod, c Container, process Process, cmd Cmd) error
 
 	// startPod will tell the agent to start all containers related to the Pod.
 	startPod(pod Pod) error

--- a/agent.go
+++ b/agent.go
@@ -117,12 +117,6 @@ type agent interface {
 	// to handle all other Agent interface methods.
 	init(pod *Pod, config interface{}) error
 
-	// start will start the agent.
-	start(pod *Pod) error
-
-	// stop will stop the agent.
-	stop(pod Pod) error
-
 	// exec will tell the agent to run a command in an already running container.
 	exec(pod *Pod, c Container, process Process, cmd Cmd) error
 

--- a/api.go
+++ b/api.go
@@ -82,6 +82,11 @@ func CreatePod(podConfig PodConfig) (*Pod, error) {
 		return nil, err
 	}
 
+	// Start shims
+	if err := p.startShims(); err != nil {
+		return nil, err
+	}
+
 	err = p.endSession()
 	if err != nil {
 		return nil, err
@@ -289,6 +294,11 @@ func RunPod(podConfig PodConfig) (*Pod, error) {
 	// Start the VM
 	err = p.startVM()
 	if err != nil {
+		return nil, err
+	}
+
+	// Start shims
+	if err := p.startShims(); err != nil {
 		return nil, err
 	}
 

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -90,7 +90,6 @@ func (c *HyperConfig) validate(pod Pod) bool {
 type hyper struct {
 	config HyperConfig
 	proxy  proxy
-	shim   shim
 }
 
 type hyperstartProxyCmd struct {
@@ -277,123 +276,48 @@ func (h *hyper) init(pod *Pod, config interface{}) (err error) {
 		return err
 	}
 
-	h.proxy, err = newProxy(pod.config.ProxyType)
-	if err != nil {
-		return err
-	}
-
-	h.shim, err = newShim(pod.config.ShimType)
-	if err != nil {
-		return err
-	}
+	h.proxy = pod.proxy
 
 	return nil
 }
 
 // start is the agent starting implementation for hyperstart.
 func (h *hyper) start(pod *Pod) error {
-	proxyInfos, url, err := h.proxy.register(*pod)
-	if err != nil {
-		return err
-	}
-
-	if len(proxyInfos) != len(pod.containers) {
-		return fmt.Errorf("Retrieved %d proxy infos, expecting %d", len(proxyInfos), len(pod.containers))
-	}
-
-	pod.state.URL = url
-	if err := pod.setPodState(pod.state); err != nil {
-		return err
-	}
-
-	for idx := range pod.containers {
-		pid, err := h.startShim(*pod, proxyInfos[idx].Token, url,
-			pod.containers[idx].config.Console)
-		if err != nil {
-			return err
-		}
-
-		pod.containers[idx].process = Process{
-			Token: proxyInfos[idx].Token,
-			Pid:   pid,
-		}
-
-		if err := pod.containers[idx].storeProcess(); err != nil {
-			return err
-		}
-	}
-
-	return h.proxy.disconnect()
+	return nil
 }
 
 // stop is the agent stopping implementation for hyperstart.
 func (h *hyper) stop(pod Pod) error {
-	if _, _, err := h.proxy.connect(pod, false); err != nil {
-		return err
-	}
-
-	if err := h.proxy.unregister(pod); err != nil {
-		return err
-	}
-
-	return h.proxy.disconnect()
+	return nil
 }
 
 // exec is the agent command execution implementation for hyperstart.
-func (h *hyper) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
-	proxyInfo, url, err := h.proxy.connect(*pod, true)
+func (h *hyper) exec(pod *Pod, c Container, process Process, cmd Cmd) error {
+	hyperProcess, err := h.buildHyperContainerProcess(cmd, c.config.Interactive)
 	if err != nil {
-		return nil, err
-	}
-
-	if pod.state.URL != url {
-		return nil, fmt.Errorf("Pod URL %s and URL from proxy %s MUST be similar", pod.state.URL, url)
-	}
-
-	process, err := h.buildHyperContainerProcess(cmd, c.config.Interactive)
-	if err != nil {
-		return nil, err
+		return err
 	}
 
 	execCommand := hyperstart.ExecCommand{
 		Container: c.id,
-		Process:   *process,
+		Process:   *hyperProcess,
 	}
 
 	proxyCmd := hyperstartProxyCmd{
 		cmd:     hyperstart.ExecCmd,
 		message: execCommand,
-		token:   proxyInfo.Token,
-	}
-
-	pid, err := h.startShim(*pod, proxyInfo.Token, url, c.config.Console)
-	if err != nil {
-		return nil, err
+		token:   process.Token,
 	}
 
 	if _, err := h.proxy.sendCmd(proxyCmd); err != nil {
-		return nil, err
+		return err
 	}
 
-	if err := h.proxy.disconnect(); err != nil {
-		return nil, err
-	}
-
-	processInfo := &Process{
-		Token: proxyInfo.Token,
-		Pid:   pid,
-	}
-
-	return processInfo, nil
+	return nil
 }
 
 // startPod is the agent Pod starting implementation for hyperstart.
 func (h *hyper) startPod(pod Pod) error {
-	_, _, err := h.proxy.connect(pod, false)
-	if err != nil {
-		return err
-	}
-
 	ifaces, routes, err := h.buildNetworkInterfacesAndRoutes(pod)
 	if err != nil {
 		return err
@@ -426,15 +350,11 @@ func (h *hyper) startPod(pod Pod) error {
 		}
 	}
 
-	return h.proxy.disconnect()
+	return nil
 }
 
 // stopPod is the agent Pod stopping implementation for hyperstart.
 func (h *hyper) stopPod(pod Pod) error {
-	if _, _, err := h.proxy.connect(pod, false); err != nil {
-		return err
-	}
-
 	for _, c := range pod.containers {
 		state, err := pod.storage.fetchContainerState(pod.id, c.id)
 		if err != nil {
@@ -455,10 +375,6 @@ func (h *hyper) stopPod(pod Pod) error {
 	}
 
 	if err := h.stopPauseContainer(pod.id); err != nil {
-		return err
-	}
-
-	if err := h.proxy.disconnect(); err != nil {
 		return err
 	}
 
@@ -534,43 +450,12 @@ func (h *hyper) startOneContainer(pod Pod, c Container) error {
 
 // createContainer is the agent Container creation implementation for hyperstart.
 func (h *hyper) createContainer(pod *Pod, c *Container) error {
-	proxyInfo, url, err := h.proxy.connect(*pod, true)
-	if err != nil {
-		return err
-	}
-
-	if pod.state.URL != url {
-		return fmt.Errorf("Pod URL %s and URL from proxy %s MUST be similar", pod.state.URL, url)
-	}
-
-	pid, err := h.startShim(*pod, proxyInfo.Token, url, c.config.Console)
-	if err != nil {
-		return err
-	}
-
-	c.process = Process{
-		Token: proxyInfo.Token,
-		Pid:   pid,
-	}
-
-	if err := c.storeProcess(); err != nil {
-		return err
-	}
-
-	return h.proxy.disconnect()
+	return nil
 }
 
 // startContainer is the agent Container starting implementation for hyperstart.
 func (h *hyper) startContainer(pod Pod, c Container) error {
-	if _, _, err := h.proxy.connect(pod, false); err != nil {
-		return err
-	}
-
-	if err := h.startOneContainer(pod, c); err != nil {
-		return err
-	}
-
-	return h.proxy.disconnect()
+	return h.startOneContainer(pod, c)
 }
 
 func (h *hyper) stopPauseContainer(podID string) error {
@@ -587,19 +472,7 @@ func (h *hyper) stopPauseContainer(podID string) error {
 
 // stopContainer is the agent Container stopping implementation for hyperstart.
 func (h *hyper) stopContainer(pod Pod, c Container) error {
-	if _, _, err := h.proxy.connect(pod, false); err != nil {
-		return err
-	}
-
-	if err := h.stopOneContainer(pod.id, c.id); err != nil {
-		return err
-	}
-
-	if err := h.proxy.disconnect(); err != nil {
-		return err
-	}
-
-	return nil
+	return h.stopOneContainer(pod.id, c.id)
 }
 
 func (h *hyper) stopOneContainer(podID, cID string) error {
@@ -625,19 +498,7 @@ func (h *hyper) stopOneContainer(podID, cID string) error {
 
 // killContainer is the agent process signal implementation for hyperstart.
 func (h *hyper) killContainer(pod Pod, c Container, signal syscall.Signal) error {
-	if _, _, err := h.proxy.connect(pod, false); err != nil {
-		return err
-	}
-
-	if err := h.killOneContainer(c.id, signal); err != nil {
-		return err
-	}
-
-	if err := h.proxy.disconnect(); err != nil {
-		return err
-	}
-
-	return nil
+	return h.killOneContainer(c.id, signal)
 }
 
 func (h *hyper) killOneContainer(cID string, signal syscall.Signal) error {
@@ -656,14 +517,4 @@ func (h *hyper) killOneContainer(cID string, signal syscall.Signal) error {
 	}
 
 	return nil
-}
-
-func (h *hyper) startShim(pod Pod, token, url, console string) (int, error) {
-	shimParams := ShimParams{
-		Token:   token,
-		URL:     url,
-		Console: console,
-	}
-
-	return h.shim.start(pod, shimParams)
 }

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -281,16 +281,6 @@ func (h *hyper) init(pod *Pod, config interface{}) (err error) {
 	return nil
 }
 
-// start is the agent starting implementation for hyperstart.
-func (h *hyper) start(pod *Pod) error {
-	return nil
-}
-
-// stop is the agent stopping implementation for hyperstart.
-func (h *hyper) stop(pod Pod) error {
-	return nil
-}
-
 // exec is the agent command execution implementation for hyperstart.
 func (h *hyper) exec(pod *Pod, c Container, process Process, cmd Cmd) error {
 	hyperProcess, err := h.buildHyperContainerProcess(cmd, c.config.Interactive)

--- a/noop_agent.go
+++ b/noop_agent.go
@@ -30,16 +30,6 @@ func (n *noopAgent) init(pod *Pod, config interface{}) error {
 	return nil
 }
 
-// start is the Noop agent starting implementation. It does nothing.
-func (n *noopAgent) start(pod *Pod) error {
-	return nil
-}
-
-// stop is the Noop agent stopping implementation. It does nothing.
-func (n *noopAgent) stop(pod Pod) error {
-	return nil
-}
-
 // exec is the Noop agent command execution implementation. It does nothing.
 func (n *noopAgent) exec(pod *Pod, c Container, process Process, cmd Cmd) error {
 	return nil

--- a/noop_agent.go
+++ b/noop_agent.go
@@ -41,8 +41,8 @@ func (n *noopAgent) stop(pod Pod) error {
 }
 
 // exec is the Noop agent command execution implementation. It does nothing.
-func (n *noopAgent) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
-	return nil, nil
+func (n *noopAgent) exec(pod *Pod, c Container, process Process, cmd Cmd) error {
+	return nil
 }
 
 // startPod is the Noop agent Pod starting implementation. It does nothing.

--- a/noop_agent_test.go
+++ b/noop_agent_test.go
@@ -30,16 +30,6 @@ func TestNoopAgentInit(t *testing.T) {
 	}
 }
 
-func TestNoopAgentStartAgent(t *testing.T) {
-	n := &noopAgent{}
-	pod := &Pod{}
-
-	err := n.start(pod)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestNoopAgentExec(t *testing.T) {
 	n := &noopAgent{}
 	pod := &Pod{}
@@ -67,16 +57,6 @@ func TestNoopAgentStopPod(t *testing.T) {
 	pod := Pod{}
 
 	err := n.stopPod(pod)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestNoopAgentStopAgent(t *testing.T) {
-	n := &noopAgent{}
-	pod := Pod{}
-
-	err := n.stop(pod)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/noop_agent_test.go
+++ b/noop_agent_test.go
@@ -44,9 +44,10 @@ func TestNoopAgentExec(t *testing.T) {
 	n := &noopAgent{}
 	pod := &Pod{}
 	container := Container{}
+	process := Process{}
 	cmd := Cmd{}
 
-	if _, err := n.exec(pod, container, cmd); err != nil {
+	if err := n.exec(pod, container, process, cmd); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/sshd.go
+++ b/sshd.go
@@ -155,27 +155,27 @@ func (s *sshd) stop(pod Pod) error {
 }
 
 // exec is the agent command execution implementation for sshd.
-func (s *sshd) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
+func (s *sshd) exec(pod *Pod, c Container, process Process, cmd Cmd) error {
 	if pod == nil {
-		return nil, errNeedPod
+		return errNeedPod
 	}
 
 	session, err := s.client.NewSession()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create session")
+		return fmt.Errorf("Failed to create session")
 	}
 	defer session.Close()
 
 	if s.spawner != nil {
 		cmd.Args, err = s.spawner.formatArgs(cmd.Args)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
 	strCmd := strings.Join(cmd.Args, " ")
 
-	return nil, execCmd(session, strCmd)
+	return execCmd(session, strCmd)
 }
 
 // startPod is the agent Pod starting implementation for sshd.

--- a/sshd.go
+++ b/sshd.go
@@ -105,12 +105,33 @@ func (s *sshd) init(pod *Pod, config interface{}) error {
 	return nil
 }
 
-// start is the agent starting implementation for sshd.
-func (s *sshd) start(pod *Pod) error {
+// exec is the agent command execution implementation for sshd.
+func (s *sshd) exec(pod *Pod, c Container, process Process, cmd Cmd) error {
 	if pod == nil {
 		return errNeedPod
 	}
 
+	session, err := s.client.NewSession()
+	if err != nil {
+		return fmt.Errorf("Failed to create session (Pod ID %s, Container ID %s)",
+			pod.id, c.id)
+	}
+	defer session.Close()
+
+	if s.spawner != nil {
+		cmd.Args, err = s.spawner.formatArgs(cmd.Args)
+		if err != nil {
+			return err
+		}
+	}
+
+	strCmd := strings.Join(cmd.Args, " ")
+
+	return execCmd(session, strCmd)
+}
+
+// startPod is the agent Pod starting implementation for sshd.
+func (s *sshd) startPod(pod Pod) error {
 	if s.client != nil {
 		session, err := s.client.NewSession()
 		if err == nil {
@@ -146,40 +167,6 @@ func (s *sshd) start(pod *Pod) error {
 		return fmt.Errorf("Failed to dial: %s", err)
 	}
 
-	return nil
-}
-
-// stop is the agent stopping implementation for sshd.
-func (s *sshd) stop(pod Pod) error {
-	return nil
-}
-
-// exec is the agent command execution implementation for sshd.
-func (s *sshd) exec(pod *Pod, c Container, process Process, cmd Cmd) error {
-	if pod == nil {
-		return errNeedPod
-	}
-
-	session, err := s.client.NewSession()
-	if err != nil {
-		return fmt.Errorf("Failed to create session")
-	}
-	defer session.Close()
-
-	if s.spawner != nil {
-		cmd.Args, err = s.spawner.formatArgs(cmd.Args)
-		if err != nil {
-			return err
-		}
-	}
-
-	strCmd := strings.Join(cmd.Args, " ")
-
-	return execCmd(session, strCmd)
-}
-
-// startPod is the agent Pod starting implementation for sshd.
-func (s *sshd) startPod(pod Pod) error {
 	return nil
 }
 


### PR DESCRIPTION
A lot of code related to the proxy and the shim was present inside hyperstart agent implementation. The problem is that this code is generic for any pod/container, and deserves to be shared across different agent implementations.

After all generic code has been moved from agent implementations to pod/container code, there is no point in having `start()` and `stop()` functions provided by the agent interface. Our agent implementations are empty for those functions, and we cannot think about a future usage for any future agent.

This PR fixes issue #202. It has been tested with the runtime and everything still works as before.