### PR TITLE
Add the ability to specify a different console for a new process on an existing container

### DIFF
--- a/container.go
+++ b/container.go
@@ -44,12 +44,6 @@ type ContainerConfig struct {
 	// RootFs is the container workload image on the host.
 	RootFs string
 
-	// Interactive specifies if the container runs in the foreground.
-	Interactive bool
-
-	// Console is a console path provided by the caller.
-	Console string
-
 	// Cmd specifies the command to run on a container
 	Cmd Cmd
 }
@@ -137,7 +131,7 @@ func (c *Container) startShim() error {
 	shimParams := ShimParams{
 		Token:   proxyInfo.Token,
 		URL:     url,
-		Console: c.config.Console,
+		Console: c.config.Cmd.Console,
 	}
 
 	pid, err := c.pod.shim.start(*(c.pod), shimParams)
@@ -468,7 +462,7 @@ func (c *Container) enter(cmd Cmd) (*Process, error) {
 	shimParams := ShimParams{
 		Token:   proxyInfo.Token,
 		URL:     url,
-		Console: c.config.Console,
+		Console: cmd.Console,
 	}
 
 	pid, err := c.pod.shim.start(*(c.pod), shimParams)

--- a/hack/virtc/README.md
+++ b/hack/virtc/README.md
@@ -197,12 +197,17 @@ Container 1 started
 
 #### Run a new process on an existing container
 ```
-# ./virtc container enter --id=1 --pod-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 --cmd="/bin/ps"
+# ./virtc container enter --id=1 --pod-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 --cmd="/bin/ps" --console="/dev/pts/30"
 ```
 This will generate output similar to the following:
 ```
 Container 1 entered
 ```
+__Note:__ The option `--console` can be any existing console.
+Don't try to provide `$(tty)` as it is your current console, and you would not be
+able to get your console back as the shim would be listening to this indefinitely.
+Instead, you would prefer to open a new shell and get the `$(tty)` from this shell.
+That way, you make sure you have a dedicated input/output terminal.
 
 #### Stop an existing container
 ```

--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -584,6 +584,11 @@ var statusPodCommand = cli.Command{
 func createContainer(context *cli.Context) error {
 	console := context.String("console")
 
+	interactive := false
+	if console != "" {
+		interactive = true
+	}
+
 	envs := []vc.EnvVar{
 		{
 			Var:   "PATH",
@@ -592,14 +597,11 @@ func createContainer(context *cli.Context) error {
 	}
 
 	cmd := vc.Cmd{
-		Args:    strings.Split(context.String("cmd"), " "),
-		Envs:    envs,
-		WorkDir: "/",
-	}
-
-	interactive := false
-	if console != "" {
-		interactive = true
+		Args:        strings.Split(context.String("cmd"), " "),
+		Envs:        envs,
+		WorkDir:     "/",
+		Interactive: interactive,
+		Console:     console,
 	}
 
 	id := context.String("id")
@@ -609,11 +611,9 @@ func createContainer(context *cli.Context) error {
 	}
 
 	containerConfig := vc.ContainerConfig{
-		ID:          id,
-		RootFs:      context.String("rootfs"),
-		Interactive: interactive,
-		Console:     console,
-		Cmd:         cmd,
+		ID:     id,
+		RootFs: context.String("rootfs"),
+		Cmd:    cmd,
 	}
 
 	_, c, err := vc.CreateContainer(context.String("pod-id"), containerConfig)
@@ -660,6 +660,13 @@ func stopContainer(context *cli.Context) error {
 }
 
 func enterContainer(context *cli.Context) error {
+	console := context.String("console")
+
+	interactive := false
+	if console != "" {
+		interactive = true
+	}
+
 	envs := []vc.EnvVar{
 		{
 			Var:   "PATH",
@@ -668,9 +675,11 @@ func enterContainer(context *cli.Context) error {
 	}
 
 	cmd := vc.Cmd{
-		Args:    strings.Split(context.String("cmd"), " "),
-		Envs:    envs,
-		WorkDir: "/",
+		Args:        strings.Split(context.String("cmd"), " "),
+		Envs:        envs,
+		WorkDir:     "/",
+		Interactive: interactive,
+		Console:     console,
 	}
 
 	_, c, _, err := vc.EnterContainer(context.String("pod-id"), context.String("id"), cmd)
@@ -811,6 +820,11 @@ var enterContainerCommand = cli.Command{
 			Name:  "cmd",
 			Value: "echo",
 			Usage: "the command executed inside the container",
+		},
+		cli.StringFlag{
+			Name:  "console",
+			Value: "",
+			Usage: "the process console",
 		},
 	},
 	Action: func(context *cli.Context) error {

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -161,19 +161,19 @@ func PodConfig(runtime RuntimeConfig, bundlePath, cid, console string) (*vc.PodC
 	ociLog.Debugf("container rootfs: %s", rootfs)
 
 	cmd := vc.Cmd{
-		Args:    ocispec.Process.Args,
-		Envs:    cmdEnvs(ocispec, []vc.EnvVar{}),
-		WorkDir: ocispec.Process.Cwd,
-		User:    strconv.FormatUint(uint64(ocispec.Process.User.UID), 10),
-		Group:   strconv.FormatUint(uint64(ocispec.Process.User.GID), 10),
+		Args:        ocispec.Process.Args,
+		Envs:        cmdEnvs(ocispec, []vc.EnvVar{}),
+		WorkDir:     ocispec.Process.Cwd,
+		User:        strconv.FormatUint(uint64(ocispec.Process.User.UID), 10),
+		Group:       strconv.FormatUint(uint64(ocispec.Process.User.GID), 10),
+		Interactive: ocispec.Process.Terminal,
+		Console:     console,
 	}
 
 	containerConfig := vc.ContainerConfig{
-		ID:          cid,
-		RootFs:      rootfs,
-		Interactive: ocispec.Process.Terminal,
-		Console:     console,
-		Cmd:         cmd,
+		ID:     cid,
+		RootFs: rootfs,
+		Cmd:    cmd,
 	}
 
 	networkConfig, err := networkConfig(ocispec)

--- a/pkg/oci/utils_test.go
+++ b/pkg/oci/utils_test.go
@@ -72,17 +72,17 @@ func TestMinimalPodConfig(t *testing.T) {
 				Value: "xterm",
 			},
 		},
-		WorkDir: "/",
-		User:    "0",
-		Group:   "0",
+		WorkDir:     "/",
+		User:        "0",
+		Group:       "0",
+		Interactive: true,
+		Console:     consolePath,
 	}
 
 	expectedContainerConfig := vc.ContainerConfig{
-		ID:          containerID,
-		RootFs:      path.Join(tempBundlePath, "rootfs"),
-		Interactive: true,
-		Console:     consolePath,
-		Cmd:         expectedCmd,
+		ID:     containerID,
+		RootFs: path.Join(tempBundlePath, "rootfs"),
+		Cmd:    expectedCmd,
 	}
 
 	expectedNetworkConfig := vc.NetworkConfig{

--- a/pod.go
+++ b/pod.go
@@ -226,6 +226,9 @@ type Cmd struct {
 
 	User  string
 	Group string
+
+	Interactive bool
+	Console     string
 }
 
 // Resources describes VM resources configuration.
@@ -633,7 +636,7 @@ func (p *Pod) startShims() error {
 		shimParams := ShimParams{
 			Token:   proxyInfos[idx].Token,
 			URL:     url,
-			Console: p.containers[idx].config.Console,
+			Console: p.containers[idx].config.Cmd.Console,
 		}
 
 		pid, err := p.shim.start(*p, shimParams)

--- a/qemu.go
+++ b/qemu.go
@@ -259,31 +259,6 @@ func (q *qemu) appendConsoles(devices []ciaoQemu.Device, podConfig PodConfig) []
 
 	devices = append(devices, console)
 
-	for i, c := range podConfig.Containers {
-		// Need to add an offset of 1 because of the console created for the pod.
-		idx := i + 1
-
-		if c.Interactive == false || c.Console == "" {
-			console = ciaoQemu.CharDevice{
-				Driver:   ciaoQemu.Console,
-				Backend:  ciaoQemu.Socket,
-				DeviceID: fmt.Sprintf("console%d", idx),
-				ID:       fmt.Sprintf("charconsole%d", idx),
-				Path:     fmt.Sprintf("%s/%s/%s/%s", runStoragePath, podConfig.ID, c.ID, defaultConsole),
-			}
-		} else {
-			console = ciaoQemu.CharDevice{
-				Driver:   ciaoQemu.Console,
-				Backend:  ciaoQemu.Serial,
-				DeviceID: fmt.Sprintf("console%d", idx),
-				ID:       fmt.Sprintf("charconsole%d", idx),
-				Path:     c.Console,
-			}
-		}
-
-		devices = append(devices, console)
-	}
-
 	return devices
 }
 

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -244,9 +244,6 @@ func TestQemuAppendFSDevices(t *testing.T) {
 
 func TestQemuAppendConsoles(t *testing.T) {
 	podID := "testPodID"
-	cID1 := "100"
-	cID2 := "200"
-	contConsolePath := "testContConsolePath"
 
 	expectedOut := []ciaoQemu.Device{
 		ciaoQemu.SerialDevice{
@@ -260,38 +257,11 @@ func TestQemuAppendConsoles(t *testing.T) {
 			ID:       "charconsole0",
 			Path:     filepath.Join(runStoragePath, podID, defaultConsole),
 		},
-		ciaoQemu.CharDevice{
-			Driver:   ciaoQemu.Console,
-			Backend:  ciaoQemu.Serial,
-			DeviceID: "console1",
-			ID:       "charconsole1",
-			Path:     contConsolePath,
-		},
-		ciaoQemu.CharDevice{
-			Driver:   ciaoQemu.Console,
-			Backend:  ciaoQemu.Socket,
-			DeviceID: "console2",
-			ID:       "charconsole2",
-			Path:     fmt.Sprintf("%s/%s/%s/%s", runStoragePath, podID, cID2, defaultConsole),
-		},
-	}
-
-	containers := []ContainerConfig{
-		{
-			ID:          cID1,
-			Interactive: true,
-			Console:     contConsolePath,
-		},
-		{
-			ID:          cID2,
-			Interactive: false,
-			Console:     "",
-		},
 	}
 
 	podConfig := PodConfig{
 		ID:         podID,
-		Containers: containers,
+		Containers: []ContainerConfig{},
 	}
 
 	testQemuAppend(t, podConfig, expectedOut, consoleDev)


### PR DESCRIPTION
There is a limitation regarding the ability to provide a different console than container's one in case we are trying to execute a new process on this existing container. Indeed, because the console is tied to the ContainerConfig structure, we have no way to specify a different console for another process.

This PR moves Interactive and Console fields from the structure ContainerConfig to Cmd, solving our current limitation.

This PR fixes issue #204.