### PR TITLE
api: ListPod() should succeed if pod directory does not exist.

### DIFF
--- a/api.go
+++ b/api.go
@@ -319,6 +319,10 @@ func RunPod(podConfig PodConfig) (*Pod, error) {
 func ListPod() ([]PodStatus, error) {
 	dir, err := os.Open(configStoragePath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			// No pod directory is not an error
+			return []PodStatus{}, nil
+		}
 		return []PodStatus{}, err
 	}
 

--- a/api_test.go
+++ b/api_test.go
@@ -526,14 +526,14 @@ func TestListPodSuccessful(t *testing.T) {
 	}
 }
 
-func TestListPodFailing(t *testing.T) {
+func TestListPodNoPodDirectory(t *testing.T) {
 	cleanUp()
 
 	os.RemoveAll(configStoragePath)
 
 	_, err := ListPod()
-	if err == nil {
-		t.Fatal()
+	if err != nil {
+		t.Fatal(fmt.Sprintf("unexpected ListPod error from non-existent pod directory: %v", err))
 	}
 }
 


### PR DESCRIPTION
Previously ListPod() returned an error if the pod directory did not
exist. However, that is the normal situation on a system where no pods
have been created.

Renamed "TestListPodFailing" test to "TestListPodNoPodDirectory"
for clarity.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>