### PR TITLE
tests: Renamed tests to match the API being tested.

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -553,7 +553,7 @@ func TestStatusPodSuccessful(t *testing.T) {
 	}
 }
 
-func TestListPodFailingFetchPodConfig(t *testing.T) {
+func TestStatusPodFailingFetchPodConfig(t *testing.T) {
 	cleanUp()
 
 	config := newTestPodConfigNoop()
@@ -572,7 +572,7 @@ func TestListPodFailingFetchPodConfig(t *testing.T) {
 	}
 }
 
-func TestListPodFailingFetchPodState(t *testing.T) {
+func TestStatusPodPodFailingFetchPodState(t *testing.T) {
 	cleanUp()
 
 	config := newTestPodConfigNoop()


### PR DESCRIPTION
TestListPodFailingFetchPodConfig() and TestListPodFailingFetchPodState()
where testing StatusPod() not ListPod(), so rename the test names to
reflect this.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>