### PR TITLE
qemu: Prevent udev from creating predictable network interface names

### DIFF
--- a/qemu.go
+++ b/qemu.go
@@ -118,6 +118,7 @@ var kernelDefaultParams = []Param{
 	{"systemd.mask", "systemd-networkd.service"},
 	{"systemd.mask", "systemd-networkd.socket"},
 	{"cryptomgr.notests", ""},
+	{"net.ifnames", "0"},
 }
 
 // kernelDefaultParamsNonDebug is a list of the default kernel

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -55,7 +55,7 @@ func testQemuBuildKernelParams(t *testing.T, kernelParams []Param, expected stri
 	}
 }
 
-var testQemuKernelParamsBase = "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug init=/usr/lib/systemd/systemd systemd.unit=cc-agent.target iommu=off systemd.mask=systemd-networkd.service systemd.mask=systemd-networkd.socket cryptomgr.notests"
+var testQemuKernelParamsBase = "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug init=/usr/lib/systemd/systemd systemd.unit=cc-agent.target iommu=off systemd.mask=systemd-networkd.service systemd.mask=systemd-networkd.socket cryptomgr.notests net.ifnames=0"
 var testQemuKernelParamsNonDebug = "quiet systemd.show_status=false"
 var testQemuKernelParamsDebug = "debug systemd.show_status=true systemd.log_level=debug"
 


### PR DESCRIPTION
Because we rely on the MAC address to find the network interface, we don't need to enable the renaming by udev of the interface created.

More than that, because hyperstart agent waits for the interface to be ready before it can continue, we don't want the name of the interface found to change after we received the first uevent.

This PR fixes the issue explained here https://github.com/01org/cc-oci-runtime/issues/815 and fixed with https://github.com/01org/cc-oci-runtime/pull/832. Related to the topic: https://github.com/clearcontainers/hyperstart/pull/20.