### PR TITLE
0.7.0 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,17 @@
+0.7.0:
+	Added Clear Containers 3.0 shim support
+	Added Clear Containers 3.0 proxy protocol support
+	Added self contained hyperstart package
+	Added full build scripts
+	Added hypervisor and pod debug options
+	Added command line and function arguments validity checks
+	Added logrus support, replacing glog
+	Added OCI runtime vendoring
+	Added structured and separated error definitions
+	Fixed networking support and unit testing
+	Fixed code layering by keeping generic code out of interface implementations
+	Fixed benchmarks
+
 0.6.0:
 	Added pullapprove support
 	Added Slack integration


### PR DESCRIPTION
Added Clear Containers 3.0 shim support
Added Clear Containers 3.0 proxy protocol support
Added self contained hyperstart package
Added full build scripts
Added hypervisor and pod debug options
Added command line and function arguments validity checks
Added logrus support, replacing glog
Added OCI runtime vendoring
Added structured and separated error definitions
Fixed networking support and unit testing
Fixed code layering by keeping generic code out of interface implementations
Fixed benchmarks

Shortlog:

432d20f qemu: Prevent udev from creating predictable network interface names
1f8daba container: Move Console from ContainerConfig to Cmd structure
9643a8a qemu: Don't append consoles for every container
3778d51 agent: Remove start() and stop() from the interface
f26b15e virtcontainers: Move generic code out of hyperstart implementation
b6d0c6a tests: Renamed tests to match the API being tested.
3db859c api: ListPod() should succeed if pod directory does not exist.
6dbf4b8 errors: Make the standard errors private.
ee0f7c6 virtc: Don't wait for the shim to return
4d6a315 shim: Add support for container's console
7ddab1f pkg: oci: Add ShimType and ShimConfig to the RuntimeConfig
f32d50d container: Fix createContainers() by providing proper pointer
06ae6c0 virtc: Modify CLI according to shim changes
3a9f63c hyperstart: Start the shim
a993af7 shim: Introduce new shim interface
79bc46e cc_proxy: Do not marshal twice
5ab3e0e test: Add proper pause binary path for tests using Hyperstart agent
5a24c61 test: Add custom flag to enable debug logs for benchmarks
811a45c test: Make benchmarks fail in case of error
23b7b2a test: Don't start an extra VM from api testing
a192e5a virtc: Add cc-shim support
fe1fead container: Add a function to retrieve the pod URL from a container
51a051d pod: Store proxy URL in pod State
028406f docs: Replace single dash with double dashes in README.md
5487e8f cc_proxy: Don't provide a token for the pause container
6ac8ac5 cnm: Fix sporadic netns issue related to wrong thread ID
c61426f pkg: oci: fix container rootfs path
ac92c3e virtc: Explain the "--id=" is set automatically by default.
f74bd13 filesystem: Improve comments on podResource.
17726a8 general: Add explicit checks on all possible function arguments.
9f78c02 arguments: Expand empty podID and containerID as early as possible.
bb8fe0d errors: Add additional standard errors.
73f5dff network: Add argument checks.
bb41d46 docs: Simplify call to "virtcontainers-setup.sh".
cc9656e docs: Improve Clear Containers image download details.
e6ec193 docs: Use latest clear containers repo for latest distros.
14513ae virtc: Introduce cc-proxy into README.md
2e921c9 virtc: Improve logging
c30472c proxy: Add unit testing
2ffd843 network: Add new unit tests
dc1898a api: Test CNM network
eb299de proxy: Clarify sendCmd() expected usage
9e46813 Makefile: Do not build all vendor packages
e68e30b virtc: Update README.md
9d46228 virtcontainers: Update README.md
69db637 travis: Exclude vendor/ directory from CI
e5ddb64 pkg: oci: Fix unit tests
fd22866 vendor: Vendor OCI runtime specification
7cbaf1e vendor: Initialize virtcontainers vendoring
43f9ecd pkg: oci: Allow logger to be defined by caller
58f86eb pkg: hyperstart: Allow logger to be defined by caller
c9156da virtcontainers: Allow logger to be defined by consumer of this package
1d848d2 pod: Remove Console field from PodConfig
ad21854 cc_proxy: Provide console path from hypervisor getPodConsole()
82fd7f9 hypervisor: qemu: Add and implement getPodConsole()
ca594f2 pkg: hyperstart: Wait for the end of the CTL channel
5714ad7 ci: Fix the build because of cni build name change
208bb0d virtcontainers: Replace glog by logrus logger
b061ae3 gitignore: Update the .gitignore file
de46d01 hyperstart: Stop generating sequence numbers for each process
1564bad cc_proxy: Move to proxy v3.0
db02bdc build: Make 'clean' idempotent
2d46c5e build: Don't cd back to the root directory after having compiled virtc
ac5adc4 travis: Add go_import_path directive
8ef0ee1 hyperstart: Rely on improved hyperstart package
ba1771d pkg: hyperstart: Export some functions for unit testing
a69bc75 pkg: hyperstart: Rely on improved hyperstart package
472119f pkg: hyperstart: Create structures for hyperstart protocol
a23f71f hyperstart: Skip IPv6 addresses
6e5e4ba cnm: Fix results from network interface scan
c76f5c3 qemu: Device IDs cannot be more than 31 bytes
c272be9 pkg: oci: Fix PodConfig filling
8effb86 hyperstart: Mount container rootfs inside "rootfs" directory
e5c3121 pause: remove SIGKILL handler
f1e6218 utils: Add a script setting up the environment for testing purpose
bce9c9d virtc: Check mandatory command-line arguments.
0d8d461 pkg: cni: Fix unit testing after CNI plugins update
0e39cb2 hyperstart: Fix IP netmask and route gateway
d0c0d75 cnm: Fill endpoints results with routes
29fd6d5 network: Factorize netlink creation and verification
30b82cc logger: Remove logger because not needed anymore
7ceffe5 network: Remove ciao/networking/libsnnet dependency
e36f357 pod: Enable pod console traces
4ff102f cnm: Interface list has to be scanned from inside the network namespace
f013c0a hyperstart: Setup network inside the VM
da3a495 syscall: Add checks for bind mount arguments.
da98a53 pkg: oci: Return OCI spec structure from PodConfig()
09fce7c pkg: oci: Rely on annotations to store/fetch OCI specific data
d9dbfe6 pod: Add Annotations fields to PodConfig
c8f47f6 syscall: Return full error details.
a1d3ccd cc_proxy: Parse a URL to connect the proxy
0ce79d4 pod: Retrieve pod URL and convey it through pod structure
fac3873 hyperstart: Remove sequence numbers, use token instead
af2a159 agent: Cleanup the interface using consistent parameters
4ee4cb8 agent: Add createContainer to store ProxyInfo
6624724 api: Return Process struct when executing new workload
eee4285 hyperstart: Move VM registration to startAgent()
1fce0ec proxy: Return ProxyInfo instead of IOStream
f3368fb container: Add public function to retrieve container process
07c61ef oci: Add a EnvVar slice conversion API
efd8eca filesystem: Remove unecessary calls to os.Stat().
d43b89e container: Add helper function for boilerplate code.
a314e86 hypervisor: Add Debug option to HypervisorConfig.
126a961 network: Make createNetworkEndpoint() return an error.
71ae569 oci: return more error details.
278ac66 filesystem: Remove duplication.
d92f476 tests: Try harder to ensure make ns path invalid
518357d tests: Skip tests that cannot be run as root.
f64805d tests: Add helper function createAndStartPod().
844d0e4 tests: Move TestMain() to new test file and make testDir a variable.
6f85e63 filesystem: Change storage path variables from const to var to allow tests to modify them.
ea44e3e pod: Remove redundant call to newAgent().
b2d3169 pod: Don't hard-code details in returned Errors.
ad2fbae oci: Use variable for directory perms.
8c3f194 oci: Fix config file permissions.
f47cf90 cni: Fix permissions for created directory.
db1998b files: Fix permissions on created directories.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>