### PR TITLE
api: Speed up container status query.

### DIFF
--- a/api.go
+++ b/api.go
@@ -630,8 +630,6 @@ func StatusContainer(podID, containerID string) (ContainerStatus, error) {
 		return ContainerStatus{}, errNeedContainerID
 	}
 
-	var contStatus ContainerStatus
-
 	pod, err := fetchPod(podID)
 	if err != nil {
 		return ContainerStatus{}, err
@@ -639,16 +637,17 @@ func StatusContainer(podID, containerID string) (ContainerStatus, error) {
 
 	for _, container := range pod.containers {
 		if container.id == containerID {
-			contStatus = ContainerStatus{
+			return ContainerStatus{
 				ID:     container.id,
 				State:  container.state,
 				PID:    container.process.Pid,
 				RootFs: container.config.RootFs,
-			}
+			}, nil
 		}
 	}
 
-	return contStatus, nil
+	// No matching containers in the pod
+	return ContainerStatus{}, nil
 }
 
 // KillContainer is the virtcontainers entry point to send a signal


### PR DESCRIPTION
StatusContainer() does not need to iterate through all containers after
it has found a matching container to return the status for.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>