### PR TITLE
hyperstart: Copy pause binary instead of creating a symbolic link

### DIFF
--- a/hyperstart.go
+++ b/hyperstart.go
@@ -195,7 +195,7 @@ func (h *hyper) buildNetworkInterfacesAndRoutes(pod Pod) ([]hyperstart.NetworkIf
 	return ifaces, routes, nil
 }
 
-func (h *hyper) linkPauseBinary(podID string) error {
+func (h *hyper) copyPauseBinary(podID string) error {
 	pauseDir := filepath.Join(defaultSharedDir, podID, pauseContainerName, rootfsDir)
 
 	if err := os.MkdirAll(pauseDir, dirMode); err != nil {
@@ -204,10 +204,10 @@ func (h *hyper) linkPauseBinary(podID string) error {
 
 	pausePath := filepath.Join(pauseDir, pauseBinName)
 
-	return os.Symlink(h.config.PauseBinPath, pausePath)
+	return fileCopy(h.config.PauseBinPath, pausePath)
 }
 
-func (h *hyper) unlinkPauseBinary(podID string) error {
+func (h *hyper) removePauseBinary(podID string) error {
 	pauseDir := filepath.Join(defaultSharedDir, podID, pauseContainerName)
 
 	return os.RemoveAll(pauseDir)
@@ -392,7 +392,7 @@ func (h *hyper) startPauseContainer(podID string) error {
 		Process: process,
 	}
 
-	if err := h.linkPauseBinary(podID); err != nil {
+	if err := h.copyPauseBinary(podID); err != nil {
 		return err
 	}
 
@@ -454,7 +454,7 @@ func (h *hyper) stopPauseContainer(podID string) error {
 		return err
 	}
 
-	if err := h.unlinkPauseBinary(podID); err != nil {
+	if err := h.removePauseBinary(podID); err != nil {
 		return err
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,43 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+const cpBinaryName = "cp"
+
+func fileCopy(srcPath, dstPath string) error {
+	if srcPath == "" {
+		return fmt.Errorf("Source path cannot be empty")
+	}
+
+	if dstPath == "" {
+		return fmt.Errorf("Destination path cannot be empty")
+	}
+
+	binPath, err := exec.LookPath(cpBinaryName)
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(binPath, srcPath, dstPath)
+
+	return cmd.Run()
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,118 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestFileCopySuccessful(t *testing.T) {
+	fileContent := "testContent"
+
+	srcFile, err := ioutil.TempFile("", "test_src_copy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(srcFile.Name())
+	defer srcFile.Close()
+
+	dstFile, err := ioutil.TempFile("", "test_dst_copy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(dstFile.Name())
+
+	dstPath := dstFile.Name()
+
+	if err := dstFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := srcFile.WriteString(fileContent); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fileCopy(srcFile.Name(), dstPath); err != nil {
+		t.Fatal(err)
+	}
+
+	dstContent, err := ioutil.ReadFile(dstPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(dstContent) != fileContent {
+		t.Fatalf("Got %q\nExpecting %q", string(dstContent), fileContent)
+	}
+
+	srcInfo, err := srcFile.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstInfo, err := os.Stat(dstPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if dstInfo.Mode() != srcInfo.Mode() {
+		t.Fatalf("Got FileMode %d\nExpecting FileMode %d", dstInfo.Mode(), srcInfo.Mode())
+	}
+
+	if dstInfo.IsDir() != srcInfo.IsDir() {
+		t.Fatalf("Got IsDir() = %t\nExpecting IsDir() = %t", dstInfo.IsDir(), srcInfo.IsDir())
+	}
+
+	if dstInfo.Size() != srcInfo.Size() {
+		t.Fatalf("Got Size() = %d\nExpecting Size() = %d", dstInfo.Size(), srcInfo.Size())
+	}
+}
+
+func TestFileCopySourceEmptyFailure(t *testing.T) {
+	if err := fileCopy("", "testDst"); err == nil {
+		t.Fatal("This test should fail because source path is empty")
+	}
+}
+
+func TestFileCopyDestinationEmptyFailure(t *testing.T) {
+	if err := fileCopy("testSrc", ""); err == nil {
+		t.Fatal("This test should fail because destination path is empty")
+	}
+}
+
+func TestFileCopySourceNotExistFailure(t *testing.T) {
+	srcFile, err := ioutil.TempFile("", "test_src_copy")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srcPath := srcFile.Name()
+
+	if err := srcFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Remove(srcPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fileCopy(srcPath, "testDest"); err == nil {
+		t.Fatal("This test should fail because source file does not exist")
+	}
+}


### PR DESCRIPTION
Initially we used a hardlink to create the pause binary to the needed location so that our pause container could use it from inside the VM. But hardlink had a limitation regarding cross partitions, and that's the reason we moved to symbolic link.

But symbolic links are not evaluated when the pause container rootfs was mounted, resulting in having the pause binary missing.

The only way to properly deal with those issues is to copy the binary to the expected location.