### PR TITLE
qemu: Fix benchmarks issues related to VM root cause

### DIFF
--- a/qemu.go
+++ b/qemu.go
@@ -25,6 +25,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	ciaoQemu "github.com/01org/ciao/qemu"
 	"github.com/01org/ciao/ssntp/uuid"
@@ -514,7 +515,19 @@ func (q *qemu) stopPod() error {
 		return err
 	}
 
-	return qmp.ExecuteQuit(q.qmpMonitorCh.ctx)
+	if err := qmp.ExecuteQuit(q.qmpMonitorCh.ctx); err != nil {
+		return err
+	}
+
+	// Wait for the VM disconnection notification
+	select {
+	case <-q.qmpControlCh.disconnectCh:
+		break
+	case <-time.After(time.Second):
+		return fmt.Errorf("Did not receive the VM disconnection notification")
+	}
+
+	return nil
 }
 
 // addDevice will add extra devices to Qemu command line.

--- a/qemu.go
+++ b/qemu.go
@@ -206,6 +206,8 @@ func (q *qemu) appendNetworks(devices []ciaoQemu.Device, endpoints []Endpoint) [
 				ID:         fmt.Sprintf("network-%d", idx),
 				IFName:     endpoint.NetPair.TAPIface.Name,
 				MACAddress: endpoint.NetPair.VirtIface.HardAddr,
+				DownScript: "no",
+				Script:     "no",
 			},
 		)
 	}


### PR DESCRIPTION
After we sent the QUIT command through QMP socket to the VM, we were just returning, assuming the VM was stopped. But in some cases, it can take a little bit more time for the VM to stop, causing issues with our benchmarks. Indeed, running the same VM with the same UUID was conflicting and the QMP sockets were not created because the previous VM with the same UUID was not stopped. This patch waits for a go channel indicating QMP socket has been disconnected, meaning the "real" end of the VM.

Fixes #199.