### PR TITLE
Add QEMU Q35 machine type support

### DIFF
--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -61,6 +61,12 @@ var podConfigFlags = []cli.Flag{
 		Usage: "the guest spawner",
 	},
 
+	cli.StringFlag{
+		Name:  "machine-type",
+		Value: "",
+		Usage: "hypervisor machine type",
+	},
+
 	cli.GenericFlag{
 		Name:  "network",
 		Value: new(vc.NetworkModel),
@@ -213,9 +219,10 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 	}
 
 	hypervisorConfig := vc.HypervisorConfig{
-		KernelPath:     "/usr/share/clear-containers/vmlinux.container",
-		ImagePath:      "/usr/share/clear-containers/clear-containers.img",
-		HypervisorPath: "/usr/bin/qemu-lite-system-x86_64",
+		KernelPath:            "/usr/share/clear-containers/vmlinux.container",
+		ImagePath:             "/usr/share/clear-containers/clear-containers.img",
+		HypervisorPath:        "/usr/bin/qemu-lite-system-x86_64",
+		HypervisorMachineType: context.String("machine-type"),
 	}
 
 	netConfig := vc.NetworkConfig{

--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -63,7 +63,7 @@ var podConfigFlags = []cli.Flag{
 
 	cli.StringFlag{
 		Name:  "machine-type",
-		Value: "",
+		Value: vc.QemuPCLite,
 		Usage: "hypervisor machine type",
 	},
 
@@ -221,7 +221,6 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 	hypervisorConfig := vc.HypervisorConfig{
 		KernelPath:            "/usr/share/clear-containers/vmlinux.container",
 		ImagePath:             "/usr/share/clear-containers/clear-containers.img",
-		HypervisorPath:        "/usr/bin/qemu-lite-system-x86_64",
 		HypervisorMachineType: context.String("machine-type"),
 	}
 

--- a/hypervisor.go
+++ b/hypervisor.go
@@ -118,6 +118,10 @@ type HypervisorConfig struct {
 	// HypervisorParams are additional hypervisor parameters.
 	HypervisorParams []Param
 
+	// HypervisorMachineType specifies the type of machine being
+	// emulated.
+	HypervisorMachineType string
+
 	// Debug changes the default hypervisor and kernel parameters to
 	// enable debug output where available.
 	Debug bool

--- a/hypervisor.go
+++ b/hypervisor.go
@@ -136,10 +136,6 @@ func (conf *HypervisorConfig) valid() (bool, error) {
 		return false, fmt.Errorf("Missing image path")
 	}
 
-	if conf.HypervisorPath == "" {
-		return false, fmt.Errorf("Missing hypervisor path")
-	}
-
 	return true, nil
 }
 

--- a/hypervisor_test.go
+++ b/hypervisor_test.go
@@ -149,7 +149,7 @@ func TestHypervisorConfigNoHypervisorPath(t *testing.T) {
 		HypervisorPath: "",
 	}
 
-	testHypervisorConfigValid(t, hypervisorConfig, false)
+	testHypervisorConfigValid(t, hypervisorConfig, true)
 }
 
 func TestHypervisorConfigIsValid(t *testing.T) {

--- a/qemu.go
+++ b/qemu.go
@@ -55,6 +55,19 @@ type qemu struct {
 
 const defaultQemuPath = "/usr/bin/qemu-system-x86_64"
 
+const defaultQemuMachineType = "pc-lite"
+
+var supportedQemuMachines = []ciaoQemu.Machine{
+	{
+		Type:         defaultQemuMachineType,
+		Acceleration: "kvm,kernel_irqchip,nvdimm",
+	},
+	{
+		Type:         "q35",
+		Acceleration: "kvm,kernel_irqchip,nvdimm,nosmm,nosmbus,nosata,nopit,nofw",
+	},
+}
+
 const (
 	defaultSockets uint32 = 1
 	defaultThreads uint32 = 1
@@ -311,6 +324,16 @@ func (q *qemu) forceUUIDFormat(str string) string {
 	return uuidSlice.String()
 }
 
+func (q *qemu) getMachine(name string) (ciaoQemu.Machine, error) {
+	for _, m := range supportedQemuMachines {
+		if m.Type == name {
+			return m, nil
+		}
+	}
+
+	return ciaoQemu.Machine{}, fmt.Errorf("unrecognised machine type: %v", name)
+}
+
 // init intializes the Qemu structure.
 func (q *qemu) init(config HypervisorConfig) error {
 	valid, err := config.valid()
@@ -402,9 +425,14 @@ func (q *qemu) setMemoryResources(podConfig PodConfig) ciaoQemu.Memory {
 func (q *qemu) createPod(podConfig PodConfig) error {
 	var devices []ciaoQemu.Device
 
-	machine := ciaoQemu.Machine{
-		Type:         "pc-lite",
-		Acceleration: "kvm,kernel_irqchip,nvdimm",
+	machineType := q.config.HypervisorMachineType
+	if machineType == "" {
+		machineType = defaultQemuMachineType
+	}
+
+	machine, err := q.getMachine(machineType)
+	if err != nil {
+		return err
 	}
 
 	smp := q.setCPUResources(podConfig)
@@ -455,7 +483,7 @@ func (q *qemu) createPod(podConfig PodConfig) error {
 
 	devices = q.appendFSDevices(devices, podConfig)
 	devices = q.appendConsoles(devices, podConfig)
-	devices, err := q.appendImage(devices, podConfig)
+	devices, err = q.appendImage(devices, podConfig)
 	if err != nil {
 		return err
 	}

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -459,3 +459,45 @@ func TestQemuGetPodConsole(t *testing.T) {
 		t.Fatalf("Got %s\nExpecting %s", result, expected)
 	}
 }
+
+func TestQemuMachineTypes(t *testing.T) {
+	type testData struct {
+		machineType string
+		expectValid bool
+	}
+
+	data := []testData{
+		{"pc-lite", true},
+		{"q35", true},
+
+		{"PC-LITE", false},
+		{"Q35", false},
+		{"", false},
+		{" ", false},
+		{".", false},
+		{"0", false},
+		{"1", false},
+		{"-1", false},
+		{"bon", false},
+	}
+
+	q := &qemu{}
+
+	for _, d := range data {
+		m, err := q.getMachine(d.machineType)
+
+		if d.expectValid == true {
+			if err != nil {
+				t.Fatalf("machine type %v unexpectedly invalid: %v", d.machineType, err)
+			}
+
+			if m.Type != d.machineType {
+				t.Fatalf("expected machine type %v, got %v", d.machineType, m.Type)
+			}
+		} else {
+			if err == nil {
+				t.Fatalf("machine type %v unexpectedly valid", d.machineType)
+			}
+		}
+	}
+}


### PR DESCRIPTION
`Q35` is a more standard and upstream QEMU machine type that is a reasonably good alternative to `pc-lite`.
We now support it through virtcontainers, although the default machine type is still `pc-lite`.