### PR TITLE
network: Fix benchmarks sporadic issues with netns

### DIFF
--- a/cnm.go
+++ b/cnm.go
@@ -181,7 +181,7 @@ func (n *cnm) run(networkNSPath string, cb func() error) error {
 		return fmt.Errorf("networkNSPath cannot be empty")
 	}
 
-	return safeDoNetNS(networkNSPath, func(_ ns.NetNS) error {
+	return doNetNS(networkNSPath, func(_ ns.NetNS) error {
 		return cb()
 	})
 }


### PR DESCRIPTION
This commit gets rid of doNetNS() function as it is too complex and it introduces some sporadic issues related to the use of go routines and network namespaces at the same time. The cause of those issues
is about some processes/threads changing during the runtime, causing some confusion with the network namespaces used.

The only way is to really make sure everything is controlled by our library, meaning we make all of our network implementations rely on the same "safe" function safeDoNetNS(). This patch also improves this
function by calling into runtime.LockOSThread(). This implies that no matter who is the caller of this function, it will end up in the expected network namespace with the guarantee the thread won't change
during the execution.

This is solving all sporadic issues related to the usage of network namespaces that have been found with the benchmarks.

Fixes #219 