### PR TITLE
network: Fix wrong MAC address configuration

### DIFF
--- a/cni.go
+++ b/cni.go
@@ -17,7 +17,6 @@
 package virtcontainers
 
 import (
-	"github.com/containernetworking/cni/pkg/ns"
 	cniPlugin "github.com/containers/virtcontainers/pkg/cni"
 )
 
@@ -62,26 +61,12 @@ func (n *cni) deleteVirtInterfaces(networkNS NetworkNamespace) error {
 
 // init initializes the network, setting a new network namespace for the CNI network.
 func (n *cni) init(config *NetworkConfig) error {
-	if config.NetNSPath == "" {
-		path, err := createNetNS()
-		if err != nil {
-			return err
-		}
-
-		config.NetNSPath = path
-	}
-
-	return nil
+	return initNetworkCommon(config)
 }
 
 // run runs a callback in the specified network namespace.
-// run does not switch the current process to the specified network namespace
-// for the CNI network. Indeed, the switch will occur in the add() and remove()
-// functions instead.
 func (n *cni) run(networkNSPath string, cb func() error) error {
-	return doNetNS(networkNSPath, func(_ ns.NetNS) error {
-		return cb()
-	})
+	return runNetworkCommon(networkNSPath, cb)
 }
 
 // add adds all needed interfaces inside the network namespace for the CNI network.
@@ -96,26 +81,11 @@ func (n *cni) add(pod Pod, config NetworkConfig) (NetworkNamespace, error) {
 		Endpoints: endpoints,
 	}
 
-	err = n.addVirtInterfaces(&networkNS)
-	if err != nil {
+	if err := n.addVirtInterfaces(&networkNS); err != nil {
 		return NetworkNamespace{}, err
 	}
 
-	err = doNetNS(networkNS.NetNsPath, func(_ ns.NetNS) error {
-		for idx := range networkNS.Endpoints {
-			if err := bridgeNetworkPair(&(networkNS.Endpoints[idx].NetPair)); err != nil {
-				return err
-			}
-		}
-
-		return nil
-	})
-	if err != nil {
-		return NetworkNamespace{}, err
-	}
-
-	err = addNetDevHypervisor(pod, networkNS.Endpoints)
-	if err != nil {
+	if err := addNetworkCommon(pod, &networkNS); err != nil {
 		return NetworkNamespace{}, err
 	}
 
@@ -125,29 +95,13 @@ func (n *cni) add(pod Pod, config NetworkConfig) (NetworkNamespace, error) {
 // remove unbridges and deletes TAP interfaces. It also removes virtual network
 // interfaces and deletes the network namespace for the CNI network.
 func (n *cni) remove(pod Pod, networkNS NetworkNamespace) error {
-	err := doNetNS(networkNS.NetNsPath, func(_ ns.NetNS) error {
-		for _, endpoint := range networkNS.Endpoints {
-			err := unBridgeNetworkPair(endpoint.NetPair)
-			if err != nil {
-				return err
-			}
-		}
-
-		return nil
-	})
-	if err != nil {
+	if err := removeNetworkCommon(networkNS); err != nil {
 		return err
 	}
 
-	err = n.deleteVirtInterfaces(networkNS)
-	if err != nil {
+	if err := n.deleteVirtInterfaces(networkNS); err != nil {
 		return err
 	}
 
-	err = deleteNetNS(networkNS.NetNsPath, true)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return deleteNetNS(networkNS.NetNsPath, true)
 }

--- a/cni.go
+++ b/cni.go
@@ -102,9 +102,8 @@ func (n *cni) add(pod Pod, config NetworkConfig) (NetworkNamespace, error) {
 	}
 
 	err = doNetNS(networkNS.NetNsPath, func(_ ns.NetNS) error {
-		for _, endpoint := range networkNS.Endpoints {
-			err = bridgeNetworkPair(endpoint.NetPair)
-			if err != nil {
+		for idx := range networkNS.Endpoints {
+			if err := bridgeNetworkPair(&(networkNS.Endpoints[idx].NetPair)); err != nil {
 				return err
 			}
 		}

--- a/cnm.go
+++ b/cnm.go
@@ -21,7 +21,6 @@ import (
 	"net"
 
 	"github.com/01org/ciao/ssntp/uuid"
-	"github.com/containernetworking/cni/pkg/ns"
 	cniTypes "github.com/containernetworking/cni/pkg/types"
 	types "github.com/containernetworking/cni/pkg/types/current"
 	"github.com/vishvananda/netlink"
@@ -159,31 +158,12 @@ func (n *cnm) createEndpointsFromScan(networkNSPath string) ([]Endpoint, error) 
 
 // init initializes the network, setting a new network namespace for the CNM network.
 func (n *cnm) init(config *NetworkConfig) error {
-	if config == nil {
-		return fmt.Errorf("config cannot be empty")
-	}
-
-	if config.NetNSPath == "" {
-		path, err := createNetNS()
-		if err != nil {
-			return err
-		}
-
-		config.NetNSPath = path
-	}
-
-	return nil
+	return initNetworkCommon(config)
 }
 
 // run runs a callback in the specified network namespace.
 func (n *cnm) run(networkNSPath string, cb func() error) error {
-	if networkNSPath == "" {
-		return fmt.Errorf("networkNSPath cannot be empty")
-	}
-
-	return doNetNS(networkNSPath, func(_ ns.NetNS) error {
-		return cb()
-	})
+	return runNetworkCommon(networkNSPath, cb)
 }
 
 // add adds all needed interfaces inside the network namespace for the CNM network.
@@ -198,21 +178,7 @@ func (n *cnm) add(pod Pod, config NetworkConfig) (NetworkNamespace, error) {
 		Endpoints: endpoints,
 	}
 
-	err = doNetNS(networkNS.NetNsPath, func(_ ns.NetNS) error {
-		for idx := range networkNS.Endpoints {
-			if err := bridgeNetworkPair(&(networkNS.Endpoints[idx].NetPair)); err != nil {
-				return err
-			}
-		}
-
-		return nil
-	})
-	if err != nil {
-		return NetworkNamespace{}, err
-	}
-
-	err = addNetDevHypervisor(pod, networkNS.Endpoints)
-	if err != nil {
+	if err := addNetworkCommon(pod, &networkNS); err != nil {
 		return NetworkNamespace{}, err
 	}
 
@@ -222,24 +188,9 @@ func (n *cnm) add(pod Pod, config NetworkConfig) (NetworkNamespace, error) {
 // remove unbridges and deletes TAP interfaces. It also removes virtual network
 // interfaces and deletes the network namespace for the CNM network.
 func (n *cnm) remove(pod Pod, networkNS NetworkNamespace) error {
-	err := doNetNS(networkNS.NetNsPath, func(_ ns.NetNS) error {
-		for _, endpoint := range networkNS.Endpoints {
-			err := unBridgeNetworkPair(endpoint.NetPair)
-			if err != nil {
-				return err
-			}
-		}
-
-		return nil
-	})
-	if err != nil {
+	if err := removeNetworkCommon(networkNS); err != nil {
 		return err
 	}
 
-	err = deleteNetNS(networkNS.NetNsPath, true)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return deleteNetNS(networkNS.NetNsPath, true)
 }

--- a/cnm.go
+++ b/cnm.go
@@ -199,9 +199,8 @@ func (n *cnm) add(pod Pod, config NetworkConfig) (NetworkNamespace, error) {
 	}
 
 	err = doNetNS(networkNS.NetNsPath, func(_ ns.NetNS) error {
-		for _, endpoint := range networkNS.Endpoints {
-			err := bridgeNetworkPair(endpoint.NetPair)
-			if err != nil {
+		for idx := range networkNS.Endpoints {
+			if err := bridgeNetworkPair(&(networkNS.Endpoints[idx].NetPair)); err != nil {
 				return err
 			}
 		}

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -166,7 +166,7 @@ func (h *hyper) buildNetworkInterfacesAndRoutes(pod Pod) ([]hyperstart.NetworkIf
 			NewDevice:   endpoint.NetPair.VirtIface.Name,
 			IPAddresses: ipAddrs,
 			MTU:         fmt.Sprintf("%d", netIface.MTU),
-			MACAddr:     endpoint.NetPair.VirtIface.HardAddr,
+			MACAddr:     endpoint.NetPair.TAPIface.HardAddr,
 		}
 
 		ifaces = append(ifaces, iface)

--- a/network.go
+++ b/network.go
@@ -126,6 +126,63 @@ func newNetwork(networkType NetworkModel) network {
 	}
 }
 
+func initNetworkCommon(config *NetworkConfig) error {
+	if config == nil {
+		return fmt.Errorf("config cannot be empty")
+	}
+
+	if config.NetNSPath == "" {
+		path, err := createNetNS()
+		if err != nil {
+			return err
+		}
+
+		config.NetNSPath = path
+	}
+
+	return nil
+}
+
+func runNetworkCommon(networkNSPath string, cb func() error) error {
+	if networkNSPath == "" {
+		return fmt.Errorf("networkNSPath cannot be empty")
+	}
+
+	return doNetNS(networkNSPath, func(_ ns.NetNS) error {
+		return cb()
+	})
+}
+
+func addNetworkCommon(pod Pod, networkNS *NetworkNamespace) error {
+	err := doNetNS(networkNS.NetNsPath, func(_ ns.NetNS) error {
+		for idx := range networkNS.Endpoints {
+			if err := bridgeNetworkPair(&(networkNS.Endpoints[idx].NetPair)); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return addNetDevHypervisor(pod, networkNS.Endpoints)
+}
+
+func removeNetworkCommon(networkNS NetworkNamespace) error {
+	return doNetNS(networkNS.NetNsPath, func(_ ns.NetNS) error {
+		for _, endpoint := range networkNS.Endpoints {
+			err := unBridgeNetworkPair(endpoint.NetPair)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
 func createLink(netHandle *netlink.Handle, name string, expectedLink netlink.Link) (netlink.Link, error) {
 	var newLink netlink.Link
 

--- a/network.go
+++ b/network.go
@@ -177,7 +177,7 @@ func getLinkByName(netHandle *netlink.Handle, name string, expectedLink netlink.
 	return nil, fmt.Errorf("Incorrect link type %s, expecting %s", link.Type(), expectedLink.Type())
 }
 
-func bridgeNetworkPair(netPair NetworkInterfacePair) error {
+func bridgeNetworkPair(netPair *NetworkInterfacePair) error {
 	netHandle, err := netlink.NewHandle()
 	if err != nil {
 		return err
@@ -192,6 +192,19 @@ func bridgeNetworkPair(netPair NetworkInterfacePair) error {
 	vethLink, err := getLinkByName(netHandle, netPair.VirtIface.Name, &netlink.Veth{})
 	if err != nil {
 		return fmt.Errorf("Could not get veth interface: %s", err)
+	}
+
+	vethLinkAttrs := vethLink.Attrs()
+
+	// Save the veth MAC address to the TAP so that it can later be used
+	// to build the hypervisor command line. This MAC address has to be
+	// the one inside the VM in order to avoid any firewall issues. The
+	// bridge created by the network plugin on the host actually expects
+	// to see traffic from this MAC address and not another one.
+	netPair.TAPIface.HardAddr = vethLinkAttrs.HardwareAddr.String()
+
+	if err := netHandle.LinkSetMTU(tapLink, vethLinkAttrs.MTU); err != nil {
+		return fmt.Errorf("Could not set TAP MTU %d: %s", vethLinkAttrs.MTU, err)
 	}
 
 	hardAddr, err := net.ParseMAC(netPair.VirtIface.HardAddr)

--- a/qemu.go
+++ b/qemu.go
@@ -233,7 +233,7 @@ func (q *qemu) appendNetworks(devices []ciaoQemu.Device, endpoints []Endpoint) [
 				Driver:     ciaoQemu.VirtioNetPCI,
 				ID:         fmt.Sprintf("network-%d", idx),
 				IFName:     endpoint.NetPair.TAPIface.Name,
-				MACAddress: endpoint.NetPair.VirtIface.HardAddr,
+				MACAddress: endpoint.NetPair.TAPIface.HardAddr,
 				DownScript: "no",
 				Script:     "no",
 			},


### PR DESCRIPTION
We were not able to ping the network plugin bridge from inside the container, meaning something was not properly configured. Indeed, we were assigning the same MAC address to the veth inside the network namespace and to the network interface inside the VM.

The right thing to do is to retrieve the MAC address of the veth after it has been created by the network plugin, then assign it to the network interface inside the VM, and reset the veth MAC to a random one. That way, we make sure the traffic will be seen by the network bridge on the host (cni0 or docker0 for instance) as if it was coming from the veth pair MAC address. But the reality is that those packets actually come from inside the VM.