### PR TITLE
api: Make StatusPod() call StatusContainer().

### DIFF
--- a/api.go
+++ b/api.go
@@ -370,11 +370,9 @@ func StatusPod(podID string) (PodStatus, error) {
 
 	var contStatusList []ContainerStatus
 	for _, container := range pod.containers {
-		contStatus := ContainerStatus{
-			ID:     container.id,
-			State:  container.state,
-			PID:    container.process.Pid,
-			RootFs: container.config.RootFs,
+		contStatus, err := StatusContainer(podID, container.id)
+		if err != nil {
+			return PodStatus{}, err
 		}
 
 		contStatusList = append(contStatusList, contStatus)

--- a/api_test.go
+++ b/api_test.go
@@ -562,6 +562,29 @@ func TestStatusPodSuccessful(t *testing.T) {
 
 	config := newTestPodConfigNoop()
 
+	expectedStatus := PodStatus{
+		ID: testPodID,
+		State: State{
+			State: StateReady,
+			URL:   "noopProxyURL",
+		},
+		Hypervisor:  MockHypervisor,
+		Agent:       NoopAgentType,
+		Annotations: podAnnotations,
+		ContainersStatus: []ContainerStatus{
+			{
+				ID: containerID,
+				State: State{
+					State: StateReady,
+					URL:   "",
+				},
+				PID:         0,
+				RootFs:      filepath.Join(testDir, testBundle),
+				Annotations: containerAnnotations,
+			},
+		},
+	}
+
 	p, err := CreatePod(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
@@ -572,8 +595,8 @@ func TestStatusPodSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if reflect.DeepEqual(config.Annotations, status.Annotations) == false {
-		t.Fatalf("Got annotations %v\n expecting %v", status.Annotations, config.Annotations)
+	if reflect.DeepEqual(status, expectedStatus) == false {
+		t.Fatalf("Got pod status %v\n expecting %v", status, expectedStatus)
 	}
 }
 


### PR DESCRIPTION
StatusPod() was constructing ContainerStatus objects, which is the job
of StatusContainer().

Previously, StatusContainer() was returning an array of
ContainerStatus's *without* the required container Annotations.

Updated TestStatusPodSuccessful() to test full PodStatus returned by
StatusPod().

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>