### PR TITLE
Add process starttime for runtime list

### DIFF
--- a/api.go
+++ b/api.go
@@ -640,6 +640,7 @@ func StatusContainer(podID, containerID string) (ContainerStatus, error) {
 				ID:          container.id,
 				State:       container.state,
 				PID:         container.process.Pid,
+				StartTime:   container.process.StartTime,
 				RootFs:      container.config.RootFs,
 				Annotations: container.config.Annotations,
 			}, nil

--- a/api_test.go
+++ b/api_test.go
@@ -595,6 +595,10 @@ func TestStatusPodSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Copy the start time as we can't pretend we know what that
+	// value will be.
+	expectedStatus.ContainersStatus[0].StartTime = status.ContainersStatus[0].StartTime
+
 	if reflect.DeepEqual(status, expectedStatus) == false {
 		t.Fatalf("Got pod status %v\n expecting %v", status, expectedStatus)
 	}
@@ -1328,6 +1332,10 @@ func TestStatusContainerSuccessful(t *testing.T) {
 	status, err := StatusContainer(p.id, contID)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if status.StartTime.Equal(c.process.StartTime) == false {
+		t.Fatalf("Got container start time %v, expecting %v", status.StartTime, c.process.StartTime)
 	}
 
 	if reflect.DeepEqual(p.config.Containers[0].Annotations, status.Annotations) == false {

--- a/container.go
+++ b/container.go
@@ -21,20 +21,23 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
+	"time"
 )
 
 // Process gathers data related to a container process.
 type Process struct {
-	Token string
-	Pid   int
+	Token     string
+	Pid       int
+	StartTime time.Time
 }
 
 // ContainerStatus describes a container status.
 type ContainerStatus struct {
-	ID     string
-	State  State
-	PID    int
-	RootFs string
+	ID        string
+	State     State
+	PID       int
+	StartTime time.Time
+	RootFs    string
 
 	// Annotations allow clients to store arbitrary values,
 	// for example to add additional status values required
@@ -504,8 +507,9 @@ func (c *Container) createShimProcess(token, url, console string) (*Process, err
 	}
 
 	process := &Process{
-		Token: token,
-		Pid:   pid,
+		Token:     token,
+		Pid:       pid,
+		StartTime: time.Now().UTC(),
 	}
 
 	return process, nil


### PR DESCRIPTION
The container start time is approximate but is useful for runtime implementations. Particularly, it is needed to implement the "list" command for the OCI runtime.