### PR TITLE
api: Remove call to fetchPod().

### DIFF
--- a/api.go
+++ b/api.go
@@ -370,7 +370,7 @@ func StatusPod(podID string) (PodStatus, error) {
 
 	var contStatusList []ContainerStatus
 	for _, container := range pod.containers {
-		contStatus, err := StatusContainer(podID, container.id)
+		contStatus, err := statusContainer(pod, container.id)
 		if err != nil {
 			return PodStatus{}, err
 		}
@@ -634,6 +634,10 @@ func StatusContainer(podID, containerID string) (ContainerStatus, error) {
 		return ContainerStatus{}, err
 	}
 
+	return statusContainer(pod, containerID)
+}
+
+func statusContainer(pod *Pod, containerID string) (ContainerStatus, error) {
 	for _, container := range pod.containers {
 		if container.id == containerID {
 			return ContainerStatus{


### PR DESCRIPTION
StatusPod() was calling StatusContainer(), but both were calling
fetchPod() for the same pod.

Introduce statusContainer() that accepts a Pod to avoid the double call.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>