### PR TITLE
api: Add HypervisorConfig to PodStatus.

### DIFF
--- a/api.go
+++ b/api.go
@@ -382,6 +382,7 @@ func StatusPod(podID string) (PodStatus, error) {
 		ID:               pod.id,
 		State:            pod.state,
 		Hypervisor:       pod.config.HypervisorType,
+		HypervisorConfig: pod.config.HypervisorConfig,
 		Agent:            pod.config.AgentType,
 		ContainersStatus: contStatusList,
 		Annotations:      pod.config.Annotations,

--- a/api_test.go
+++ b/api_test.go
@@ -561,6 +561,11 @@ func TestStatusPodSuccessful(t *testing.T) {
 	cleanUp()
 
 	config := newTestPodConfigNoop()
+	hypervisorConfig := HypervisorConfig{
+		KernelPath:     filepath.Join(testDir, testKernel),
+		ImagePath:      filepath.Join(testDir, testImage),
+		HypervisorPath: filepath.Join(testDir, testHypervisor),
+	}
 
 	expectedStatus := PodStatus{
 		ID: testPodID,
@@ -568,9 +573,10 @@ func TestStatusPodSuccessful(t *testing.T) {
 			State: StateReady,
 			URL:   "noopProxyURL",
 		},
-		Hypervisor:  MockHypervisor,
-		Agent:       NoopAgentType,
-		Annotations: podAnnotations,
+		Hypervisor:       MockHypervisor,
+		HypervisorConfig: hypervisorConfig,
+		Agent:            NoopAgentType,
+		Annotations:      podAnnotations,
 		ContainersStatus: []ContainerStatus{
 			{
 				ID: containerID,

--- a/pod.go
+++ b/pod.go
@@ -246,6 +246,7 @@ type PodStatus struct {
 	ID               string
 	State            State
 	Hypervisor       HypervisorType
+	HypervisorConfig HypervisorConfig
 	Agent            AgentType
 	ContainersStatus []ContainerStatus
 


### PR DESCRIPTION
Added hypervisor configuration to PodStatus. The latter already held the
hypervisor type but adding the configuration will allow runtimes to
implement richer "list" and "state" commands which include hypervisor
configuration details.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>