### PR TITLE
tests: Fix-up for Container start time.

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -1402,6 +1402,10 @@ func TestStatusContainer(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Copy the start time as we can't pretend we know what that
+	// value will be.
+	expectedStatus.StartTime = status.StartTime
+
 	if reflect.DeepEqual(status, expectedStatus) == false {
 		t.Fatalf("Got container status %v, expected %v", status, expectedStatus)
 	}


### PR DESCRIPTION
Stop TestStatusContainer() from failing due to a missing container start
time.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>