### PR TITLE
container: Create function to create a Process.

### DIFF
--- a/container.go
+++ b/container.go
@@ -506,11 +506,15 @@ func (c *Container) createShimProcess(token, url, console string) (*Process, err
 		return &Process{}, err
 	}
 
-	process := &Process{
+	process := newProcess(token, pid)
+
+	return &process, nil
+}
+
+func newProcess(token string, pid int) Process {
+	return Process{
 		Token:     token,
 		Pid:       pid,
 		StartTime: time.Now().UTC(),
 	}
-
-	return process, nil
 }

--- a/pod.go
+++ b/pod.go
@@ -661,10 +661,7 @@ func (p *Pod) startShims() error {
 			return err
 		}
 
-		p.containers[idx].process = Process{
-			Token: proxyInfos[idx].Token,
-			Pid:   pid,
-		}
+		p.containers[idx].process = newProcess(proxyInfos[idx].Token, pid)
 
 		if err := p.containers[idx].storeProcess(); err != nil {
 			return err


### PR DESCRIPTION
Previously, Process objects were created in separate parts of the code,
but were not consistent (only one set Process.StartTime).

Introduce newProcess() to centralise the creation of these objects.

Fixes #252.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>