### PR TITLE
oci: Make OCI config file and bundle directory paths public.

### DIFF
--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -32,11 +32,11 @@ var (
 	// ErrNoLinux is an error for missing Linux sections in the OCI configuration file.
 	ErrNoLinux = errors.New("missing Linux section")
 
-	// ociConfigPathKey is the annotation key to fetch the OCI configuration file path.
-	ociConfigPathKey = "com.github.containers.virtcontainers.pkg.oci.config_path"
+	// ConfigPathKey is the annotation key to fetch the OCI configuration file path.
+	ConfigPathKey = "com.github.containers.virtcontainers.pkg.oci.config_path"
 
-	// ociBundlePathKey is the annotation key to fetch the OCI configuration file path.
-	ociBundlePathKey = "com.github.containers.virtcontainers.pkg.oci.bundle_path"
+	// BundlePathKey is the annotation key to fetch the OCI configuration file path.
+	BundlePathKey = "com.github.containers.virtcontainers.pkg.oci.bundle_path"
 )
 
 // RuntimeConfig aggregates all runtime specific settings
@@ -183,8 +183,8 @@ func PodConfig(runtime RuntimeConfig, bundlePath, cid, console string) (*vc.PodC
 		RootFs: rootfs,
 		Cmd:    cmd,
 		Annotations: map[string]string{
-			ociConfigPathKey: configPath,
-			ociBundlePathKey: bundlePath,
+			ConfigPathKey: configPath,
+			BundlePathKey: bundlePath,
 		},
 	}
 
@@ -236,7 +236,7 @@ func StatusToOCIState(status vc.PodStatus) (spec.State, error) {
 		ID:          status.ID,
 		Status:      stateToOCIState(status.ContainersStatus[0].State),
 		Pid:         status.ContainersStatus[0].PID,
-		Bundle:      status.ContainersStatus[0].Annotations[ociBundlePathKey],
+		Bundle:      status.ContainersStatus[0].Annotations[BundlePathKey],
 		Annotations: status.ContainersStatus[0].Annotations,
 	}
 
@@ -296,7 +296,7 @@ func EnvVars(envs []string) ([]vc.EnvVar, error) {
 // PodToOCIConfig returns an OCI spec configuration from the annotation
 // stored into the pod.
 func PodToOCIConfig(pod vc.Pod) (spec.Spec, error) {
-	ociConfigPath, err := pod.Annotations(ociConfigPathKey)
+	ociConfigPath, err := pod.Annotations(ConfigPathKey)
 	if err != nil {
 		return spec.Spec{}, err
 	}

--- a/pkg/oci/utils_test.go
+++ b/pkg/oci/utils_test.go
@@ -85,8 +85,8 @@ func TestMinimalPodConfig(t *testing.T) {
 		RootFs: path.Join(tempBundlePath, "rootfs"),
 		Cmd:    expectedCmd,
 		Annotations: map[string]string{
-			ociConfigPathKey: configPath,
-			ociBundlePathKey: tempBundlePath,
+			ConfigPathKey: configPath,
+			BundlePathKey: tempBundlePath,
 		},
 	}
 
@@ -150,8 +150,8 @@ func TestStatusToOCIStateSuccessfulWithReadyState(t *testing.T) {
 	}
 
 	containerAnnotations := map[string]string{
-		ociConfigPathKey: configPath,
-		ociBundlePathKey: tempBundlePath,
+		ConfigPathKey: configPath,
+		BundlePathKey: tempBundlePath,
 	}
 
 	cStatuses := []vc.ContainerStatus{
@@ -201,8 +201,8 @@ func TestStatusToOCIStateSuccessfulWithRunningState(t *testing.T) {
 	}
 
 	containerAnnotations := map[string]string{
-		ociConfigPathKey: configPath,
-		ociBundlePathKey: tempBundlePath,
+		ConfigPathKey: configPath,
+		BundlePathKey: tempBundlePath,
 	}
 
 	cStatuses := []vc.ContainerStatus{
@@ -252,8 +252,8 @@ func TestStatusToOCIStateSuccessfulWithStoppedState(t *testing.T) {
 	}
 
 	containerAnnotations := map[string]string{
-		ociConfigPathKey: configPath,
-		ociBundlePathKey: tempBundlePath,
+		ConfigPathKey: configPath,
+		BundlePathKey: tempBundlePath,
 	}
 
 	cStatuses := []vc.ContainerStatus{
@@ -299,8 +299,8 @@ func TestStatusToOCIStateSuccessfulWithNoState(t *testing.T) {
 	testRootFs := "testRootFs"
 
 	containerAnnotations := map[string]string{
-		ociConfigPathKey: configPath,
-		ociBundlePathKey: tempBundlePath,
+		ConfigPathKey: configPath,
+		BundlePathKey: tempBundlePath,
 	}
 
 	cStatuses := []vc.ContainerStatus{


### PR DESCRIPTION
The OCI configuration file path and the OCI bundle directory need to be
public to allow them to be used by runtime implementations.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>