### PR TITLE
tty: Set the console as the controlling terminal for shim

### DIFF
--- a/cc_shim.go
+++ b/cc_shim.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"syscall"
 )
 
 type ccShim struct{}
@@ -75,6 +76,15 @@ func (s *ccShim) start(pod Pod, params ShimParams) (int, error) {
 		cmd.Stdin = f
 		cmd.Stdout = f
 		cmd.Stderr = f
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			// Create Session
+			Setsid: true,
+
+			// Set Controlling terminal to Ctty
+			Setctty: true,
+			Ctty:    int(f.Fd()),
+		}
+
 	}
 	defer func() {
 		if f != nil {


### PR DESCRIPTION
The console passed in the config needs to be set as the
controlling terminal for the shim. This is done so that the
shim receives signals regarding terminal changes as well as
terminal's interrupt(Ctrl-C) and quit key are sent to
the shim process.

Fixes #257

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>