### PR TITLE
oci: copy container's annotations to pod

### DIFF
--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -237,7 +237,10 @@ func PodConfig(runtime RuntimeConfig, bundlePath, cid, console string) (*vc.PodC
 
 		Containers: []vc.ContainerConfig{containerConfig},
 
-		Annotations: map[string]string{},
+		Annotations: map[string]string{
+			ConfigPathKey: configPath,
+			BundlePathKey: bundlePath,
+		},
 	}
 
 	return &podConfig, &ocispec, nil

--- a/pkg/oci/utils_test.go
+++ b/pkg/oci/utils_test.go
@@ -107,7 +107,10 @@ func TestMinimalPodConfig(t *testing.T) {
 
 		Containers: []vc.ContainerConfig{expectedContainerConfig},
 
-		Annotations: map[string]string{},
+		Annotations: map[string]string{
+			ConfigPathKey: configPath,
+			BundlePathKey: tempBundlePath,
+		},
 	}
 
 	podConfig, _, err := PodConfig(runtimeConfig, tempBundlePath, containerID, consolePath)


### PR DESCRIPTION
When the pod is deleted we need to know the container's
annotations in order to be able to delete the pod.

fixes https://github.com/clearcontainers/runtime/issues/133

Signed-off-by: Julio Montes <julio.montes@intel.com>