### PR TITLE
rootfs: Support mounting the rootfs as readonly

### DIFF
--- a/container.go
+++ b/container.go
@@ -52,6 +52,9 @@ type ContainerConfig struct {
 	// RootFs is the container workload image on the host.
 	RootFs string
 
+	// ReadOnlyRootfs indicates if the rootfs should be mounted readonly
+	ReadonlyRootfs bool
+
 	// Cmd specifies the command to run on a container
 	Cmd Cmd
 

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -214,10 +214,10 @@ func (h *hyper) removePauseBinary(podID string) error {
 	return os.RemoveAll(pauseDir)
 }
 
-func (h *hyper) bindMountContainerRootfs(podID, cID, cRootFs string) error {
+func (h *hyper) bindMountContainerRootfs(podID, cID, cRootFs string, readonly bool) error {
 	rootfsDest := filepath.Join(defaultSharedDir, podID, cID, rootfsDir)
 
-	return bindMount(cRootFs, rootfsDest)
+	return bindMount(cRootFs, rootfsDest, readonly)
 }
 
 func (h *hyper) bindUnmountContainerRootfs(podID, cID string) error {
@@ -422,7 +422,7 @@ func (h *hyper) startOneContainer(pod Pod, c Container) error {
 		Process: process,
 	}
 
-	if err := h.bindMountContainerRootfs(pod.id, c.id, c.rootFs); err != nil {
+	if err := h.bindMountContainerRootfs(pod.id, c.id, c.rootFs, c.config.ReadonlyRootfs); err != nil {
 		h.bindUnmountAllRootfs(pod)
 		return err
 	}


### PR DESCRIPTION
This adds support for the oci specification to mount
the rootfs as readonly.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>