### PR TITLE
api: Add 'all' parameter to KillContainer().

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -135,6 +135,8 @@ type agent interface {
 	// stopContainer will tell the agent to stop a container related to a Pod.
 	stopContainer(pod Pod, c Container) error
 
-	// killContainer will tell the agent to send a signal to a container related to a Pod.
-	killContainer(pod Pod, c Container, signal syscall.Signal) error
+	// killContainer will tell the agent to send a signal to a
+	// container related to a Pod. If all is true, all processes in
+	// the container will be sent the signal.
+	killContainer(pod Pod, c Container, signal syscall.Signal, all bool) error
 }

--- a/api.go
+++ b/api.go
@@ -657,8 +657,9 @@ func statusContainer(pod *Pod, containerID string) (ContainerStatus, error) {
 }
 
 // KillContainer is the virtcontainers entry point to send a signal
-// to a container running inside a pod.
-func KillContainer(podID, containerID string, signal syscall.Signal) error {
+// to a container running inside a pod. If all is true, all processes in
+// the container will be sent the signal.
+func KillContainer(podID, containerID string, signal syscall.Signal, all bool) error {
 	if podID == "" {
 		return errNeedPodID
 	}
@@ -685,7 +686,7 @@ func KillContainer(podID, containerID string, signal syscall.Signal) error {
 	}
 
 	// Send a signal to the process.
-	err = c.kill(signal)
+	err = c.kill(signal, all)
 	if err != nil {
 		return err
 	}

--- a/container.go
+++ b/container.go
@@ -429,7 +429,7 @@ func (c *Container) stop() error {
 	}
 	defer c.pod.proxy.disconnect()
 
-	err = c.pod.agent.killContainer(*(c.pod), *c, syscall.SIGTERM)
+	err = c.pod.agent.killContainer(*(c.pod), *c, syscall.SIGTERM, true)
 	if err != nil {
 		return err
 	}
@@ -475,7 +475,7 @@ func (c *Container) enter(cmd Cmd) (*Process, error) {
 	return process, nil
 }
 
-func (c *Container) kill(signal syscall.Signal) error {
+func (c *Container) kill(signal syscall.Signal, all bool) error {
 	state, err := c.fetchState("signal")
 	if err != nil {
 		return err
@@ -490,7 +490,7 @@ func (c *Container) kill(signal syscall.Signal) error {
 	}
 	defer c.pod.proxy.disconnect()
 
-	err = c.pod.agent.killContainer(*(c.pod), *c, signal)
+	err = c.pod.agent.killContainer(*(c.pod), *c, signal, all)
 	if err != nil {
 		return err
 	}

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -356,7 +356,7 @@ func (h *hyper) stopPod(pod Pod) error {
 			continue
 		}
 
-		if err := h.killOneContainer(c.id, syscall.SIGTERM); err != nil {
+		if err := h.killOneContainer(c.id, syscall.SIGTERM, true); err != nil {
 			return err
 		}
 
@@ -451,7 +451,7 @@ func (h *hyper) startContainer(pod Pod, c Container) error {
 }
 
 func (h *hyper) stopPauseContainer(podID string) error {
-	if err := h.killOneContainer(pauseContainerName, syscall.SIGKILL); err != nil {
+	if err := h.killOneContainer(pauseContainerName, syscall.SIGKILL, true); err != nil {
 		return err
 	}
 
@@ -489,14 +489,15 @@ func (h *hyper) stopOneContainer(podID, cID string) error {
 }
 
 // killContainer is the agent process signal implementation for hyperstart.
-func (h *hyper) killContainer(pod Pod, c Container, signal syscall.Signal) error {
-	return h.killOneContainer(c.id, signal)
+func (h *hyper) killContainer(pod Pod, c Container, signal syscall.Signal, all bool) error {
+	return h.killOneContainer(c.id, signal, all)
 }
 
-func (h *hyper) killOneContainer(cID string, signal syscall.Signal) error {
+func (h *hyper) killOneContainer(cID string, signal syscall.Signal, all bool) error {
 	killCmd := hyperstart.KillCommand{
-		Container: cID,
-		Signal:    signal,
+		Container:    cID,
+		Signal:       signal,
+		AllProcesses: all,
 	}
 
 	proxyCmd := hyperstartProxyCmd{

--- a/noop_agent.go
+++ b/noop_agent.go
@@ -61,6 +61,6 @@ func (n *noopAgent) stopContainer(pod Pod, c Container) error {
 }
 
 // killContainer is the Noop agent Container signaling implementation. It does nothing.
-func (n *noopAgent) killContainer(pod Pod, c Container, signal syscall.Signal) error {
+func (n *noopAgent) killContainer(pod Pod, c Container, signal syscall.Signal, all bool) error {
 	return nil
 }

--- a/pkg/hyperstart/types.go
+++ b/pkg/hyperstart/types.go
@@ -58,8 +58,9 @@ type FileCommand struct {
 // KillCommand is the structure corresponding to the format expected by
 // hyperstart to kill a container on the guest.
 type KillCommand struct {
-	Container string         `json:"container"`
-	Signal    syscall.Signal `json:"signal"`
+	Container    string         `json:"container"`
+	Signal       syscall.Signal `json:"signal"`
+	AllProcesses bool           `json:"allProcesses"`
 }
 
 // ExecCommand is the structure corresponding to the format expected by

--- a/sshd.go
+++ b/sshd.go
@@ -191,6 +191,6 @@ func (s *sshd) stopContainer(pod Pod, c Container) error {
 }
 
 // killContainer is the agent Container signaling implementation for sshd.
-func (s *sshd) killContainer(pod Pod, c Container, signal syscall.Signal) error {
+func (s *sshd) killContainer(pod Pod, c Container, signal syscall.Signal, all bool) error {
 	return nil
 }


### PR DESCRIPTION
Allow all processes in a container to be killed.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>