### PR TITLE
tests: Use defer with call to unmount

### DIFF
--- a/syscall_test.go
+++ b/syscall_test.go
@@ -111,14 +111,14 @@ func TestBindMountReadonlySuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	defer syscall.Unmount(dest, 0)
+
 	// should not be able to create file in read-only mount
 	destFile := filepath.Join(dest, "foo")
 	_, err = os.OpenFile(destFile, os.O_CREATE, mountPerm)
 	if err == nil {
 		t.Fatal(err)
 	}
-
-	syscall.Unmount(dest, 0)
 }
 
 func TestEnsureDestinationExistsNonExistingSource(t *testing.T) {


### PR DESCRIPTION
Use defer here, in case we succeed in creating a file in the
read-only bind mount, the unmount may not be called.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>