### PR TITLE
oci: Pass the read-only config from the oci spec file

### DIFF
--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -199,9 +199,10 @@ func PodConfig(runtime RuntimeConfig, bundlePath, cid, console string) (*vc.PodC
 	}
 
 	containerConfig := vc.ContainerConfig{
-		ID:     cid,
-		RootFs: rootfs,
-		Cmd:    cmd,
+		ID:             cid,
+		RootFs:         rootfs,
+		ReadonlyRootfs: ocispec.Spec.Root.Readonly,
+		Cmd:            cmd,
 		Annotations: map[string]string{
 			ConfigPathKey: configPath,
 			BundlePathKey: bundlePath,

--- a/pkg/oci/utils_test.go
+++ b/pkg/oci/utils_test.go
@@ -81,9 +81,10 @@ func TestMinimalPodConfig(t *testing.T) {
 	}
 
 	expectedContainerConfig := vc.ContainerConfig{
-		ID:     containerID,
-		RootFs: path.Join(tempBundlePath, "rootfs"),
-		Cmd:    expectedCmd,
+		ID:             containerID,
+		RootFs:         path.Join(tempBundlePath, "rootfs"),
+		ReadonlyRootfs: true,
+		Cmd:            expectedCmd,
 		Annotations: map[string]string{
 			ConfigPathKey: configPath,
 			BundlePathKey: tempBundlePath,


### PR DESCRIPTION
Now that read-only rootfs support has been added pass this to
the container config.
Should have been part of earlier PR, missed adding this.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>