### PR TITLE
 agent: implement ps command

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -26,6 +26,22 @@ import (
 // AgentType describes the type of guest agent a Pod should run.
 type AgentType string
 
+// ProcessListOptions contains the options used to list running
+// processes inside the container
+type ProcessListOptions struct {
+	// Format describes the output format to list the running processes.
+	// Formats are unrelated to ps(1) formats, only two formats can be specified:
+	// "json" and "table"
+	Format string
+
+	// Args contains the list of arguments to run ps(1) command.
+	// If Args is empty the agent will use "-ef" as options to ps(1).
+	Args []string
+}
+
+// ProcessList represents the list of running processes inside the container
+type ProcessList []byte
+
 const (
 	// NoopAgentType is the No-Op agent.
 	NoopAgentType AgentType = "noop"
@@ -146,4 +162,7 @@ type agent interface {
 	// container related to a Pod. If all is true, all processes in
 	// the container will be sent the signal.
 	killContainer(pod Pod, c Container, signal syscall.Signal, all bool) error
+
+	// processListContainer will list the processes running inside the container
+	processListContainer(pod Pod, c Container, options ProcessListOptions) (ProcessList, error)
 }

--- a/api.go
+++ b/api.go
@@ -678,3 +678,34 @@ func PausePod(podID string) (VCPod, error) {
 func ResumePod(podID string) (VCPod, error) {
 	return togglePausePod(podID, false)
 }
+
+// ProcessListContainer is the virtcontainers entry point to list
+// processes running inside a container
+func ProcessListContainer(podID, containerID string, options ProcessListOptions) (ProcessList, error) {
+	if podID == "" {
+		return nil, errNeedPodID
+	}
+
+	if containerID == "" {
+		return nil, errNeedContainerID
+	}
+
+	lockFile, err := lockPod(podID)
+	if err != nil {
+		return nil, err
+	}
+	defer unlockPod(lockFile)
+
+	p, err := fetchPod(podID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fetch the container.
+	c, err := fetchContainer(p, containerID)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.processList(options)
+}

--- a/api_test.go
+++ b/api_test.go
@@ -1656,6 +1656,51 @@ func TestStatusContainerFailing(t *testing.T) {
 	}
 }
 
+func TestProcessListContainer(t *testing.T) {
+	cleanUp()
+
+	assert := assert.New(t)
+
+	contID := "abc"
+	options := ProcessListOptions{
+		Format: "json",
+		Args:   []string{"-ef"},
+	}
+
+	_, err := ProcessListContainer("", "", options)
+	assert.Error(err)
+
+	_, err = ProcessListContainer("xyz", "", options)
+	assert.Error(err)
+
+	_, err = ProcessListContainer("xyz", "xyz", options)
+	assert.Error(err)
+
+	config := newTestPodConfigNoop()
+	p, err := CreatePod(config)
+	assert.NoError(err)
+	assert.NotNil(p)
+
+	pImpl, ok := p.(*Pod)
+	assert.True(ok)
+	defer os.RemoveAll(pImpl.configPath)
+
+	contConfig := newTestContainerConfigNoop(contID)
+	_, c, err := CreateContainer(p.ID(), contConfig)
+	assert.NoError(err)
+	assert.NotNil(c)
+
+	_, err = ProcessListContainer(pImpl.id, "xyz", options)
+	assert.Error(err)
+
+	_, err = ProcessListContainer("xyz", contID, options)
+	assert.Error(err)
+
+	_, err = ProcessListContainer(pImpl.id, contID, options)
+	// Pod not running, impossible to ps the container
+	assert.Error(err)
+}
+
 /*
  * Benchmarks
  */

--- a/cc_proxy.go
+++ b/cc_proxy.go
@@ -207,9 +207,5 @@ func (p *ccProxy) sendCmd(cmd interface{}) (interface{}, error) {
 		tokens = append(tokens, proxyCmd.token)
 	}
 
-	if _, err := p.client.HyperWithTokens(proxyCmd.cmd, tokens, proxyCmd.message); err != nil {
-		return nil, err
-	}
-
-	return nil, nil
+	return p.client.HyperWithTokens(proxyCmd.cmd, tokens, proxyCmd.message)
 }

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -649,3 +649,32 @@ func (h *hyper) killOneContainer(cID string, signal syscall.Signal, all bool) er
 
 	return nil
 }
+
+func (h *hyper) processListContainer(pod Pod, c Container, options ProcessListOptions) (ProcessList, error) {
+	return h.processListOneContainer(pod.id, c.id, options)
+}
+
+func (h *hyper) processListOneContainer(podID, cID string, options ProcessListOptions) (ProcessList, error) {
+	psCmd := hyperstart.PsCommand{
+		Container: cID,
+		Format:    options.Format,
+		PsArgs:    options.Args,
+	}
+
+	proxyCmd := hyperstartProxyCmd{
+		cmd:     hyperstart.PsContainer,
+		message: psCmd,
+	}
+
+	response, err := h.proxy.sendCmd(proxyCmd)
+	if err != nil {
+		return nil, err
+	}
+
+	msg, ok := response.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("failed to get response message from container %s pod %s", cID, podID)
+	}
+
+	return msg, nil
+}

--- a/implementation.go
+++ b/implementation.go
@@ -112,3 +112,8 @@ func (impl *VCImpl) StatusContainer(podID, containerID string) (ContainerStatus,
 func (impl *VCImpl) KillContainer(podID, containerID string, signal syscall.Signal, all bool) error {
 	return KillContainer(podID, containerID, signal, all)
 }
+
+// ProcessListContainer implements the VC function of the same name.
+func (impl *VCImpl) ProcessListContainer(podID, containerID string, options ProcessListOptions) (ProcessList, error) {
+	return ProcessListContainer(podID, containerID, options)
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -41,6 +41,7 @@ type VC interface {
 	StartContainer(podID, containerID string) (VCContainer, error)
 	StatusContainer(podID, containerID string) (ContainerStatus, error)
 	StopContainer(podID, containerID string) (VCContainer, error)
+	ProcessListContainer(podID, containerID string, options ProcessListOptions) (ProcessList, error)
 }
 
 // VCPod is the Pod interface

--- a/noop_agent.go
+++ b/noop_agent.go
@@ -74,3 +74,8 @@ func (n *noopAgent) stopContainer(pod Pod, c Container) error {
 func (n *noopAgent) killContainer(pod Pod, c Container, signal syscall.Signal, all bool) error {
 	return nil
 }
+
+// processListContainer is the Noop agent Container ps implementation. It does nothing.
+func (n *noopAgent) processListContainer(pod Pod, c Container, options ProcessListOptions) (ProcessList, error) {
+	return nil, nil
+}

--- a/pkg/hyperstart/hyperstart.go
+++ b/pkg/hyperstart/hyperstart.go
@@ -50,6 +50,7 @@ const (
 	SetupInterface  = "setupinterface"
 	SetupRoute      = "setuproute"
 	RemoveContainer = "removecontainer"
+	PsContainer     = "pscontainer"
 )
 
 // CodeList is the map making the relation between a string command
@@ -73,6 +74,7 @@ var CodeList = map[string]uint32{
 	SetupInterface:  SetupInterfaceCode,
 	SetupRoute:      SetupRouteCode,
 	RemoveContainer: RemoveContainerCode,
+	PsContainer:     PsContainerCode,
 }
 
 // Values related to the communication on control channel.

--- a/pkg/hyperstart/types.go
+++ b/pkg/hyperstart/types.go
@@ -45,6 +45,7 @@ const (
 	SetupInterfaceCode
 	SetupRouteCode
 	RemoveContainerCode
+	PsContainerCode
 	ProcessAsyncEventCode
 )
 
@@ -74,6 +75,14 @@ type ExecCommand struct {
 // hyperstart to remove a container on the guest.
 type RemoveCommand struct {
 	Container string `json:"container"`
+}
+
+// PsCommand is the structure corresponding to the format expected by
+// hyperstart to list processes of a container on the guest.
+type PsCommand struct {
+	Container string   `json:"container"`
+	Format    string   `json:"format"`
+	PsArgs    []string `json:"psargs"`
 }
 
 // PAECommand is the structure hyperstart can expects to

--- a/pkg/vcMock/mock.go
+++ b/pkg/vcMock/mock.go
@@ -186,3 +186,12 @@ func (m *VCMock) KillContainer(podID, containerID string, signal syscall.Signal,
 
 	return fmt.Errorf("%s: %s (%+v): podID: %v, containerID: %v, signal: %v, all: %v", mockErrorPrefix, getSelf(), m, podID, containerID, signal, all)
 }
+
+// ProcessListContainer implements the VC function of the same name.
+func (m *VCMock) ProcessListContainer(podID, containerID string, options vc.ProcessListOptions) (vc.ProcessList, error) {
+	if m.ProcessListContainerFunc != nil {
+		return m.ProcessListContainerFunc(podID, containerID, options)
+	}
+
+	return nil, fmt.Errorf("%s: %s (%+v): podID: %v, containerID: %v", mockErrorPrefix, getSelf(), m, podID, containerID)
+}

--- a/pkg/vcMock/mock_test.go
+++ b/pkg/vcMock/mock_test.go
@@ -544,3 +544,36 @@ func TestVCMockStopContainer(t *testing.T) {
 	assert.Error(err)
 	assert.True(IsMockError(err))
 }
+
+func TestVCMockProcessListContainer(t *testing.T) {
+	assert := assert.New(t)
+
+	m := &VCMock{}
+	assert.Nil(m.ProcessListContainerFunc)
+
+	options := vc.ProcessListOptions{
+		Format: "json",
+		Args:   []string{"-ef"},
+	}
+
+	_, err := m.ProcessListContainer(testPodID, testContainerID, options)
+	assert.Error(err)
+	assert.True(IsMockError(err))
+
+	processList := vc.ProcessList("hi")
+
+	m.ProcessListContainerFunc = func(podID, containerID string, options vc.ProcessListOptions) (vc.ProcessList, error) {
+		return processList, nil
+	}
+
+	pList, err := m.ProcessListContainer(testPodID, testContainerID, options)
+	assert.NoError(err)
+	assert.Equal(pList, processList)
+
+	// reset
+	m.ProcessListContainerFunc = nil
+
+	_, err = m.ProcessListContainer(testPodID, testContainerID, options)
+	assert.Error(err)
+	assert.True(IsMockError(err))
+}

--- a/pkg/vcMock/types.go
+++ b/pkg/vcMock/types.go
@@ -55,11 +55,12 @@ type VCMock struct {
 	StatusPodFunc func(podID string) (vc.PodStatus, error)
 	StopPodFunc   func(podID string) (vc.VCPod, error)
 
-	CreateContainerFunc func(podID string, containerConfig vc.ContainerConfig) (vc.VCPod, vc.VCContainer, error)
-	DeleteContainerFunc func(podID, containerID string) (vc.VCContainer, error)
-	EnterContainerFunc  func(podID, containerID string, cmd vc.Cmd) (vc.VCPod, vc.VCContainer, *vc.Process, error)
-	KillContainerFunc   func(podID, containerID string, signal syscall.Signal, all bool) error
-	StartContainerFunc  func(podID, containerID string) (vc.VCContainer, error)
-	StatusContainerFunc func(podID, containerID string) (vc.ContainerStatus, error)
-	StopContainerFunc   func(podID, containerID string) (vc.VCContainer, error)
+	CreateContainerFunc      func(podID string, containerConfig vc.ContainerConfig) (vc.VCPod, vc.VCContainer, error)
+	DeleteContainerFunc      func(podID, containerID string) (vc.VCContainer, error)
+	EnterContainerFunc       func(podID, containerID string, cmd vc.Cmd) (vc.VCPod, vc.VCContainer, *vc.Process, error)
+	KillContainerFunc        func(podID, containerID string, signal syscall.Signal, all bool) error
+	StartContainerFunc       func(podID, containerID string) (vc.VCContainer, error)
+	StatusContainerFunc      func(podID, containerID string) (vc.ContainerStatus, error)
+	StopContainerFunc        func(podID, containerID string) (vc.VCContainer, error)
+	ProcessListContainerFunc func(podID, containerID string, options vc.ProcessListOptions) (vc.ProcessList, error)
 }

--- a/sshd.go
+++ b/sshd.go
@@ -203,3 +203,8 @@ func (s *sshd) stopContainer(pod Pod, c Container) error {
 func (s *sshd) killContainer(pod Pod, c Container, signal syscall.Signal, all bool) error {
 	return nil
 }
+
+// processListContainer is the agent Container ps implementation for sshd.
+func (s *sshd) processListContainer(pod Pod, c Container, options ProcessListOptions) (ProcessList, error) {
+	return nil, nil
+}


### PR DESCRIPTION
ps command is used to list the processes running inside
the container, this command is called by ```docker top```

partially fixes clearcontainers/runtime#95

Signed-off-by: Julio Montes <julio.montes@intel.com>