### PR TITLE
utils: Fix the script installing CNI plugins

### DIFF
--- a/utils/virtcontainers-setup.sh
+++ b/utils/virtcontainers-setup.sh
@@ -59,7 +59,7 @@ cp -r ${busybox_bundle}/* ${pause_bundle}/
 echo -e "Move to ${tmpdir}/${virtcontainers_build_dir}"
 pushd ${tmpdir}/${virtcontainers_build_dir}
 echo "Clone cni"
-git clone https://github.com/containernetworking/cni.git
+git clone https://github.com/containernetworking/plugins.git
 
 echo "Copy CNI config files"
 cp $GOPATH/src/github.com/containers/virtcontainers/test/cni/10-mynet.conf ${ETCDIR}/cni/net.d/
@@ -71,7 +71,7 @@ make
 cp pause ${pause_bundle}/${rootfsdir}/bin/
 make clean
 popd
-pushd cni
+pushd plugins
 ./build.sh
 cp ./bin/bridge ${TMPDIR}/cni/bin/cni-bridge
 cp ./bin/loopback ${TMPDIR}/cni/bin/loopback


### PR DESCRIPTION
Because CNI recently moved all their plugins to a different repo, we have to update our scripts to make sure we can still build CNI plugins from sources. This is needed for our CI to continue to be functional.
The new repo is: github.com/containernetworking/plugins