### PR TITLE
Generalise *logrus.Logger to the logrus.FieldLogger interface

### DIFF
--- a/api.go
+++ b/api.go
@@ -28,10 +28,10 @@ func init() {
 	runtime.LockOSThread()
 }
 
-var virtLog = logrus.New()
+var virtLog = logrus.FieldLogger(logrus.New())
 
 // SetLogger sets the logger for virtcontainers package.
-func SetLogger(logger *logrus.Logger) {
+func SetLogger(logger logrus.FieldLogger) {
 	virtLog = logger
 }
 

--- a/api.go
+++ b/api.go
@@ -30,8 +30,8 @@ func init() {
 
 var virtLog = logrus.New()
 
-// SetLog sets the logger for virtcontainers package.
-func SetLog(logger *logrus.Logger) {
+// SetLogger sets the logger for virtcontainers package.
+func SetLogger(logger *logrus.Logger) {
 	virtLog = logger
 }
 

--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -962,7 +962,7 @@ func main() {
 		}
 
 		// Set virtcontainers logger.
-		vc.SetLog(virtcLog)
+		vc.SetLogger(virtcLog)
 
 		return nil
 	}

--- a/pkg/hyperstart/hyperstart.go
+++ b/pkg/hyperstart/hyperstart.go
@@ -131,8 +131,8 @@ type Hyperstart struct {
 
 var hyperLog = logrus.New()
 
-// SetLog sets the logger for hyperstart package.
-func SetLog(logger *logrus.Logger) {
+// SetLogger sets the logger for hyperstart package.
+func SetLogger(logger *logrus.Logger) {
 	hyperLog = logger
 }
 

--- a/pkg/hyperstart/hyperstart.go
+++ b/pkg/hyperstart/hyperstart.go
@@ -129,10 +129,10 @@ type Hyperstart struct {
 	ctlChDone chan interface{}
 }
 
-var hyperLog = logrus.New()
+var hyperLog = logrus.FieldLogger(logrus.New())
 
 // SetLogger sets the logger for hyperstart package.
-func SetLogger(logger *logrus.Logger) {
+func SetLogger(logger logrus.FieldLogger) {
 	hyperLog = logger
 }
 

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -78,10 +78,10 @@ type RuntimeConfig struct {
 	Console string
 }
 
-var ociLog = logrus.New()
+var ociLog = logrus.FieldLogger(logrus.New())
 
 // SetLogger sets the logger for oci package.
-func SetLogger(logger *logrus.Logger) {
+func SetLogger(logger logrus.FieldLogger) {
 	ociLog = logger
 }
 

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -80,8 +80,8 @@ type RuntimeConfig struct {
 
 var ociLog = logrus.New()
 
-// SetLog sets the logger for oci package.
-func SetLog(logger *logrus.Logger) {
+// SetLogger sets the logger for oci package.
+func SetLogger(logger *logrus.Logger) {
 	ociLog = logger
 }
 

--- a/virtcontainers_test.go
+++ b/virtcontainers_test.go
@@ -73,12 +73,14 @@ func TestMain(m *testing.M) {
 
 	flag.Parse()
 
-	virtLog.Level = logrus.ErrorLevel
+	logger := logrus.New()
+	logger.Level = logrus.ErrorLevel
 	for _, arg := range flag.Args() {
 		if arg == "debug-logs" {
-			virtLog.Level = logrus.DebugLevel
+			logger.Level = logrus.DebugLevel
 		}
 	}
+	SetLogger(logger)
 
 	testDir, err = ioutil.TempDir("", "virtcontainers-tmp-")
 	if err != nil {


### PR DESCRIPTION
We don't really want a Logger object, but either a Logger or an Entry. Using the FieldLogger interface leaves a choice to users.

Took the opportunity to rename SetLog to SetLogger as well, looks slightly better to me.