### PR TITLE
shim: Stop the shim if container has only been created

### DIFF
--- a/api.go
+++ b/api.go
@@ -115,6 +115,11 @@ func DeletePod(podID string) (*Pod, error) {
 		return nil, err
 	}
 
+	// Stop shims
+	if err := p.stopShims(); err != nil {
+		return nil, err
+	}
+
 	// Stop the VM
 	err = p.stopVM()
 	if err != nil {

--- a/container.go
+++ b/container.go
@@ -337,6 +337,10 @@ func (c *Container) delete() error {
 		return fmt.Errorf("Container not ready or stopped, impossible to delete")
 	}
 
+	if err := stopShim(c.process.Pid); err != nil {
+		return err
+	}
+
 	err = c.pod.storage.deleteContainerResources(c.podID, c.id, nil)
 	if err != nil {
 		return err

--- a/pod.go
+++ b/pod.go
@@ -756,6 +756,20 @@ func (p *Pod) stopSetStates() error {
 	return nil
 }
 
+// stopShims stops all remaining shims corresponfing to not started/stopped
+// containers.
+func (p *Pod) stopShims() error {
+	for _, c := range p.containers {
+		if err := stopShim(c.process.Pid); err != nil {
+			return err
+		}
+	}
+
+	virtLog.Infof("Shim(s) stopped")
+
+	return nil
+}
+
 // stopVM stops the agent inside the VM and shut down the VM itself.
 func (p *Pod) stopVM() error {
 	if _, _, err := p.proxy.connect(*p, false); err != nil {

--- a/shim.go
+++ b/shim.go
@@ -18,6 +18,7 @@ package virtcontainers
 
 import (
 	"fmt"
+	"syscall"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -94,6 +95,20 @@ func newShimConfig(config PodConfig) interface{} {
 	default:
 		return nil
 	}
+}
+
+func stopShim(pid int) error {
+	if pid <= 0 {
+		return nil
+	}
+
+	virtLog.Infof("Stopping shim PID %d", pid)
+
+	if err := syscall.Kill(pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+		return err
+	}
+
+	return nil
 }
 
 // shim is the virtcontainers shim interface.

--- a/shim_test.go
+++ b/shim_test.go
@@ -17,8 +17,13 @@
 package virtcontainers
 
 import (
+	"os/exec"
 	"reflect"
 	"testing"
+)
+
+var (
+	testRunningProcess = "sleep"
 )
 
 func testSetShimType(t *testing.T, value string, expected ShimType) {
@@ -146,4 +151,42 @@ func TestNewShimConfigFromUnknownShimPodConfig(t *testing.T) {
 	}
 
 	testNewShimConfigFromPodConfig(t, podConfig, nil)
+}
+
+func TestStopShimSuccessfulProcessNotRunning(t *testing.T) {
+	binPath, err := exec.LookPath(testRunningProcess)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(binPath, "0")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	pid := cmd.Process.Pid
+
+	if err := cmd.Wait(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := stopShim(pid); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStopShimSuccessfulProcessRunning(t *testing.T) {
+	binPath, err := exec.LookPath(testRunningProcess)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(binPath, "999")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := stopShim(cmd.Process.Pid); err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
In case a shim has been created because a pod or a container has been created, we don't want to end up with a call to DeleteContainer() or DeletePod() that could end up in one or several shims running with no container related.