### PR TITLE
Handle bind-mounts and use devicemapper device when available

### DIFF
--- a/container.go
+++ b/container.go
@@ -102,6 +102,9 @@ type Container struct {
 
 	rootFs string
 
+	// File system type of rootfs block device
+	fstype string
+
 	config *ContainerConfig
 
 	pod *Pod

--- a/container.go
+++ b/container.go
@@ -294,6 +294,11 @@ func createContainers(pod *Pod, contConfigs []ContainerConfig) ([]*Container, er
 			c.process = process
 		}
 
+		mounts, err := c.fetchMounts()
+		if err == nil {
+			c.mounts = mounts
+		}
+
 		containers = append(containers, c)
 	}
 
@@ -330,6 +335,11 @@ func createContainer(pod *Pod, contConfig ContainerConfig) (*Container, error) {
 	process, err := c.fetchProcess()
 	if err == nil {
 		c.process = process
+	}
+
+	mounts, err := c.fetchMounts()
+	if err == nil {
+		c.mounts = mounts
 	}
 
 	state, err := c.pod.storage.fetchContainerState(c.podID, c.id)
@@ -428,6 +438,8 @@ func (c *Container) start() error {
 		c.stop()
 		return err
 	}
+
+	c.storeMounts()
 
 	err = c.setContainerState(StateRunning)
 	if err != nil {

--- a/container.go
+++ b/container.go
@@ -45,6 +45,18 @@ type ContainerStatus struct {
 	Annotations map[string]string
 }
 
+// Mount describes a container mount.
+type Mount struct {
+	Source      string
+	Destination string
+
+	// Type specifies the type of filesystem to mount.
+	Type string
+
+	// Options list all the mount options of the filesystem.
+	Options []string
+}
+
 // ContainerConfig describes one container runtime configuration.
 type ContainerConfig struct {
 	ID string
@@ -62,6 +74,8 @@ type ContainerConfig struct {
 	// for example to add additional status values required
 	// to support particular specifications.
 	Annotations map[string]string
+
+	Mounts []Mount
 }
 
 // valid checks that the container configuration is valid.
@@ -96,6 +110,8 @@ type Container struct {
 	state State
 
 	process Process
+
+	mounts []Mount
 }
 
 // ID returns the container identifier string.
@@ -254,6 +270,7 @@ func createContainers(pod *Pod, contConfigs []ContainerConfig) ([]*Container, er
 			containerPath: filepath.Join(pod.id, contConfig.ID),
 			state:         State{},
 			process:       Process{},
+			mounts:        contConfig.Mounts,
 		}
 
 		state, err := c.pod.storage.fetchContainerState(c.podID, c.id)

--- a/container.go
+++ b/container.go
@@ -55,6 +55,9 @@ type Mount struct {
 
 	// Options list all the mount options of the filesystem.
 	Options []string
+
+	// HostPath used to store host side bind mount path
+	HostPath string
 }
 
 // ContainerConfig describes one container runtime configuration.

--- a/container.go
+++ b/container.go
@@ -186,6 +186,14 @@ func (c *Container) fetchProcess() (Process, error) {
 	return c.pod.storage.fetchContainerProcess(c.podID, c.id)
 }
 
+func (c *Container) storeMounts() error {
+	return c.pod.storage.storeContainerMounts(c.podID, c.id, c.mounts)
+}
+
+func (c *Container) fetchMounts() ([]Mount, error) {
+	return c.pod.storage.fetchContainerMounts(c.podID, c.id)
+}
+
 // fetchContainer fetches a container config from a pod ID and returns a Container.
 func fetchContainer(pod *Pod, containerID string) (*Container, error) {
 	if pod == nil {

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -359,6 +359,10 @@ func (h *hyper) init(pod *Pod, config interface{}) (err error) {
 		return err
 	}
 
+	if err := pod.addDrives(); err != nil {
+		return err
+	}
+
 	h.proxy = pod.proxy
 
 	return nil

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -495,6 +495,8 @@ func (h *hyper) startPauseContainer(podID string) error {
 	return nil
 }
 
+var diskIndex = int(0)
+
 func (h *hyper) startOneContainer(pod Pod, c Container) error {
 	process, err := h.buildHyperContainerProcess(c.config.Cmd)
 	if err != nil {
@@ -506,6 +508,17 @@ func (h *hyper) startOneContainer(pod Pod, c Container) error {
 		Image:   c.id,
 		Rootfs:  rootfsDir,
 		Process: process,
+	}
+
+	if c.fstype != "" {
+		driveName, err := getVirtDriveName(diskIndex)
+		if err != nil {
+			return err
+		}
+
+		container.Fstype = c.fstype
+		container.Image = driveName
+		diskIndex = diskIndex + 1
 	}
 
 	if err := h.bindMountContainerRootfs(pod.id, c.id, c.rootFs, c.config.ReadonlyRootfs); err != nil {

--- a/hypervisor.go
+++ b/hypervisor.go
@@ -112,6 +112,9 @@ type HypervisorConfig struct {
 	// HypervisorPath is the hypervisor executable host path.
 	HypervisorPath string
 
+	// DisableBlockDeviceUse disallows a block device from being used.
+	DisableBlockDeviceUse bool
+
 	// KernelParams are additional guest kernel parameters.
 	KernelParams []Param
 

--- a/mount.go
+++ b/mount.go
@@ -198,3 +198,36 @@ func isDeviceMapper(major, minor int) (bool, error) {
 		return false, err
 	}
 }
+
+// getVirtBlockDriveName returns the disk name format for virtio-blk
+// Reference: https://github.com/torvalds/linux/blob/master/drivers/block/virtio_blk.c#L478
+func getVirtDriveName(index int) (string, error) {
+	if index < 0 {
+		return "", fmt.Errorf("Index cannot be negative for drive")
+	}
+
+	// Prefix used for virtio-block devices
+	prefix := "vd"
+
+	//Refer to DISK_NAME_LEN: https://github.com/torvalds/linux/blob/08c521a2011ff492490aa9ed6cc574be4235ce2b/include/linux/genhd.h#L61
+	diskNameLen := 32
+	base := 26
+
+	suffLen := diskNameLen - len(prefix)
+	diskLetters := make([]byte, suffLen)
+
+	var i int
+
+	for i = 0; i < suffLen && index >= 0; i++ {
+		letter := byte('a' + (index % base))
+		diskLetters[i] = letter
+		index = index/base - 1
+	}
+
+	if index >= 0 {
+		return "", fmt.Errorf("Index not supported")
+	}
+
+	diskName := prefix + reverseString(string(diskLetters[:i]))
+	return diskName, nil
+}

--- a/mount.go
+++ b/mount.go
@@ -16,7 +16,13 @@
 
 package virtcontainers
 
-import "strings"
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
 
 // These mounts need to be created by the agent within the VM
 var systemMounts = []string{"/proc", "/dev", "/dev/pts", "/dev/shm", "/dev/mqueue", "/sys", "/sys/fs/cgroup"}
@@ -33,4 +39,89 @@ func isSystemMount(m string) bool {
 		}
 	}
 	return false
+}
+
+func major(dev uint64) int {
+	return int((dev >> 8) & 0xfff)
+
+}
+
+func minor(dev uint64) int {
+	return int((dev & 0xff) | ((dev >> 12) & 0xfff00))
+}
+
+type device struct {
+	major      int
+	minor      int
+	mountPoint string
+}
+
+var errMountPointNotFound = errors.New("Mount point not found")
+
+// getDeviceForPath gets the underlying device containing the file specified by path.
+// The device type constitutes the major-minor number of the device and the dest mountPoint for the device
+//
+// eg. if /dev/sda1 is mounted on /a/b/c, a call to getDeviceForPath("/a/b/c/file") would return
+//
+//	device {
+//		major : major(/dev/sda1)
+//		manor : minor(/dev/sda1)
+//		mountPoint: /a/b/c
+//	}
+func getDeviceForPath(path string) (device, error) {
+	if path == "" {
+		return device{}, fmt.Errorf("Path cannot be empty")
+	}
+
+	stat := syscall.Stat_t{}
+	err := syscall.Stat(path, &stat)
+	if err != nil {
+		return device{}, err
+	}
+
+	// stat.Dev points to the underlying device containing the file
+	major := major(stat.Dev)
+	minor := minor(stat.Dev)
+
+	mountPoint := path
+
+	if path == "/" {
+		return device{
+			major:      major,
+			minor:      minor,
+			mountPoint: mountPoint,
+		}, nil
+	}
+
+	// We get the mount point by recursively peforming stat on the path
+	// The point where the device changes indicates the mountpoint
+	for {
+		if mountPoint == "/" {
+			return device{}, errMountPointNotFound
+		}
+
+		parentStat := syscall.Stat_t{}
+		parentDir := filepath.Dir(path)
+
+		err := syscall.Lstat(parentDir, &parentStat)
+		if err != nil {
+			return device{}, err
+		}
+
+		if parentStat.Dev != stat.Dev {
+			break
+		}
+
+		mountPoint = parentDir
+		stat = parentStat
+		path = parentDir
+	}
+
+	dev := device{
+		major:      major,
+		minor:      minor,
+		mountPoint: mountPoint,
+	}
+
+	return dev, nil
 }

--- a/mount.go
+++ b/mount.go
@@ -181,3 +181,20 @@ func getDevicePathAndFsType(mountPoint string) (devicePath, fsType string, err e
 
 	return
 }
+
+// isDeviceMapper checks if the device with the major and minor numbers is a devicemapper block device
+func isDeviceMapper(major, minor int) (bool, error) {
+
+	//Check if /sys/dev/block/${major}-${minor}/dm exists
+	sysPath := fmt.Sprintf("/sys/dev/block/%d:%d/dm", major, minor)
+
+	_, err := os.Stat(sysPath)
+
+	if err == nil {
+		return true, nil
+	} else if os.IsNotExist(err) {
+		return false, nil
+	} else {
+		return false, err
+	}
+}

--- a/mount.go
+++ b/mount.go
@@ -16,40 +16,21 @@
 
 package virtcontainers
 
-import (
-	"crypto/rand"
-	"fmt"
-	"os/exec"
-)
+import "strings"
 
-const cpBinaryName = "cp"
+// These mounts need to be created by the agent within the VM
+var systemMounts = []string{"/proc", "/dev", "/dev/pts", "/dev/shm", "/dev/mqueue", "/sys", "/sys/fs/cgroup"}
 
-func fileCopy(srcPath, dstPath string) error {
-	if srcPath == "" {
-		return fmt.Errorf("Source path cannot be empty")
+var systemMountPrefixes = []string{"/proc", "/dev", "/sys"}
+
+func isSystemMount(m string) bool {
+	for _, p := range systemMountPrefixes {
+		if m == p {
+			return true
+		}
+		if strings.HasPrefix(m, p+"/") {
+			return true
+		}
 	}
-
-	if dstPath == "" {
-		return fmt.Errorf("Destination path cannot be empty")
-	}
-
-	binPath, err := exec.LookPath(cpBinaryName)
-	if err != nil {
-		return err
-	}
-
-	cmd := exec.Command(binPath, srcPath, dstPath)
-
-	return cmd.Run()
-}
-
-func generateRandomBytes(n int) ([]byte, error) {
-	b := make([]byte, n)
-	_, err := rand.Read(b)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return b, nil
+	return false
 }

--- a/mount.go
+++ b/mount.go
@@ -17,8 +17,11 @@
 package virtcontainers
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -124,4 +127,57 @@ func getDeviceForPath(path string) (device, error) {
 	}
 
 	return dev, nil
+}
+
+const (
+	procMountsFile = "/proc/mounts"
+
+	fieldsPerLine = 6
+)
+
+const (
+	procDeviceIndex = iota
+	procPathIndex
+	procTypeIndex
+)
+
+func getDevicePathAndFsType(mountPoint string) (devicePath, fsType string, err error) {
+	if mountPoint == "" {
+		err = fmt.Errorf("Mount Point cannot be empty")
+		return
+	}
+
+	var file *os.File
+
+	file, err = os.Open(procMountsFile)
+	if err != nil {
+		return
+	}
+
+	defer file.Close()
+
+	reader := bufio.NewReader(file)
+	for {
+		var line string
+
+		line, err = reader.ReadString('\n')
+		if err == io.EOF {
+			err = fmt.Errorf("Mount %s not found", mountPoint)
+			break
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) != fieldsPerLine {
+			err = fmt.Errorf("Incorrect no of fields (expected %d, got %d)) :%s", fieldsPerLine, len(fields), line)
+			break
+		}
+
+		if mountPoint == fields[procPathIndex] {
+			devicePath = fields[procDeviceIndex]
+			fsType = fields[procTypeIndex]
+			return
+		}
+	}
+
+	return
 }

--- a/mount_test.go
+++ b/mount_test.go
@@ -125,3 +125,23 @@ func TestGetDeviceForPathEmptyPath(t *testing.T) {
 		t.Fatal()
 	}
 }
+
+func TestGetDevicePathAndFsTypeEmptyMount(t *testing.T) {
+	_, _, err := getDevicePathAndFsType("")
+
+	if err == nil {
+		t.Fatal()
+	}
+}
+
+func TestGetDevicePathAndFsTypeSuccessful(t *testing.T) {
+	path, fstype, err := getDevicePathAndFsType("/proc")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if path != "proc" || fstype != "proc" {
+		t.Fatal(err)
+	}
+}

--- a/mount_test.go
+++ b/mount_test.go
@@ -1,0 +1,43 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import "testing"
+
+func TestIsSystemMount(t *testing.T) {
+	tests := []struct {
+		mnt      string
+		expected bool
+	}{
+		{"/sys", true},
+		{"/sys/", true},
+		{"/sys//", true},
+		{"/sys/fs", true},
+		{"/sys/fs/", true},
+		{"/sys/fs/cgroup", true},
+		{"/sysfoo", false},
+		{"/home", false},
+		{"/dev/block/", true},
+	}
+
+	for _, test := range tests {
+		result := isSystemMount(test.mnt)
+		if result != test.expected {
+			t.Fatalf("Expected result for path %s : %v, got %v", test.mnt, test.expected, result)
+		}
+	}
+}

--- a/mount_test.go
+++ b/mount_test.go
@@ -145,3 +145,35 @@ func TestGetDevicePathAndFsTypeSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestGetVirtDriveNameInvalidIndex(t *testing.T) {
+	index := -1
+	_, err := getVirtDriveName(index)
+	if err == nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetVirtDriveName(t *testing.T) {
+	tests := []struct {
+		index         int
+		expectedDrive string
+	}{
+		{0, "vda"},
+		{25, "vdz"},
+		{27, "vdab"},
+		{704, "vdaac"},
+		{18277, "vdzzz"},
+	}
+
+	for _, test := range tests {
+		driveName, err := getVirtDriveName(test.index)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if driveName != test.expectedDrive {
+			t.Fatalf("Incorrect drive Name: Got: %s, Expecting :%s", driveName, test.expectedDrive)
+
+		}
+	}
+}

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -139,6 +139,30 @@ func containerHooks(spec CompatOCISpec) vc.Hooks {
 	return hooks
 }
 
+func newMount(m spec.Mount) vc.Mount {
+	return vc.Mount{
+		Source:      m.Source,
+		Destination: m.Destination,
+		Type:        m.Type,
+		Options:     m.Options,
+	}
+}
+
+func containerMounts(spec CompatOCISpec) []vc.Mount {
+	ociMounts := spec.Spec.Mounts
+
+	if ociMounts == nil {
+		return []vc.Mount{}
+	}
+
+	var mnts []vc.Mount
+	for _, m := range ociMounts {
+		mnts = append(mnts, newMount(m))
+	}
+
+	return mnts
+}
+
 func networkConfig(ocispec CompatOCISpec) (vc.NetworkConfig, error) {
 	linux := ocispec.Linux
 	if linux == nil {
@@ -207,6 +231,7 @@ func PodConfig(runtime RuntimeConfig, bundlePath, cid, console string) (*vc.PodC
 			ConfigPathKey: configPath,
 			BundlePathKey: bundlePath,
 		},
+		Mounts: containerMounts(ocispec),
 	}
 
 	networkConfig, err := networkConfig(ocispec)

--- a/pkg/oci/utils_test.go
+++ b/pkg/oci/utils_test.go
@@ -86,18 +86,21 @@ func TestMinimalPodConfig(t *testing.T) {
 			Destination: "/proc",
 			Type:        "proc",
 			Options:     nil,
+			HostPath:    "",
 		},
 		{
 			Source:      "tmpfs",
 			Destination: "/dev",
 			Type:        "tmpfs",
 			Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
+			HostPath:    "",
 		},
 		{
 			Source:      "devpts",
 			Destination: "/dev/pts",
 			Type:        "devpts",
 			Options:     []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=5"},
+			HostPath:    "",
 		},
 	}
 

--- a/pkg/oci/utils_test.go
+++ b/pkg/oci/utils_test.go
@@ -80,6 +80,27 @@ func TestMinimalPodConfig(t *testing.T) {
 		Console:             consolePath,
 	}
 
+	expectedMounts := []vc.Mount{
+		{
+			Source:      "proc",
+			Destination: "/proc",
+			Type:        "proc",
+			Options:     nil,
+		},
+		{
+			Source:      "tmpfs",
+			Destination: "/dev",
+			Type:        "tmpfs",
+			Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
+		},
+		{
+			Source:      "devpts",
+			Destination: "/dev/pts",
+			Type:        "devpts",
+			Options:     []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=5"},
+		},
+	}
+
 	expectedContainerConfig := vc.ContainerConfig{
 		ID:             containerID,
 		RootFs:         path.Join(tempBundlePath, "rootfs"),
@@ -89,6 +110,7 @@ func TestMinimalPodConfig(t *testing.T) {
 			ConfigPathKey: configPath,
 			BundlePathKey: tempBundlePath,
 		},
+		Mounts: expectedMounts,
 	}
 
 	expectedNetworkConfig := vc.NetworkConfig{

--- a/pkg/oci/utils_test_config.go
+++ b/pkg/oci/utils_test_config.go
@@ -86,51 +86,6 @@ const minimalConfig = `
 				"mode=0620",
 				"gid=5"
 			]
-		},
-		{
-			"destination": "/dev/shm",
-			"type": "tmpfs",
-			"source": "shm",
-			"options": [
-				"nosuid",
-				"noexec",
-				"nodev",
-				"mode=1777",
-				"size=65536k"
-			]
-		},
-		{
-			"destination": "/dev/mqueue",
-			"type": "mqueue",
-			"source": "mqueue",
-			"options": [
-				"nosuid",
-				"noexec",
-				"nodev"
-			]
-		},
-		{
-			"destination": "/sys",
-			"type": "sysfs",
-			"source": "sysfs",
-			"options": [
-				"nosuid",
-				"noexec",
-				"nodev",
-				"ro"
-			]
-		},
-		{
-			"destination": "/sys/fs/cgroup",
-			"type": "cgroup",
-			"source": "cgroup",
-			"options": [
-				"nosuid",
-				"noexec",
-				"nodev",
-				"relatime",
-				"ro"
-			]
 		}
 	],
 	"hooks": {},

--- a/pod.go
+++ b/pod.go
@@ -718,6 +718,10 @@ func (p *Pod) start() error {
 		return err
 	}
 
+	for _, c := range p.containers {
+		c.storeMounts()
+	}
+
 	if err := p.startSetStates(); err != nil {
 		return err
 	}

--- a/pod.go
+++ b/pod.go
@@ -932,6 +932,11 @@ func (p *Pod) checkContainersState(state stateString) error {
 // The container then uses the block device as its rootfs instead of overlay.
 // The container fstype is assigned the file system type of the block device to indicate this.
 func (p *Pod) addDrives() error {
+
+	if p.config.HypervisorConfig.DisableBlockDeviceUse {
+		return nil
+	}
+
 	for _, c := range p.containers {
 		dev, err := getDeviceForPath(c.rootFs)
 		if err != nil && err != errMountPointNotFound {

--- a/pod.go
+++ b/pod.go
@@ -212,6 +212,19 @@ func (s *Sockets) String() string {
 	return strings.Join(sockSlice, " ")
 }
 
+// Drive represents a block storage drive which may be used in case the storage
+// driver has an underlying block storage device.
+type Drive struct {
+
+	// Path to the disk-image/device which will be used with this drive
+	File string
+
+	// Format of the drive
+	Format string
+
+	ID string
+}
+
 // EnvVar is a key/value structure representing a command
 // environment variable.
 type EnvVar struct {

--- a/qemu.go
+++ b/qemu.go
@@ -205,6 +205,29 @@ func (q *qemu) appendVolume(devices []ciaoQemu.Device, volume Volume) []ciaoQemu
 	return devices
 }
 
+func (q *qemu) appendBlockDevice(devices []ciaoQemu.Device, drive Drive) []ciaoQemu.Device {
+	if drive.File == "" || drive.ID == "" || drive.Format == "" {
+		return devices
+	}
+
+	if len(drive.ID) > maxDevIDSize {
+		drive.ID = string(drive.ID[:maxDevIDSize])
+	}
+
+	devices = append(devices,
+		ciaoQemu.BlockDevice{
+			Driver:    ciaoQemu.VirtioBlock,
+			ID:        drive.ID,
+			File:      drive.File,
+			AIO:       ciaoQemu.Threads,
+			Format:    ciaoQemu.BlockDeviceFormat(drive.Format),
+			Interface: "none",
+		},
+	)
+
+	return devices
+}
+
 func (q *qemu) appendSocket(devices []ciaoQemu.Device, socket Socket) []ciaoQemu.Device {
 	devID := socket.ID
 	if len(devID) > maxDevIDSize {
@@ -610,6 +633,9 @@ func (q *qemu) addDevice(devInfo interface{}, devType deviceType) error {
 	case netDev:
 		endpoints := devInfo.([]Endpoint)
 		q.qemuConfig.Devices = q.appendNetworks(q.qemuConfig.Devices, endpoints)
+	case blockDev:
+		drive := devInfo.(Drive)
+		q.qemuConfig.Devices = q.appendBlockDevice(q.qemuConfig.Devices, drive)
 	default:
 		break
 	}

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -112,6 +112,8 @@ func testQemuAppend(t *testing.T, structure interface{}, expected []ciaoQemu.Dev
 		case consoleDev:
 			devices = q.appendConsoles(devices, s)
 		}
+	case Drive:
+		devices = q.appendBlockDevice(devices, s)
 	}
 
 	if reflect.DeepEqual(devices, expected) == false {
@@ -167,6 +169,31 @@ func TestQemuAppendSocket(t *testing.T) {
 	}
 
 	testQemuAppend(t, socket, expectedOut, -1)
+}
+
+func TestQemuAppendBlockDevice(t *testing.T) {
+	id := "blockDevTest"
+	file := "/root"
+	format := "raw"
+
+	expectedOut := []ciaoQemu.Device{
+		ciaoQemu.BlockDevice{
+			Driver:    ciaoQemu.VirtioBlock,
+			ID:        id,
+			File:      "/root",
+			AIO:       ciaoQemu.Threads,
+			Format:    ciaoQemu.BlockDeviceFormat(format),
+			Interface: "none",
+		},
+	}
+
+	drive := Drive{
+		File:   file,
+		Format: format,
+		ID:     id,
+	}
+
+	testQemuAppend(t, drive, expectedOut, -1)
 }
 
 func TestQemuAppendFSDevices(t *testing.T) {

--- a/utils.go
+++ b/utils.go
@@ -53,3 +53,12 @@ func generateRandomBytes(n int) ([]byte, error) {
 
 	return b, nil
 }
+
+func reverseString(s string) string {
+	r := []rune(s)
+	for i, j := 0, len(r)-1; i < len(r)/2; i, j = i+1, j-1 {
+		r[i], r[j] = r[j], r[i]
+	}
+
+	return string(r)
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -116,3 +116,15 @@ func TestFileCopySourceNotExistFailure(t *testing.T) {
 		t.Fatal("This test should fail because source file does not exist")
 	}
 }
+
+func TestGenerateRandomBytes(t *testing.T) {
+	bytesNeeded := 8
+	randBytes, err := generateRandomBytes(bytesNeeded)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(randBytes) != bytesNeeded {
+		t.Fatalf("Failed to generate %d random bytes", bytesNeeded)
+	}
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -128,3 +128,11 @@ func TestGenerateRandomBytes(t *testing.T) {
 		t.Fatalf("Failed to generate %d random bytes", bytesNeeded)
 	}
 }
+
+func TestRevereString(t *testing.T) {
+	str := "Teststr"
+	reversed := reverseString(str)
+	if reversed != "rtstseT" {
+		t.Fatal("Incorrect String Reversal")
+	}
+}


### PR DESCRIPTION
This PR handles the mounts passed with the OCI spec file. It handles the bind-mounts by passing them to the VM through 9pfs and handling the bind-mounting within the VM to work for both cases where we plan to use overlay as rootfs or a block device.
When devicemapper is the storage driver for the container rootfs, use the underlying block device instead.