### PR TITLE
Use block device for container rootfs in case of devicemapper

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -117,6 +117,10 @@ type agent interface {
 	// to handle all other Agent interface methods.
 	init(pod *Pod, config interface{}) error
 
+	// capabilities should return a structure that specifies the capabilities
+	// supported by the agent.
+	capabilities() capabilities
+
 	// exec will tell the agent to run a command in an already running container.
 	exec(pod *Pod, c Container, process Process, cmd Cmd) error
 

--- a/capabilities.go
+++ b/capabilities.go
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+const (
+	blockDeviceSupport = 1 << iota
+)
+
+type capabilities struct {
+	flags uint
+}
+
+func (caps *capabilities) isBlockDeviceSupported() bool {
+	if caps.flags&blockDeviceSupport != 0 {
+		return true
+	}
+	return false
+}
+
+func (caps *capabilities) setBlockDeviceSupport() {
+	caps.flags = caps.flags | blockDeviceSupport
+}

--- a/capabilities_test.go
+++ b/capabilities_test.go
@@ -1,0 +1,33 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import "testing"
+
+func TestBlockDeviceCapability(t *testing.T) {
+	var caps capabilities
+
+	if caps.isBlockDeviceSupported() {
+		t.Fatal()
+	}
+
+	caps.setBlockDeviceSupport()
+
+	if !caps.isBlockDeviceSupported() {
+		t.Fatal()
+	}
+}

--- a/container.go
+++ b/container.go
@@ -102,9 +102,6 @@ type Container struct {
 
 	rootFs string
 
-	// File system type of rootfs block device
-	fstype string
-
 	config *ContainerConfig
 
 	pod *Pod

--- a/container.go
+++ b/container.go
@@ -152,6 +152,28 @@ func (c *Container) SetPid(pid int) error {
 	return c.storeProcess()
 }
 
+func (c *Container) setStateBlockIndex(index int) error {
+	c.state.BlockIndex = index
+
+	err := c.pod.storage.storeContainerResource(c.pod.id, c.id, stateFileType, c.state)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Container) setStateFstype(fstype string) error {
+	c.state.Fstype = fstype
+
+	err := c.pod.storage.storeContainerResource(c.pod.id, c.id, stateFileType, c.state)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // URL returns the URL related to the pod.
 func (c *Container) URL() string {
 	return c.pod.URL()

--- a/container.go
+++ b/container.go
@@ -102,6 +102,9 @@ type Container struct {
 
 	rootFs string
 
+	// File system type of rootfs block device
+	fstype string
+
 	config *ContainerConfig
 
 	pod *Pod

--- a/container.go
+++ b/container.go
@@ -290,7 +290,7 @@ func newContainer(pod *Pod, contConfig ContainerConfig) (*Container, error) {
 
 	state, err := c.pod.storage.fetchContainerState(c.podID, c.id)
 	if err == nil {
-		c.state.State = state.State
+		c.state = state
 	}
 
 	process, err := c.pod.storage.fetchContainerProcess(c.podID, c.id)

--- a/container.go
+++ b/container.go
@@ -242,12 +242,10 @@ func (c *Container) setContainerState(state stateString) error {
 	}
 
 	// update in-memory state
-	c.state = State{
-		State: state,
-	}
+	c.state.State = state
 
 	// update on-disk state
-	err := c.pod.storage.storeContainerResource(c.podID, c.id, stateFileType, c.state)
+	err := c.pod.storage.storeContainerResource(c.pod.id, c.id, stateFileType, c.state)
 	if err != nil {
 		return err
 	}

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -323,7 +323,9 @@ func (h *hyper) bindUnmountContainerRootfs(podID, cID string) error {
 func (h *hyper) bindUnmountAllRootfs(pod Pod) {
 	for _, c := range pod.containers {
 		h.bindUnmountContainerMounts(c.mounts)
-		h.bindUnmountContainerRootfs(pod.id, c.id)
+		if c.fstype == "" {
+			h.bindUnmountContainerRootfs(pod.id, c.id)
+		}
 	}
 }
 
@@ -541,11 +543,12 @@ func (h *hyper) startOneContainer(pod Pod, c Container) error {
 		container.Fstype = c.fstype
 		container.Image = driveName
 		diskIndex = diskIndex + 1
-	}
+	} else {
 
-	if err := h.bindMountContainerRootfs(pod.id, c.id, c.rootFs, false); err != nil {
-		h.bindUnmountAllRootfs(pod)
-		return err
+		if err := h.bindMountContainerRootfs(pod.id, c.id, c.rootFs, false); err != nil {
+			h.bindUnmountAllRootfs(pod)
+			return err
+		}
 	}
 
 	//TODO : Enter mount namespace
@@ -618,8 +621,10 @@ func (h *hyper) stopOneContainer(podID string, c Container) error {
 		return err
 	}
 
-	if err := h.bindUnmountContainerRootfs(podID, c.id); err != nil {
-		return err
+	if c.fstype == "" {
+		if err := h.bindUnmountContainerRootfs(podID, c.id); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -517,6 +517,8 @@ func (h *hyper) startPauseContainer(podID string) error {
 	return nil
 }
 
+var diskIndex = int(0)
+
 func (h *hyper) startOneContainer(pod Pod, c Container) error {
 	process, err := h.buildHyperContainerProcess(c.config.Cmd)
 	if err != nil {
@@ -528,6 +530,17 @@ func (h *hyper) startOneContainer(pod Pod, c Container) error {
 		Image:   c.id,
 		Rootfs:  rootfsDir,
 		Process: process,
+	}
+
+	if c.fstype != "" {
+		driveName, err := getVirtDriveName(diskIndex)
+		if err != nil {
+			return err
+		}
+
+		container.Fstype = c.fstype
+		container.Image = driveName
+		diskIndex = diskIndex + 1
 	}
 
 	if err := h.bindMountContainerRootfs(pod.id, c.id, c.rootFs, false); err != nil {

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -376,6 +376,15 @@ func (h *hyper) init(pod *Pod, config interface{}) (err error) {
 	return nil
 }
 
+func (h *hyper) capabilities() capabilities {
+	var caps capabilities
+
+	// add all capabilities supported by agent
+	caps.setBlockDeviceSupport()
+
+	return caps
+}
+
 // exec is the agent command execution implementation for hyperstart.
 func (h *hyper) exec(pod *Pod, c Container, process Process, cmd Cmd) error {
 	hyperProcess, err := h.buildHyperContainerProcess(cmd)

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -323,7 +323,9 @@ func (h *hyper) bindUnmountContainerRootfs(podID, cID string) error {
 func (h *hyper) bindUnmountAllRootfs(pod Pod) {
 	for _, c := range pod.containers {
 		h.bindUnmountContainerMounts(c.mounts)
-		if c.fstype == "" {
+		if c.state.Fstype == "" {
+			// Need to check for error returned by this call.
+			// See: https://github.com/containers/virtcontainers/issues/295
 			h.bindUnmountContainerRootfs(pod.id, c.id)
 		}
 	}
@@ -519,8 +521,6 @@ func (h *hyper) startPauseContainer(podID string) error {
 	return nil
 }
 
-var diskIndex = int(0)
-
 func (h *hyper) startOneContainer(pod Pod, c Container) error {
 	process, err := h.buildHyperContainerProcess(c.config.Cmd)
 	if err != nil {
@@ -534,15 +534,14 @@ func (h *hyper) startOneContainer(pod Pod, c Container) error {
 		Process: process,
 	}
 
-	if c.fstype != "" {
-		driveName, err := getVirtDriveName(diskIndex)
+	if c.state.Fstype != "" {
+		driveName, err := getVirtDriveName(c.state.BlockIndex)
 		if err != nil {
 			return err
 		}
 
-		container.Fstype = c.fstype
+		container.Fstype = c.state.Fstype
 		container.Image = driveName
-		diskIndex = diskIndex + 1
 	} else {
 
 		if err := h.bindMountContainerRootfs(pod.id, c.id, c.rootFs, false); err != nil {
@@ -621,7 +620,7 @@ func (h *hyper) stopOneContainer(podID string, c Container) error {
 		return err
 	}
 
-	if c.fstype == "" {
+	if c.state.Fstype == "" {
 		if err := h.bindUnmountContainerRootfs(podID, c.id); err != nil {
 			return err
 		}

--- a/hypervisor.go
+++ b/hypervisor.go
@@ -112,6 +112,9 @@ type HypervisorConfig struct {
 	// HypervisorPath is the hypervisor executable host path.
 	HypervisorPath string
 
+	// DisableBlockDeviceUse disallows a block device from being used.
+	DisableBlockDeviceUse bool
+
 	// KernelParams are additional guest kernel parameters.
 	KernelParams []Param
 

--- a/mount.go
+++ b/mount.go
@@ -181,3 +181,21 @@ func getDevicePathAndFsType(mountPoint string) (devicePath, fsType string, err e
 		}
 	}
 }
+
+var blockFormatTemplate = "/sys/dev/block/%d:%d/dm"
+
+// isDeviceMapper checks if the device with the major and minor numbers is a devicemapper block device
+func isDeviceMapper(major, minor int) (bool, error) {
+
+	//Check if /sys/dev/block/${major}-${minor}/dm exists
+	sysPath := fmt.Sprintf(blockFormatTemplate, major, minor)
+
+	_, err := os.Stat(sysPath)
+	if err == nil {
+		return true, nil
+	} else if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	return false, err
+}

--- a/mount.go
+++ b/mount.go
@@ -16,7 +16,13 @@
 
 package virtcontainers
 
-import "strings"
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
 
 // These mounts need to be created by the agent within the VM
 var systemMounts = []string{"/proc", "/dev", "/dev/pts", "/dev/shm", "/dev/mqueue", "/sys", "/sys/fs/cgroup"}
@@ -31,4 +37,93 @@ func isSystemMount(m string) bool {
 	}
 
 	return false
+}
+
+func major(dev uint64) int {
+	return int((dev >> 8) & 0xfff)
+}
+
+func minor(dev uint64) int {
+	return int((dev & 0xff) | ((dev >> 12) & 0xfff00))
+}
+
+type device struct {
+	major      int
+	minor      int
+	mountPoint string
+}
+
+var errMountPointNotFound = errors.New("Mount point not found")
+
+// getDeviceForPath gets the underlying device containing the file specified by path.
+// The device type constitutes the major-minor number of the device and the dest mountPoint for the device
+//
+// eg. if /dev/sda1 is mounted on /a/b/c, a call to getDeviceForPath("/a/b/c/file") would return
+//
+//	device {
+//		major : major(/dev/sda1)
+//		manor : minor(/dev/sda1)
+//		mountPoint: /a/b/c
+//	}
+func getDeviceForPath(path string) (device, error) {
+	if path == "" {
+		return device{}, fmt.Errorf("Path cannot be empty")
+	}
+
+	stat := syscall.Stat_t{}
+	err := syscall.Stat(path, &stat)
+	if err != nil {
+		return device{}, err
+	}
+
+	// stat.Dev points to the underlying device containing the file
+	major := major(stat.Dev)
+	minor := minor(stat.Dev)
+
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return device{}, err
+	}
+
+	mountPoint := path
+
+	if path == "/" {
+		return device{
+			major:      major,
+			minor:      minor,
+			mountPoint: mountPoint,
+		}, nil
+	}
+
+	// We get the mount point by recursively peforming stat on the path
+	// The point where the device changes indicates the mountpoint
+	for {
+		if mountPoint == "/" {
+			return device{}, errMountPointNotFound
+		}
+
+		parentStat := syscall.Stat_t{}
+		parentDir := filepath.Dir(path)
+
+		err := syscall.Lstat(parentDir, &parentStat)
+		if err != nil {
+			return device{}, err
+		}
+
+		if parentStat.Dev != stat.Dev {
+			break
+		}
+
+		mountPoint = parentDir
+		stat = parentStat
+		path = parentDir
+	}
+
+	dev := device{
+		major:      major,
+		minor:      minor,
+		mountPoint: mountPoint,
+	}
+
+	return dev, nil
 }

--- a/mount.go
+++ b/mount.go
@@ -199,3 +199,36 @@ func isDeviceMapper(major, minor int) (bool, error) {
 
 	return false, err
 }
+
+// getVirtBlockDriveName returns the disk name format for virtio-blk
+// Reference: https://github.com/torvalds/linux/blob/master/drivers/block/virtio_blk.c @c0aa3e0916d7e531e69b02e426f7162dfb1c6c0
+func getVirtDriveName(index int) (string, error) {
+	if index < 0 {
+		return "", fmt.Errorf("Index cannot be negative for drive")
+	}
+
+	// Prefix used for virtio-block devices
+	const prefix = "vd"
+
+	//Refer to DISK_NAME_LEN: https://github.com/torvalds/linux/blob/08c521a2011ff492490aa9ed6cc574be4235ce2b/include/linux/genhd.h#L61
+	diskNameLen := 32
+	base := 26
+
+	suffLen := diskNameLen - len(prefix)
+	diskLetters := make([]byte, suffLen)
+
+	var i int
+
+	for i = 0; i < suffLen && index >= 0; i++ {
+		letter := byte('a' + (index % base))
+		diskLetters[i] = letter
+		index = index/base - 1
+	}
+
+	if index >= 0 {
+		return "", fmt.Errorf("Index not supported")
+	}
+
+	diskName := prefix + reverseString(string(diskLetters[:i]))
+	return diskName, nil
+}

--- a/mount_test.go
+++ b/mount_test.go
@@ -250,3 +250,35 @@ func TestIsDeviceMapper(t *testing.T) {
 		t.Fatal()
 	}
 }
+
+func TestGetVirtDriveNameInvalidIndex(t *testing.T) {
+	_, err := getVirtDriveName(-1)
+
+	if err == nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetVirtDriveName(t *testing.T) {
+	tests := []struct {
+		index         int
+		expectedDrive string
+	}{
+		{0, "vda"},
+		{25, "vdz"},
+		{27, "vdab"},
+		{704, "vdaac"},
+		{18277, "vdzzz"},
+	}
+
+	for _, test := range tests {
+		driveName, err := getVirtDriveName(test.index)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if driveName != test.expectedDrive {
+			t.Fatalf("Incorrect drive Name: Got: %s, Expecting :%s", driveName, test.expectedDrive)
+
+		}
+	}
+}

--- a/mount_test.go
+++ b/mount_test.go
@@ -16,7 +16,17 @@
 
 package virtcontainers
 
-import "testing"
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+)
 
 func TestIsSystemMount(t *testing.T) {
 	tests := []struct {
@@ -39,5 +49,158 @@ func TestIsSystemMount(t *testing.T) {
 		if result != test.expected {
 			t.Fatalf("Expected result for path %s : %v, got %v", test.mnt, test.expected, result)
 		}
+	}
+}
+
+func TestMajorMinorNumber(t *testing.T) {
+	devices := []string{"/dev/zero", "/dev/net/tun"}
+
+	for _, device := range devices {
+		cmdStr := fmt.Sprintf("ls -l %s | awk '{print $5$6}'", device)
+		cmd := exec.Command("sh", "-c", cmdStr)
+		output, err := cmd.Output()
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		data := bytes.Split(output, []byte(","))
+		if len(data) < 2 {
+			t.Fatal()
+		}
+
+		majorStr := strings.TrimSpace(string(data[0]))
+		minorStr := strings.TrimSpace(string(data[1]))
+
+		majorNo, err := strconv.Atoi(majorStr)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		minorNo, err := strconv.Atoi(minorStr)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		stat := syscall.Stat_t{}
+		err = syscall.Stat(device, &stat)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Get major and minor numbers for the device itself. Note the use of stat.Rdev instead of Dev.
+		major := major(stat.Rdev)
+		minor := minor(stat.Rdev)
+
+		if minor != minorNo {
+			t.Fatalf("Expected minor number for device %s: %d, Got :%d", device, minorNo, minor)
+		}
+
+		if major != majorNo {
+			t.Fatalf("Expected major number for device %s : %d, Got :%d", device, majorNo, major)
+		}
+	}
+}
+
+func TestGetDeviceForPathRoot(t *testing.T) {
+	dev, err := getDeviceForPath("/")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "/"
+
+	if dev.mountPoint != expected {
+		t.Fatalf("Expected %s mountpoint, got %s", expected, dev.mountPoint)
+	}
+}
+
+func TestGetDeviceForPathValidMount(t *testing.T) {
+	dev, err := getDeviceForPath("/proc")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "/proc"
+
+	if dev.mountPoint != expected {
+		t.Fatalf("Expected %s mountpoint, got %s", expected, dev.mountPoint)
+	}
+}
+
+func TestGetDeviceForPathEmptyPath(t *testing.T) {
+	_, err := getDeviceForPath("")
+	if err == nil {
+		t.Fatal()
+	}
+}
+
+func TestGetDeviceForPath(t *testing.T) {
+	dev, err := getDeviceForPath("///")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if dev.mountPoint != "/" {
+		t.Fatal(err)
+	}
+
+	_, err = getDeviceForPath("/../../.././././../.")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = getDeviceForPath("/root/file with spaces")
+	if err == nil {
+		t.Fatal()
+	}
+}
+
+func TestGetDeviceForPathBindMount(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip(testDisabledAsNonRoot)
+	}
+
+	source := filepath.Join(testDir, "testDeviceDirSrc")
+	dest := filepath.Join(testDir, "testDeviceDirDest")
+	syscall.Unmount(dest, 0)
+	os.Remove(source)
+	os.Remove(dest)
+
+	err := os.MkdirAll(source, mountPerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.Remove(source)
+
+	err = os.MkdirAll(dest, mountPerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.Remove(dest)
+
+	err = bindMount(source, dest, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer syscall.Unmount(dest, 0)
+
+	destFile := filepath.Join(dest, "test")
+	_, err = os.Create(destFile)
+	if err != nil {
+		fmt.Println("Could not create test file:", err)
+		t.Fatal(err)
+	}
+
+	defer os.Remove(destFile)
+
+	sourceDev, _ := getDeviceForPath(source)
+	destDev, _ := getDeviceForPath(destFile)
+
+	if sourceDev != destDev {
+		t.Fatal()
 	}
 }

--- a/mount_test.go
+++ b/mount_test.go
@@ -224,3 +224,29 @@ func TestGetDevicePathAndFsTypeSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestIsDeviceMapper(t *testing.T) {
+	// known major, minor for /dev/tty
+	major := 5
+	minor := 0
+
+	isDM, err := isDeviceMapper(major, minor)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if isDM {
+		t.Fatal()
+	}
+
+	// fake the block device format
+	blockFormatTemplate = "/sys/dev/char/%d:%d"
+	isDM, err = isDeviceMapper(major, minor)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !isDM {
+		t.Fatal()
+	}
+}

--- a/mount_test.go
+++ b/mount_test.go
@@ -204,3 +204,23 @@ func TestGetDeviceForPathBindMount(t *testing.T) {
 		t.Fatal()
 	}
 }
+
+func TestGetDevicePathAndFsTypeEmptyMount(t *testing.T) {
+	_, _, err := getDevicePathAndFsType("")
+
+	if err == nil {
+		t.Fatal()
+	}
+}
+
+func TestGetDevicePathAndFsTypeSuccessful(t *testing.T) {
+	path, fstype, err := getDevicePathAndFsType("/proc")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if path != "proc" || fstype != "proc" {
+		t.Fatal(err)
+	}
+}

--- a/noop_agent.go
+++ b/noop_agent.go
@@ -30,6 +30,11 @@ func (n *noopAgent) init(pod *Pod, config interface{}) error {
 	return nil
 }
 
+// capabilities returns empty capabilities, i.e no capabilties are supported.
+func (n *noopAgent) capabilities() capabilities {
+	return capabilities{}
+}
+
 // exec is the Noop agent command execution implementation. It does nothing.
 func (n *noopAgent) exec(pod *Pod, c Container, process Process, cmd Cmd) error {
 	return nil

--- a/pod.go
+++ b/pod.go
@@ -975,21 +975,13 @@ func (p *Pod) setContainerState(containerID string, state stateString) error {
 		return errNeedContainerID
 	}
 
-	contState := State{
-		State: state,
+	c := p.GetContainer(containerID)
+	if c == nil {
+		return fmt.Errorf("Pod %s has no container %s", p.id, containerID)
 	}
 
-	c, err := p.getContainer(containerID)
-	if err != nil {
-		return err
-	}
-
-	// update in-memory state
-	c.state = contState
-
-	// update on-disk state
-	err = p.storage.storeContainerResource(p.id, containerID, stateFileType, contState)
-	if err != nil {
+	// Let container handle its state update
+	if err := c.setContainerState(state); err != nil {
 		return err
 	}
 

--- a/pod.go
+++ b/pod.go
@@ -556,6 +556,15 @@ func createPod(podConfig PodConfig) (*Pod, error) {
 		return p, nil
 	}
 
+	// fetch agent capabilities and call addDrives if the agent has support
+	// for block devices.
+	caps := p.agent.capabilities()
+	if caps.isBlockDeviceSupported() {
+		if err := p.addDrives(); err != nil {
+			return nil, err
+		}
+	}
+
 	if err := p.createSetStates(); err != nil {
 		p.storage.deletePodResources(p.id, nil)
 		return nil, err

--- a/pod.go
+++ b/pod.go
@@ -1093,3 +1093,53 @@ func togglePausePod(podID string, pause bool) (*Pod, error) {
 
 	return p, nil
 }
+
+// addDrives can be used to pass block storage devices to the hypervisor in case of devicemapper storage.
+// The container then uses the block device as its rootfs instead of overlay.
+// The container fstype is assigned the file system type of the block device to indicate this.
+func (p *Pod) addDrives() error {
+	for _, c := range p.containers {
+		dev, err := getDeviceForPath(c.rootFs)
+		if err != nil && err != errMountPointNotFound {
+			return err
+		}
+
+		if err == errMountPointNotFound {
+			continue
+		}
+
+		virtLog.Infof("Device details for container %s: Major:%d, Minor:%d, MountPoint:%s\n", c.id, dev.major, dev.minor, dev.mountPoint)
+
+		isDM, err := isDeviceMapper(dev.major, dev.minor)
+		if err != nil {
+			return err
+		}
+
+		if !isDM {
+			continue
+		}
+
+		// If device mapper device, then fetch the full path of the device
+		devicePath, fsType, err := getDevicePathAndFsType(dev.mountPoint)
+		if err != nil {
+			return err
+		}
+
+		virtLog.Infof("Block Device path %s detected for container with fstype : %s\n", devicePath, c.id, fsType)
+
+		// Add drive with id as container id
+		devID := fmt.Sprintf("drive-%s", c.id)
+		drive := Drive{
+			File:   devicePath,
+			Format: "raw",
+			ID:     devID,
+		}
+
+		if err := p.hypervisor.addDevice(drive, blockDev); err != nil {
+			return err
+		}
+
+		c.fstype = fsType
+	}
+	return nil
+}

--- a/pod.go
+++ b/pod.go
@@ -220,6 +220,20 @@ func (s *Sockets) String() string {
 	return strings.Join(sockSlice, " ")
 }
 
+// Drive represents a block storage drive which may be used in case the storage
+// driver has an underlying block storage device.
+type Drive struct {
+
+	// Path to the disk-image/device which will be used with this drive
+	File string
+
+	// Format of the drive
+	Format string
+
+	// ID is used to identify this drive in the hypervisor options.
+	ID string
+}
+
 // EnvVar is a key/value structure representing a command
 // environment variable.
 type EnvVar struct {

--- a/pod.go
+++ b/pod.go
@@ -58,6 +58,12 @@ const (
 type State struct {
 	State stateString `json:"state"`
 	URL   string      `json:"url,omitempty"`
+
+	// Index of the block device passed to hypervisor.
+	BlockIndex int `json:"blockIndex"`
+
+	// File system of the rootfs incase it is block device
+	Fstype string `json:"fstype"`
 }
 
 // valid checks that the pod state is valid.

--- a/pod.go
+++ b/pod.go
@@ -1107,6 +1107,11 @@ func togglePausePod(podID string, pause bool) (*Pod, error) {
 // The container then uses the block device as its rootfs instead of overlay.
 // The container fstype is assigned the file system type of the block device to indicate this.
 func (p *Pod) addDrives() error {
+
+	if p.config.HypervisorConfig.DisableBlockDeviceUse {
+		return nil
+	}
+
 	for _, c := range p.containers {
 		dev, err := getDeviceForPath(c.rootFs)
 		if err != nil && err != errMountPointNotFound {

--- a/qemu.go
+++ b/qemu.go
@@ -205,6 +205,29 @@ func (q *qemu) appendVolume(devices []ciaoQemu.Device, volume Volume) []ciaoQemu
 	return devices
 }
 
+func (q *qemu) appendBlockDevice(devices []ciaoQemu.Device, drive Drive) []ciaoQemu.Device {
+	if drive.File == "" || drive.ID == "" || drive.Format == "" {
+		return devices
+	}
+
+	if len(drive.ID) > maxDevIDSize {
+		drive.ID = string(drive.ID[:maxDevIDSize])
+	}
+
+	devices = append(devices,
+		ciaoQemu.BlockDevice{
+			Driver:    ciaoQemu.VirtioBlock,
+			ID:        drive.ID,
+			File:      drive.File,
+			AIO:       ciaoQemu.Threads,
+			Format:    ciaoQemu.BlockDeviceFormat(drive.Format),
+			Interface: "none",
+		},
+	)
+
+	return devices
+}
+
 func (q *qemu) appendSocket(devices []ciaoQemu.Device, socket Socket) []ciaoQemu.Device {
 	devID := socket.ID
 	if len(devID) > maxDevIDSize {
@@ -657,6 +680,9 @@ func (q *qemu) addDevice(devInfo interface{}, devType deviceType) error {
 	case netDev:
 		endpoints := devInfo.([]Endpoint)
 		q.qemuConfig.Devices = q.appendNetworks(q.qemuConfig.Devices, endpoints)
+	case blockDev:
+		drive := devInfo.(Drive)
+		q.qemuConfig.Devices = q.appendBlockDevice(q.qemuConfig.Devices, drive)
 	default:
 		break
 	}

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -112,6 +112,8 @@ func testQemuAppend(t *testing.T, structure interface{}, expected []ciaoQemu.Dev
 		case consoleDev:
 			devices = q.appendConsoles(devices, s)
 		}
+	case Drive:
+		devices = q.appendBlockDevice(devices, s)
 	}
 
 	if reflect.DeepEqual(devices, expected) == false {
@@ -167,6 +169,31 @@ func TestQemuAppendSocket(t *testing.T) {
 	}
 
 	testQemuAppend(t, socket, expectedOut, -1)
+}
+
+func TestQemuAppendBlockDevice(t *testing.T) {
+	id := "blockDevTest"
+	file := "/root"
+	format := "raw"
+
+	expectedOut := []ciaoQemu.Device{
+		ciaoQemu.BlockDevice{
+			Driver:    ciaoQemu.VirtioBlock,
+			ID:        id,
+			File:      "/root",
+			AIO:       ciaoQemu.Threads,
+			Format:    ciaoQemu.BlockDeviceFormat(format),
+			Interface: "none",
+		},
+	}
+
+	drive := Drive{
+		File:   file,
+		Format: format,
+		ID:     id,
+	}
+
+	testQemuAppend(t, drive, expectedOut, -1)
 }
 
 func TestQemuAppendFSDevices(t *testing.T) {

--- a/sshd.go
+++ b/sshd.go
@@ -105,6 +105,10 @@ func (s *sshd) init(pod *Pod, config interface{}) error {
 	return nil
 }
 
+func (s *sshd) capabilities() capabilities {
+	return capabilities{}
+}
+
 // exec is the agent command execution implementation for sshd.
 func (s *sshd) exec(pod *Pod, c Container, process Process, cmd Cmd) error {
 	if pod == nil {

--- a/utils.go
+++ b/utils.go
@@ -53,3 +53,14 @@ func generateRandomBytes(n int) ([]byte, error) {
 
 	return b, nil
 }
+
+func reverseString(s string) string {
+	r := []rune(s)
+
+	length := len(r)
+	for i, j := 0, length-1; i < length/2; i, j = i+1, j-1 {
+		r[i], r[j] = r[j], r[i]
+	}
+
+	return string(r)
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -128,3 +128,12 @@ func TestGenerateRandomBytes(t *testing.T) {
 		t.Fatalf("Failed to generate %d random bytes", bytesNeeded)
 	}
 }
+
+func TestRevereString(t *testing.T) {
+	str := "Teststr"
+	reversed := reverseString(str)
+
+	if reversed != "rtstseT" {
+		t.Fatal("Incorrect String Reversal")
+	}
+}


### PR DESCRIPTION
In case of device mapper storage driver, the overlay file system is backed by a block device.
With this PR, we directly use the block device for container rootfs, instead of the overlay. As we do not go through 9pfs, this gives us much better I/O performance. We go through 9pfs only for the bind-mounts.

