### PR TITLE
api: Implement PausePod() and ResumePod().

### DIFF
--- a/api.go
+++ b/api.go
@@ -630,3 +630,15 @@ func KillContainer(podID, containerID string, signal syscall.Signal, all bool) e
 
 	return nil
 }
+
+// PausePod is the virtcontainers pausing entry point which pauses an
+// already running pod.
+func PausePod(podID string) (*Pod, error) {
+	return togglePausePod(podID, true)
+}
+
+// ResumePod is the virtcontainers resuming entry point which resumes
+// (or unpauses) and already paused pod.
+func ResumePod(podID string) (*Pod, error) {
+	return togglePausePod(podID, false)
+}

--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -459,6 +459,28 @@ func stopPod(context *cli.Context) error {
 	return nil
 }
 
+func pausePod(context *cli.Context) error {
+	p, err := vc.PausePod(context.String("id"))
+	if err != nil {
+		return fmt.Errorf("Could not pause pod: %s", err)
+	}
+
+	fmt.Printf("Pod %s paused\n", p.ID())
+
+	return nil
+}
+
+func resumePod(context *cli.Context) error {
+	p, err := vc.ResumePod(context.String("id"))
+	if err != nil {
+		return fmt.Errorf("Could not resume pod: %s", err)
+	}
+
+	fmt.Printf("Pod %s resumed\n", p.ID())
+
+	return nil
+}
+
 func listPods(context *cli.Context) error {
 	podStatusList, err := vc.ListPod()
 	if err != nil {
@@ -584,6 +606,36 @@ var statusPodCommand = cli.Command{
 	},
 	Action: func(context *cli.Context) error {
 		return checkPodArgs(context, statusPod)
+	},
+}
+
+var pausePodCommand = cli.Command{
+	Name:  "pause",
+	Usage: "pause an existing pod",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "id",
+			Value: "",
+			Usage: "the pod identifier",
+		},
+	},
+	Action: func(context *cli.Context) error {
+		return checkPodArgs(context, pausePod)
+	},
+}
+
+var resumePodCommand = cli.Command{
+	Name:  "resume",
+	Usage: "unpause a paused pod",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "id",
+			Value: "",
+			Usage: "the pod identifier",
+		},
+	},
+	Action: func(context *cli.Context) error {
+		return checkPodArgs(context, resumePod)
 	},
 }
 
@@ -919,6 +971,8 @@ func main() {
 				createPodCommand,
 				deletePodCommand,
 				listPodsCommand,
+				pausePodCommand,
+				resumePodCommand,
 				runPodCommand,
 				startPodCommand,
 				stopPodCommand,

--- a/hypervisor.go
+++ b/hypervisor.go
@@ -171,6 +171,8 @@ type hypervisor interface {
 	createPod(podConfig PodConfig) error
 	startPod(startCh, stopCh chan struct{}) error
 	stopPod() error
+	pausePod() error
+	resumePod() error
 	addDevice(devInfo interface{}, devType deviceType) error
 	getPodConsole(podID string) string
 }

--- a/mock_hypervisor.go
+++ b/mock_hypervisor.go
@@ -42,6 +42,14 @@ func (m *mockHypervisor) stopPod() error {
 	return nil
 }
 
+func (m *mockHypervisor) pausePod() error {
+	return nil
+}
+
+func (m *mockHypervisor) resumePod() error {
+	return nil
+}
+
 func (m *mockHypervisor) addDevice(devInfo interface{}, devType deviceType) error {
 	return nil
 }

--- a/pod.go
+++ b/pod.go
@@ -47,6 +47,9 @@ const (
 	// StateRunning represents a pod/container that's currently running.
 	StateRunning stateString = "running"
 
+	// StatePaused represents a pod/container that has been paused.
+	StatePaused stateString = "paused"
+
 	// StateStopped represents a pod/container that has been stopped.
 	StateStopped stateString = "stopped"
 )
@@ -59,7 +62,7 @@ type State struct {
 
 // valid checks that the pod state is valid.
 func (state *State) valid() bool {
-	for _, validState := range []stateString{StateReady, StateRunning, StateStopped} {
+	for _, validState := range []stateString{StateReady, StateRunning, StatePaused, StateStopped} {
 		if state.State == validState {
 			return true
 		}
@@ -82,7 +85,12 @@ func (state *State) validTransition(oldState stateString, newState stateString) 
 		}
 
 	case StateRunning:
-		if newState == StateStopped {
+		if newState == StatePaused || newState == StateStopped {
+			return nil
+		}
+
+	case StatePaused:
+		if newState == StateRunning || newState == StateStopped {
 			return nil
 		}
 
@@ -350,7 +358,7 @@ func unlockPod(lockFile *os.File) error {
 }
 
 // Pod is composed of a set of containers and a runtime environment.
-// A Pod can be created, deleted, started, stopped, listed, entered, paused and restored.
+// A Pod can be created, deleted, started, paused, stopped, listed, entered, and restored.
 type Pod struct {
 	id string
 
@@ -584,8 +592,8 @@ func (p *Pod) delete() error {
 		return err
 	}
 
-	if state.State != StateReady && state.State != StateStopped {
-		return fmt.Errorf("Pod not ready or stopped, impossible to delete")
+	if state.State != StateReady && state.State != StatePaused && state.State != StateStopped {
+		return fmt.Errorf("Pod not ready, paused or stopped, impossible to delete")
 	}
 
 	err = p.storage.deletePodResources(p.id, nil)
@@ -785,6 +793,49 @@ func (p *Pod) stopShims() error {
 	return nil
 }
 
+func (p *Pod) pauseSetStates() error {
+	state := State{
+		State: StatePaused,
+		URL:   p.state.URL,
+	}
+
+	// XXX: When a pod is paused, all its containers are forcibly
+	// paused too.
+
+	err := p.setContainersState(state.State)
+	if err != nil {
+		return err
+	}
+
+	err = p.setPodState(state)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *Pod) resumeSetStates() error {
+	state := State{
+		State: StateRunning,
+		URL:   p.state.URL,
+	}
+
+	// XXX: Resuming a paused pod puts all containers back into the
+	// running state.
+	err := p.setContainersState(state.State)
+	if err != nil {
+		return err
+	}
+
+	err = p.setPodState(state)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // stopVM stops the agent inside the VM and shut down the VM itself.
 func (p *Pod) stopVM() error {
 	if _, _, err := p.proxy.connect(*p, false); err != nil {
@@ -823,6 +874,30 @@ func (p *Pod) stop() error {
 	}
 
 	if err := p.stopSetStates(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *Pod) pause() error {
+	if err := p.hypervisor.pausePod(); err != nil {
+		return err
+	}
+
+	if err := p.pauseSetStates(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *Pod) resume() error {
+	if err := p.hypervisor.resumePod(); err != nil {
+		return err
+	}
+
+	if err := p.resumeSetStates(); err != nil {
 		return err
 	}
 
@@ -967,4 +1042,36 @@ func (p *Pod) checkContainersState(state stateString) error {
 	}
 
 	return nil
+}
+
+// togglePausePod pauses a pod if pause is set to true, else it resumes
+// it.
+func togglePausePod(podID string, pause bool) (*Pod, error) {
+	if podID == "" {
+		return nil, errNeedPod
+	}
+
+	lockFile, err := lockPod(podID)
+	if err != nil {
+		return nil, err
+	}
+	defer unlockPod(lockFile)
+
+	// Fetch the pod from storage and create it.
+	p, err := fetchPod(podID)
+	if err != nil {
+		return nil, err
+	}
+
+	if pause {
+		err = p.pause()
+	} else {
+		err = p.resume()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return p, nil
 }

--- a/pod_test.go
+++ b/pod_test.go
@@ -123,14 +123,21 @@ func TestPodStateReadyRunning(t *testing.T) {
 }
 
 func TestPodStateRunningPaused(t *testing.T) {
-	err := testPodStateTransition(t, StateRunning, StateStopped)
+	err := testPodStateTransition(t, StateRunning, StatePaused)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestPodStatePausedRunning(t *testing.T) {
-	err := testPodStateTransition(t, StateStopped, StateRunning)
+	err := testPodStateTransition(t, StatePaused, StateRunning)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPodStatePausedStopped(t *testing.T) {
+	err := testPodStateTransition(t, StatePaused, StateStopped)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,6 +264,7 @@ func testStateValid(t *testing.T, stateStr stateString, expected bool) {
 func TestStateValidSuccessful(t *testing.T) {
 	testStateValid(t, StateReady, true)
 	testStateValid(t, StateRunning, true)
+	testStateValid(t, StatePaused, true)
 	testStateValid(t, StateStopped, true)
 }
 


### PR DESCRIPTION
Allow a pod to be paused (all processes suspended) and resumed (all
processes allowed to continue).

Fixes #267.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>