### PR TITLE
1.0.0-rc.0 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,14 @@
+1.0.0-rc.0:
+	Added pod pause and resume support
+	Added bind mounts support
+	Added CRI-O support
+	Added QEMU Q35 machine type support
+	Added readonly rootfs support
+	Added annotations passing to the OCI config file
+	Fixed hyperstart users and groups management
+	Fixed the installation and build scripts
+	Fixed networking MAC address configuration
+
 0.7.0:
 	Added Clear Containers 3.0 shim support
 	Added Clear Containers 3.0 proxy protocol support


### PR DESCRIPTION
Added pod pause and resume support
Added bind mounts support
Added CRI-O support
Added QEMU Q35 machine type support
Added readonly rootfs support
Added annotations passing to the OCI config file
Fixed hyperstart users and groups management
Fixed the installation and build scripts
Fixed networking MAC address configuration

Shortlog:

0b08b32 api: Implement PausePod() and ResumePod().
0e47e70 pod: Make state handling functions set in-memory state.
d2e6aaa mounts: Add function to perform unmounts
3719480 mounts: Store mounts after bind-mounts are handled
63cbcca state: Add functionality to store/fetch mounts to/from filesystem.
a249fde test: Add test for checking if a path is system mount
0ef264e mounts: Handle bind mounts
90ef63f container: Add comments for setContainerState().
6b8f0b5 tests: Add test to verify mounts are parsed and stored
a98a913 mounts: Parse and store mounts from oci spec file.
53b7cad vendor: Add CRI-O vendoring to our list of dependencies
c53cfa8 oci: Implement CRI-O support
bdefe47 hyperstart: Limit the hostname length to prevent from hyperstart errors
f663cb2 hyperstart: Prevent container rootfs from being mounted readonly
c3a4570 hyperstart: User and groups are not handled properly
b25540e container: Get pod handler from any container
c611050 network: Determine if netns was provided or created
ab994f0 api: Execute poststart and poststop hooks outside of netns
2e3765e shim: Stop the shim if container has only been created
2ccf287 api: Remove the session ending call
181d371 logging: Use the logrus.FieldLogger interface in SetLogger
a46174b logging: Rename SetLog to SetLogger
64b2808 utils: Fix the script installing CNI plugins
bf18ba1 test: Add test to verify the readonly config for rootfs is assigned
2c6a037 oci: Pass the read-only config from the oci spec file
6b7c753 tests: Use defer with call to unmount
725de4d api: Add 'all' parameter to KillContainer().
b42fa98 tests: Add test to verify read-only bind mounts
b51fd53 rootfs: Support mounting the rootfs as readonly
8d49dfc oci: copy container's annotations to pod
8155768 pod: Adds RW lock to access pod's annotations
c1cb7eb pod: add function to get pod's annotations
8509c34 pod: add function to set or add annotations
148ba85 container: Add function to get container's annotations
449497a vendor: Update runtime-spec to v1.0.0-rc5 to be CRI-O compliant
9e7005c vendor: Update all vendored repositories
a43b84a tty: Set the console as the controlling terminal for shim
122b44e build: Make mock binary paths dynamically generated by Makefile
4704c5f travis: Enhance travis.yml
bb2d085 ci: Introduce go static and go test scripts
a587134 build: Enhance Makefile to build and install all binaries
22da7fd ci: Add semaphore scripts to simplify semaphore settings
2d8cecc oci: Make OCI config file and bundle directory paths public.
36faae0 container: Create function to create a Process.
7f7e7b6 tests: Fix-up for Container start time.
07ff99a api: Remove redundant call to fetchPod().
bf695ef api: Add HypervisorConfig to PodStatus.
70c7917 pod: rename GetContainers to GetAllContainers
3ad4c50 api: Make StatusContainer() include container start time.
c0e2098 pod: Add function to get a specific container
ff66ff4 container: Remove duplication for shim and process handling.
c2b3139 api: Make StatusPod() call StatusContainer().
e3e6f68 oci: Return correct Bundle path in StatusToOCIState().
60138bd oci: Add annotations to OCI State object.
38f24d4 oci: Add bundlepath to container Annotations.
b566e59 oci: Move OCI config path from pod to container annotations.
e2e5f8d annotations: Add annotations to ContainerStatus.
5a2b64d annotations: Add annotations to PodStatus.
24fd25f OWNERS: Add OWNERS files
bd0e479 oci: Rename Group to PrimaryGroup
00ef6ed tests: Change test config to test for additional gids
aa52eb4 oci: Add support for additional groups while running a container
df324ac network: Factorize common code between network implementations
9726597 network: Fix wrong MAC address configuration
fcceae7 README: Change shim path in virtc README
7dd546e networking: Turn off multicast snooping on integration bridge
782e907 CONTRIBUTING: Fix the md links
267bb85 vendor: Update vendoring with latest dep tool version
5d33348 network: Fix benchmarks sporadic issues with netns
702b16f README: Fix proxy compilation instructions in README
d37c723 README: Fix shim compilation instructions in README
fbc84a7 readme: Add Semaphore CI build badge
6081e64 virtc: Default QEMU machine type is pc-lite
be0f200 hypervisor: Missing a configured path is not an error
a9cf7a7 qemu: Build the QEMU binary path
4c185df virtc: Add "--machine-type=" option.
5817687 qemu: Add support for 'q35' machine type.
e614a37 hypervisor: Add machine type to HypervisorConfig.
b267d75 qemu: Use virtio-net-pci for our network driver
c1338cc hyperstart: Copy pause binary instead of creating a symbolic link
4d69498 qemu: Wait for the end of the VM
2b81883 qemu: Set script and downscript to "no" by default
bd08145 pod: Fix typo.
008eeb9 oci: Fix annotation namespacing.
72cb6df hyperstart: Do not use hard links
e934235 api: Speed up container status query.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>