### PR TITLE
network: Handle routes with empty/nil destination as "default" destination

### DIFF
--- a/cnm.go
+++ b/cnm.go
@@ -95,7 +95,12 @@ func (n *cnm) createResult(iface net.Interface, addrs []net.Addr, routes []netli
 	var resultRoutes []*cniTypes.Route
 	for _, route := range routes {
 		if route.Dst == nil {
-			continue
+			_, defaultRoute, err := net.ParseCIDR(defaultRouteDest)
+			if err != nil {
+				return types.Result{}, err
+			}
+
+			route.Dst = defaultRoute
 		}
 
 		r := &cniTypes.Route{

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"syscall"
 
+	cniTypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/containers/virtcontainers/pkg/hyperstart"
 )
 
@@ -122,6 +123,30 @@ func (h *hyper) buildHyperContainerProcess(cmd Cmd) (*hyperstart.Process, error)
 	return process, nil
 }
 
+func (h *hyper) processHyperRoute(route *cniTypes.Route, deviceName string) *hyperstart.Route {
+	gateway := route.GW.String()
+	if gateway == "<nil>" {
+		gateway = ""
+	}
+
+	destination := route.Dst.String()
+	if destination == defaultRouteDest {
+		destination = defaultRouteLabel
+	}
+
+	// Skip IPv6 because not supported by hyperstart
+	if destination != defaultRouteDest && route.Dst.IP.To4() == nil {
+		virtLog.Warnf("IPv6 route destination %q not supported", destination)
+		return nil
+	}
+
+	return &hyperstart.Route{
+		Dest:    destination,
+		Gateway: gateway,
+		Device:  deviceName,
+	}
+}
+
 func (h *hyper) buildNetworkInterfacesAndRoutes(pod Pod) ([]hyperstart.NetworkIface, []hyperstart.Route, error) {
 	networkNS, err := pod.storage.fetchPodNetwork(pod.id)
 	if err != nil {
@@ -172,23 +197,12 @@ func (h *hyper) buildNetworkInterfacesAndRoutes(pod Pod) ([]hyperstart.NetworkIf
 		ifaces = append(ifaces, iface)
 
 		for _, r := range endpoint.Properties.Routes {
-			// Skip IPv6 because not supported by hyperstart
-			if r.Dst.IP.To4() == nil {
+			route := h.processHyperRoute(r, endpoint.NetPair.VirtIface.Name)
+			if route == nil {
 				continue
 			}
 
-			gateway := r.GW.String()
-			if gateway == "<nil>" {
-				gateway = ""
-			}
-
-			route := hyperstart.Route{
-				Dest:    r.Dst.String(),
-				Gateway: gateway,
-				Device:  endpoint.NetPair.VirtIface.Name,
-			}
-
-			routes = append(routes, route)
+			routes = append(routes, *route)
 		}
 	}
 

--- a/hyperstart_test.go
+++ b/hyperstart_test.go
@@ -18,10 +18,20 @@ package virtcontainers
 
 import (
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
+
+	cniTypes "github.com/containernetworking/cni/pkg/types"
+	"github.com/containers/virtcontainers/pkg/hyperstart"
 )
+
+var testRouteDest = "192.168.10.1/32"
+var testRouteGateway = "192.168.0.0"
+var testRouteDeviceName = "test_eth0"
+var testRouteDestIPv6 = "2001:db8::/32"
 
 func TestHyperstartValidateNoSocketsSuccessful(t *testing.T) {
 	config := &HyperConfig{
@@ -104,4 +114,76 @@ func TestCopyPauseBinarySuccessful(t *testing.T) {
 	if _, err := os.Stat(dstPath); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func testProcessHyperRoute(t *testing.T, route *cniTypes.Route, deviceName string, expected *hyperstart.Route) {
+	h := &hyper{}
+	hyperRoute := h.processHyperRoute(route, deviceName)
+
+	if expected == nil {
+		if hyperRoute != nil {
+			t.Fatalf("Expecting route to be nil, Got %+v", hyperRoute)
+		} else {
+			return
+		}
+	}
+
+	// At this point, we know that "expected" != nil.
+	if !reflect.DeepEqual(*expected, *hyperRoute) {
+		t.Fatalf("Expecting %+v, Got %+v", *expected, *hyperRoute)
+	}
+}
+
+func TestProcessHyperRouteEmptyGWSuccessful(t *testing.T) {
+	expected := &hyperstart.Route{
+		Dest:    testRouteDest,
+		Gateway: "",
+		Device:  testRouteDeviceName,
+	}
+
+	_, dest, err := net.ParseCIDR(testRouteDest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	route := &cniTypes.Route{
+		Dst: *dest,
+		GW:  net.IP{},
+	}
+
+	testProcessHyperRoute(t, route, testRouteDeviceName, expected)
+}
+
+func TestProcessHyperRouteEmptyDestSuccessful(t *testing.T) {
+	expected := &hyperstart.Route{
+		Dest:    defaultRouteLabel,
+		Gateway: testRouteGateway,
+		Device:  testRouteDeviceName,
+	}
+
+	_, dest, err := net.ParseCIDR(defaultRouteDest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	route := &cniTypes.Route{
+		Dst: *dest,
+		GW:  net.ParseIP(testRouteGateway),
+	}
+
+	testProcessHyperRoute(t, route, testRouteDeviceName, expected)
+}
+
+func TestProcessHyperRouteDestIPv6Failure(t *testing.T) {
+	_, dest, err := net.ParseCIDR(testRouteDestIPv6)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	route := &cniTypes.Route{
+		Dst: *dest,
+		GW:  net.IP{},
+	}
+
+	testProcessHyperRoute(t, route, testRouteDeviceName, nil)
 }

--- a/network.go
+++ b/network.go
@@ -30,6 +30,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// Introduces constants related to network routes.
+const (
+	defaultRouteDest = "0.0.0.0/0"
+)
+
 type netIfaceAddrs struct {
 	iface net.Interface
 	addrs []net.Addr

--- a/network.go
+++ b/network.go
@@ -32,7 +32,8 @@ import (
 
 // Introduces constants related to network routes.
 const (
-	defaultRouteDest = "0.0.0.0/0"
+	defaultRouteDest  = "0.0.0.0/0"
+	defaultRouteLabel = "default"
 )
 
 type netIfaceAddrs struct {


### PR DESCRIPTION
Until now, we were ignoring routes that we scanned in case the destination was nil, but we were missing the most important route, i.e the one redirecting everything else to the docker gateway (usually 172.17.0.1).