### PR TITLE
1.0.0-rc.1 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+1.0.0-rc.1:
+	Added standard error for invalid pod resources
+	Fixed docker gateway routing
+
 1.0.0-rc.0:
 	Added pod pause and resume support
 	Added bind mounts support


### PR DESCRIPTION
Added standard error for invalid pod resources
Fixed docker gateway routing

Shortlog:

ba8cba8 hyperstart: Consider 0.0.0.0/0 route destination as default
147f06d cnm: Don't ignore routes with empty/nil destination
2e31e20 errors: Introduce standard error for invalid pod resource.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>