### PR TITLE
container: Stop a container with SIGKILL instead of SIGTERM

### DIFF
--- a/container.go
+++ b/container.go
@@ -482,7 +482,7 @@ func (c *Container) stop() error {
 	}
 	defer c.pod.proxy.disconnect()
 
-	err = c.pod.agent.killContainer(*(c.pod), *c, syscall.SIGTERM, true)
+	err = c.pod.agent.killContainer(*(c.pod), *c, syscall.SIGKILL, true)
 	if err != nil {
 		return err
 	}

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -455,7 +455,7 @@ func (h *hyper) stopPod(pod Pod) error {
 			continue
 		}
 
-		if err := h.killOneContainer(c.id, syscall.SIGTERM, true); err != nil {
+		if err := h.killOneContainer(c.id, syscall.SIGKILL, true); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
SIGTERM could not be handled by some processes. Because this signal is sent to stop the container or the pod, that means we don't mind about the way those processes are terminated, and we make sure that SIGKILL will do the job.

To give you more context, I have realized that starting a container like that:
```
docker run -d busybox sleep 1000
```
and trying to stop it with:
```
docker stop 36d562a063e8111b670f9b8198c3692e84369b87a61f8b31f32226873b1a0977
```
was actually leading to an issue with our new agent. Okay so try to follow me here, there are several reasons for this change.

First you have to know that Docker issues a SIGTERM and after a timeout, if nothing happened (process still running), it issues a SIGKILL.
- If you make the test with `runc`, it will hang for 10 seconds (default timeout before docker send the SIGKILL) because libcontainer cannot terminate a `sleep` command. But after those 10s the container is killed with the SIGKILL.
- In case of `cc-runtime` + `hyperstart` agent, we are doing better than `runc` because hyperstart is able to terminate a `sleep` command from a SIGTERM.
- In case of `cc-runtime` + our `agent`, we hang for 10s and then we cannot remove the container. But more than that, we are not receiving the SIGKILL issued by Docker because the shim cannot handle a SIGKILL on himself. But it is not a problem with `hyperstart` agent because it has already been killed by the termination caused by SIGTERM.

The only way to make this works is to stop our pod and our containers with SIGKILL, that's the only way we can make sure we are really stopping any process on each container, and that's the purpose of this patch.
Or we could design the shim a bit differently so that we could handle a SIGKILL, but that's a bigger change.