### PR TITLE
pkg: oci: Rely on sandbox ID instead of sandbox name

### DIFF
--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -47,8 +47,8 @@ var (
 	CRIContainerTypeKeyList = []string{annotations.ContainerType}
 
 	// CRISandboxNameKeyList lists all the CRI keys that could define
-	// the sandbox name (pod ID) from annotations in the config.json.
-	CRISandboxNameKeyList = []string{annotations.SandboxName}
+	// the sandbox ID (pod ID) from annotations in the config.json.
+	CRISandboxNameKeyList = []string{annotations.SandboxID}
 )
 
 const (

--- a/pkg/oci/utils_test.go
+++ b/pkg/oci/utils_test.go
@@ -532,7 +532,7 @@ func TestPodIDSuccessful(t *testing.T) {
 	testPodID := "testPodID"
 
 	ociSpec.Annotations = map[string]string{
-		annotations.SandboxName: testPodID,
+		annotations.SandboxID: testPodID,
 	}
 
 	podID, err := ociSpec.PodID()


### PR DESCRIPTION
Due to recent changes in CRI-O database, we have to rely on the sandbox ID and not the sandbox name anymore.