### PR TITLE
container: Add StateReady to StateStopped as valid transition

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -1152,7 +1152,7 @@ func TestStopContainerFailingNoContainer(t *testing.T) {
 	}
 }
 
-func TestStopContainerFailingContNotStarted(t *testing.T) {
+func TestStopContainerFromContReadySuccessful(t *testing.T) {
 	cleanUp()
 
 	contID := "100"
@@ -1177,7 +1177,7 @@ func TestStopContainerFailingContNotStarted(t *testing.T) {
 	}
 
 	c, err = StopContainer(p.id, contID)
-	if c != nil || err == nil {
+	if err != nil {
 		t.Fatal()
 	}
 }

--- a/container.go
+++ b/container.go
@@ -458,6 +458,17 @@ func (c *Container) stop() error {
 		return err
 	}
 
+	// In case our container is "ready", there is no point in trying to
+	// stop it because nothing has been started. However, this is a valid
+	// case and we handle this by updating the container state only.
+	if state.State == StateReady {
+		if err := state.validTransition(StateReady, StateStopped); err != nil {
+			return err
+		}
+
+		return c.setContainerState(StateStopped)
+	}
+
 	if state.State != StateRunning {
 		return fmt.Errorf("Container not running, impossible to stop")
 	}

--- a/pod.go
+++ b/pod.go
@@ -80,7 +80,7 @@ func (state *State) validTransition(oldState stateString, newState stateString) 
 
 	switch state.State {
 	case StateReady:
-		if newState == StateRunning {
+		if newState == StateRunning || newState == StateStopped {
 			return nil
 		}
 

--- a/pod_test.go
+++ b/pod_test.go
@@ -152,8 +152,8 @@ func TestPodStateRunningStopped(t *testing.T) {
 
 func TestPodStateReadyPaused(t *testing.T) {
 	err := testPodStateTransition(t, StateReady, StateStopped)
-	if err == nil {
-		t.Fatal("Invalid transition from Ready to Paused")
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
This patch allows any container in StateReady state to be switched
to a StateStopped state, without doing further action than updating
the container state itself.