### PR TITLE
1.0.0-rc.2 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+1.0.0-rc.2:
+	Added support for transitioning from Ready to Stopped
+	Fixed pod container creation
+	Fixed CRI-O support for sandbox identifiers
+
 1.0.0-rc.1:
 	Added standard error for invalid pod resources
 	Fixed docker gateway routing


### PR DESCRIPTION
Added support for transitioning from Ready to Stopped
Fixed pod container creation
Fixed CRI-O support for sandbox identifiers

Shortlog:

f6f4997 container: Add StateReady to StateStopped as valid transition
0693a26 vendor: Update vendoring to master branches
db39ee5 pkg: oci: Rely on sandbox ID instead of sandbox name
a93417c container: Rename createContainers
407bb96 container: Factorize container creation
d3429b8 container: Stop a container with SIGKILL instead of SIGTERM

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>