### PR TITLE
pkg: hyperstart: Fix MTU type from string to integer

### DIFF
--- a/hyperstart.go
+++ b/hyperstart.go
@@ -190,7 +190,7 @@ func (h *hyper) buildNetworkInterfacesAndRoutes(pod Pod) ([]hyperstart.NetworkIf
 		iface := hyperstart.NetworkIface{
 			NewDevice:   endpoint.NetPair.VirtIface.Name,
 			IPAddresses: ipAddrs,
-			MTU:         fmt.Sprintf("%d", netIface.MTU),
+			MTU:         netIface.MTU,
 			MACAddr:     endpoint.NetPair.TAPIface.HardAddr,
 		}
 

--- a/pkg/hyperstart/types.go
+++ b/pkg/hyperstart/types.go
@@ -189,7 +189,7 @@ type NetworkIface struct {
 	Device      string      `json:"device,omitempty"`
 	NewDevice   string      `json:"newDeviceName,omitempty"`
 	IPAddresses []IPAddress `json:"ipAddresses"`
-	MTU         string      `json:"mtu"`
+	MTU         int         `json:"mtu"`
 	MACAddr     string      `json:"macAddr"`
 }
 


### PR DESCRIPTION
The MTU parameter was working with hyperstart but it is only because
the cast worked. This patch makes sure that we are passing the MTU
as an integer as it is expected by hyperstart.