### PR TITLE
hypervisor: Add Default{VCPUs, MemSz} to HypervisorConfig

### DIFF
--- a/hypervisor.go
+++ b/hypervisor.go
@@ -31,6 +31,12 @@ const (
 	MockHypervisor HypervisorType = "mock"
 )
 
+const (
+	defaultVCPUs = 1
+	// 2 GiB
+	defaultMemSzMiB = 2048
+)
+
 // deviceType describes a virtualized device type.
 type deviceType int
 
@@ -128,6 +134,14 @@ type HypervisorConfig struct {
 	// Debug changes the default hypervisor and kernel parameters to
 	// enable debug output where available.
 	Debug bool
+
+	// DefaultVCPUs specifies default number of vCPUs for the VM.
+	// Pod configuration VMConfig.VCPUs overwrites this.
+	DefaultVCPUs uint32
+
+	// DefaultMem specifies default memory size in MiB for the VM.
+	// Pod configuration VMConfig.Memory overwrites this.
+	DefaultMemSz uint32
 }
 
 func (conf *HypervisorConfig) valid() (bool, error) {
@@ -137,6 +151,14 @@ func (conf *HypervisorConfig) valid() (bool, error) {
 
 	if conf.ImagePath == "" {
 		return false, fmt.Errorf("Missing image path")
+	}
+
+	if conf.DefaultVCPUs == 0 {
+		conf.DefaultVCPUs = defaultVCPUs
+	}
+
+	if conf.DefaultMemSz == 0 {
+		conf.DefaultMemSz = defaultMemSzMiB
 	}
 
 	return true, nil

--- a/hypervisor_test.go
+++ b/hypervisor_test.go
@@ -162,6 +162,26 @@ func TestHypervisorConfigIsValid(t *testing.T) {
 	testHypervisorConfigValid(t, hypervisorConfig, true)
 }
 
+func TestHypervisorConfigDefaults(t *testing.T) {
+	hypervisorConfig := &HypervisorConfig{
+		KernelPath:     fmt.Sprintf("%s/%s", testDir, testKernel),
+		ImagePath:      fmt.Sprintf("%s/%s", testDir, testImage),
+		HypervisorPath: "",
+	}
+	testHypervisorConfigValid(t, hypervisorConfig, true)
+
+	hypervisorConfigDefaultsExpected := &HypervisorConfig{
+		KernelPath:     fmt.Sprintf("%s/%s", testDir, testKernel),
+		ImagePath:      fmt.Sprintf("%s/%s", testDir, testImage),
+		HypervisorPath: "",
+		DefaultVCPUs:   defaultVCPUs,
+		DefaultMemSz:   defaultMemSzMiB,
+	}
+	if reflect.DeepEqual(hypervisorConfig, hypervisorConfigDefaultsExpected) == false {
+		t.Fatal()
+	}
+}
+
 func TestAppendParams(t *testing.T) {
 	paramList := []Param{
 		{

--- a/qemu.go
+++ b/qemu.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -88,8 +87,6 @@ const (
 )
 
 const (
-	defaultMemSize        = "2G"
-	defaultMemMax         = "3G"
 	defaultMemSlots uint8 = 2
 )
 
@@ -448,14 +445,14 @@ func (q *qemu) qmpMonitor(connectedCh chan struct{}) {
 }
 
 func (q *qemu) setCPUResources(podConfig PodConfig) ciaoQemu.SMP {
-	vcpus := uint(runtime.NumCPU())
+	vcpus := q.config.DefaultVCPUs
 	if podConfig.VMConfig.VCPUs > 0 {
-		vcpus = podConfig.VMConfig.VCPUs
+		vcpus = uint32(podConfig.VMConfig.VCPUs)
 	}
 
 	smp := ciaoQemu.SMP{
-		CPUs:    uint32(vcpus),
-		Cores:   uint32(vcpus),
+		CPUs:    vcpus,
+		Cores:   vcpus,
 		Sockets: defaultSockets,
 		Threads: defaultThreads,
 	}
@@ -464,8 +461,8 @@ func (q *qemu) setCPUResources(podConfig PodConfig) ciaoQemu.SMP {
 }
 
 func (q *qemu) setMemoryResources(podConfig PodConfig) ciaoQemu.Memory {
-	mem := defaultMemSize
-	memMax := defaultMemMax
+	mem := fmt.Sprintf("%dM", q.config.DefaultMemSz)
+	memMax := fmt.Sprintf("%dM", int(float64(q.config.DefaultMemSz)*1.5))
 	if podConfig.VMConfig.Memory > 0 {
 		mem = fmt.Sprintf("%dM", podConfig.VMConfig.Memory)
 		intMemMax := int(float64(podConfig.VMConfig.Memory) * 1.5)

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -32,6 +32,8 @@ func newQemuConfig() HypervisorConfig {
 		KernelPath:     testQemuKernelPath,
 		ImagePath:      testQemuImagePath,
 		HypervisorPath: testQemuPath,
+		DefaultVCPUs:   defaultVCPUs,
+		DefaultMemSz:   defaultMemSzMiB,
 	}
 }
 


### PR DESCRIPTION
A runtime implementation can use these fields to setup the default
vCPU number and default memory size for new VMs.
VMConfig can overwrite these settings.

Signed-off-by: Dmitry Voytik <dmitry.voytik@huawei.com>