### PR TITLE
1.0.0-rc.3 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+1.0.0-rc.3:
+	Added support for assigning the container rootfs underlying block device to the VM (when using devicemapper)
+	Changed qemu to use virtio-net vhost by default
+	Changed qemu parameters to not be Clear Containers specific
+	Fixed MTU passing to hyperstart
+
 1.0.0-rc.2:
 	Added support for transitioning from Ready to Stopped
 	Fixed pod container creation


### PR DESCRIPTION
Added support for assigning the container rootfs underlying block device to the
VM (when using devicemapper)
Changed qemu to use virtio-net vhost by default
Changed qemu parameters to not be Clear Containers specific
Fixed MTU passing to hyperstart

Shortlog:

d10cac1 qemu: Remove Clear Containers specific kernel parameters
53d6cc4 hypervisor: Export the Param structure
76651e6 hypervisor: Implement helper for adding kernel parameters
5bb4196 qemu: Enable virtio-net vhost by default
b9292d2 pkg: hyperstart: Fix MTU type from string to integer
d2d23cf docs: Add documentation for the devicemapper storage scanario.
9a7b349 devicemapper: Use state vars to pass the blkdevice info to hyperstart
b7de0e1 state: Add fields to state for storing storage related info
359beef state: Update the entire container state when fetched
3044ee8 state: Fix container state update
152837b devicemapper: Add config to use 9pfs in case of devicemapper
ed74225 devicemapper: Do not bind-mount rootfs in case of devicemapper.
1b84ead storage: Pass the drive name and fstype to hyperstart
6a0071a storage: Add function to get virtio drive name.
8089c75 storage: Query a capabilities interface on agent for adding drives.
879cbd5 storage: Add function to add block device in case of devicemapper.
77eee48 storage: Add function to check if device is devicemapper device.
6b58b0f storage: Add function to get the device path and file system type
d434670 storage: Add function to get the underlying device and mount point
be93ab2 hypervisor: Add ability to add block devices for qemu.
5b5d67f storage: Add a "Drive" struct to represent a block device

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>