### PR TITLE
shim: Stop forwarding output in detach mode

### DIFF
--- a/cc_shim.go
+++ b/cc_shim.go
@@ -61,9 +61,11 @@ func (s *ccShim) start(pod Pod, params ShimParams) (int, error) {
 	cmd := exec.Command(config.Path, "-t", params.Token, "-u", params.URL)
 	cmd.Env = os.Environ()
 
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	if !params.Detach {
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
 
 	var f *os.File
 	var err error

--- a/container.go
+++ b/container.go
@@ -191,7 +191,7 @@ func (c *Container) startShim() error {
 		return err
 	}
 
-	process, err := c.createShimProcess(proxyInfo.Token, url, c.config.Cmd.Console)
+	process, err := c.createShimProcess(proxyInfo.Token, url, c.config.Cmd)
 	if err != nil {
 		return err
 	}
@@ -537,7 +537,7 @@ func (c *Container) enter(cmd Cmd) (*Process, error) {
 	}
 	defer c.pod.proxy.disconnect()
 
-	process, err := c.createShimProcess(proxyInfo.Token, url, cmd.Console)
+	process, err := c.createShimProcess(proxyInfo.Token, url, cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -572,7 +572,7 @@ func (c *Container) kill(signal syscall.Signal, all bool) error {
 	return nil
 }
 
-func (c *Container) createShimProcess(token, url, console string) (*Process, error) {
+func (c *Container) createShimProcess(token, url string, cmd Cmd) (*Process, error) {
 	if c.pod.state.URL != url {
 		return &Process{}, fmt.Errorf("Pod URL %s and URL from proxy %s MUST be identical", c.pod.state.URL, url)
 	}
@@ -580,7 +580,8 @@ func (c *Container) createShimProcess(token, url, console string) (*Process, err
 	shimParams := ShimParams{
 		Token:   token,
 		URL:     url,
-		Console: console,
+		Console: cmd.Console,
+		Detach:  cmd.Detach,
 	}
 
 	pid, err := c.pod.shim.start(*(c.pod), shimParams)

--- a/pkg/mock/mock.go
+++ b/pkg/mock/mock.go
@@ -21,3 +21,9 @@ var DefaultMockCCShimBinPath string
 
 // DefaultMockHookBinPath is populated at link time.
 var DefaultMockHookBinPath string
+
+// ShimStdoutOutput is the expected output sent by the mock shim on stdout.
+const ShimStdoutOutput = "Some output on stdout"
+
+// ShimStderrOutput is the expected output sent by the mock shim on stderr.
+const ShimStderrOutput = "Some output on stderr"

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -286,8 +286,8 @@ func (spec *CompatOCISpec) PodID() (string, error) {
 
 // PodConfig converts an OCI compatible runtime configuration file
 // to a virtcontainers pod configuration structure.
-func PodConfig(ocispec CompatOCISpec, runtime RuntimeConfig, bundlePath, cid, console string) (vc.PodConfig, error) {
-	containerConfig, err := ContainerConfig(ocispec, bundlePath, cid, console)
+func PodConfig(ocispec CompatOCISpec, runtime RuntimeConfig, bundlePath, cid, console string, detach bool) (vc.PodConfig, error) {
+	containerConfig, err := ContainerConfig(ocispec, bundlePath, cid, console, detach)
 	if err != nil {
 		return vc.PodConfig{}, err
 	}
@@ -334,7 +334,7 @@ func PodConfig(ocispec CompatOCISpec, runtime RuntimeConfig, bundlePath, cid, co
 
 // ContainerConfig converts an OCI compatible runtime configuration
 // file to a virtcontainers container configuration structure.
-func ContainerConfig(ocispec CompatOCISpec, bundlePath, cid, console string) (vc.ContainerConfig, error) {
+func ContainerConfig(ocispec CompatOCISpec, bundlePath, cid, console string, detach bool) (vc.ContainerConfig, error) {
 	configPath := getConfigPath(bundlePath)
 
 	rootfs := ocispec.Root.Path
@@ -351,6 +351,7 @@ func ContainerConfig(ocispec CompatOCISpec, bundlePath, cid, console string) (vc
 		PrimaryGroup: strconv.FormatUint(uint64(ocispec.Process.User.GID), 10),
 		Interactive:  ocispec.Process.Terminal,
 		Console:      console,
+		Detach:       detach,
 	}
 
 	cmd.SupplementaryGroups = []string{}

--- a/pkg/oci/utils_test.go
+++ b/pkg/oci/utils_test.go
@@ -147,7 +147,7 @@ func TestMinimalPodConfig(t *testing.T) {
 		t.Fatalf("Could not parse config.json: %v", err)
 	}
 
-	podConfig, err := PodConfig(ociSpec, runtimeConfig, tempBundlePath, containerID, consolePath)
+	podConfig, err := PodConfig(ociSpec, runtimeConfig, tempBundlePath, containerID, consolePath, false)
 	if err != nil {
 		t.Fatalf("Could not create Pod configuration %v", err)
 	}

--- a/pod.go
+++ b/pod.go
@@ -259,6 +259,7 @@ type Cmd struct {
 
 	Interactive bool
 	Console     string
+	Detach      bool
 }
 
 // Resources describes VM resources configuration.
@@ -730,6 +731,7 @@ func (p *Pod) startShims() error {
 			Token:   proxyInfos[idx].Token,
 			URL:     url,
 			Console: p.containers[idx].config.Cmd.Console,
+			Detach:  p.containers[idx].config.Cmd.Detach,
 		}
 
 		pid, err := p.shim.start(*p, shimParams)

--- a/shim.go
+++ b/shim.go
@@ -40,6 +40,7 @@ type ShimParams struct {
 	Token   string
 	URL     string
 	Console string
+	Detach  bool
 }
 
 // Set sets a shim type based on the input string.

--- a/shim/mock/shim.go
+++ b/shim/mock/shim.go
@@ -23,6 +23,8 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+
+	"github.com/containers/virtcontainers/pkg/mock"
 )
 
 const logFileName = "mock_shim.log"
@@ -31,7 +33,7 @@ const numArgsExpected = 2
 func main() {
 	logDirPath, err := ioutil.TempDir("", "cc-shim-")
 	if err != nil {
-		fmt.Printf("ERROR: Could not generate temporary log directory path: %s\n", err)
+		fmt.Fprintf(os.Stderr, "ERROR: Could not generate temporary log directory path: %s\n", err)
 		os.Exit(1)
 	}
 
@@ -39,7 +41,7 @@ func main() {
 
 	f, err := os.Create(logFilePath)
 	if err != nil {
-		fmt.Printf("ERROR: Could not create temporary log file %q: %s\n", logFilePath, err)
+		fmt.Fprintf(os.Stderr, "ERROR: Could not create temporary log file %q: %s\n", logFilePath, err)
 		os.Exit(1)
 	}
 	defer f.Close()
@@ -66,6 +68,14 @@ func main() {
 		fmt.Fprintf(f, "ERROR: Could not parse the URL %q: %s\n", *urlFlag, err)
 		os.Exit(1)
 	}
+
+	// Print some traces to stdout
+	fmt.Fprintf(os.Stdout, mock.ShimStdoutOutput)
+	os.Stdout.Close()
+
+	// Print some traces to stderr
+	fmt.Fprintf(os.Stderr, mock.ShimStderrOutput)
+	os.Stderr.Close()
 
 	fmt.Fprintf(f, "INFO: Shim exited properly\n")
 }


### PR DESCRIPTION
When a process is started as "detached" from one of the following
commands:
	- cc-runtime run -d <containerID>
	- cc-runtime exec -d <containerID>

we don't want to see the output posted on the current shell used,
instead we expect this to be silent.

Fixes #303