### PR TITLE
CI: Add a new reviewer to pullapprove

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -48,3 +48,5 @@ groups:
     required: 1
     teams:
       - virtcontainers-maintainers
+    users:
+      - amshinde


### PR DESCRIPTION
We are missing reviewers given the fact that some people are in
vacation and others are leaving.