### PR TITLE
create: Split hyperstart init function to perform setup only at create

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -121,6 +121,9 @@ type agent interface {
 	// supported by the agent.
 	capabilities() capabilities
 
+	// createPod will tell the agent to perform necessary setup for a Pod.
+	createPod(pod *Pod) error
+
 	// exec will tell the agent to run a command in an already running container.
 	exec(pod *Pod, c Container, process Process, cmd Cmd) error
 

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -346,6 +346,12 @@ func (h *hyper) init(pod *Pod, config interface{}) (err error) {
 	// Override pod agent configuration
 	pod.config.AgentConfig = h.config
 
+	h.proxy = pod.proxy
+
+	return nil
+}
+
+func (h *hyper) createPod(pod *Pod) (err error) {
 	for _, volume := range h.config.Volumes {
 		err := pod.hypervisor.addDevice(volume, fsDev)
 		if err != nil {
@@ -374,8 +380,6 @@ func (h *hyper) init(pod *Pod, config interface{}) (err error) {
 	if err := pod.hypervisor.addDevice(sharedVolume, fsDev); err != nil {
 		return err
 	}
-
-	h.proxy = pod.proxy
 
 	return nil
 }

--- a/noop_agent.go
+++ b/noop_agent.go
@@ -30,6 +30,11 @@ func (n *noopAgent) init(pod *Pod, config interface{}) error {
 	return nil
 }
 
+// createPod is the Noop agent pod creation implementation. It does nothing.
+func (n *noopAgent) createPod(pod *Pod) error {
+	return nil
+}
+
 // capabilities returns empty capabilities, i.e no capabilties are supported.
 func (n *noopAgent) capabilities() capabilities {
 	return capabilities{}

--- a/sshd.go
+++ b/sshd.go
@@ -105,6 +105,11 @@ func (s *sshd) init(pod *Pod, config interface{}) error {
 	return nil
 }
 
+// createPod is the agent pod creation implementation for sshd.
+func (s *sshd) createPod(pod *Pod) error {
+	return nil
+}
+
 func (s *sshd) capabilities() capabilities {
 	return capabilities{}
 }


### PR DESCRIPTION
The hyperstart agent implementation for init() interface was
performing setup such as adding devices with the hypervisor.
Since init is called during create, start and all other container
lifecycle stages, this setup was being performed repeatedly.

Introduce a new interface for agent called "createPod" that is
supposed to perform all the initial setup while creating a Pod.
Refactor hyperstart init() to exclude the device creation and move
that to createPod.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>