### PR TITLE
stop: Wait for end of container process before to remove

### DIFF
--- a/container.go
+++ b/container.go
@@ -508,6 +508,11 @@ func (c *Container) stop() error {
 		return err
 	}
 
+	// Wait for the end of container
+	if err := waitForShim(c.process.Pid); err != nil {
+		return err
+	}
+
 	err = c.pod.agent.stopContainer(*(c.pod), *c)
 	if err != nil {
 		return err

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -458,25 +458,6 @@ func (h *hyper) startPod(pod Pod) error {
 
 // stopPod is the agent Pod stopping implementation for hyperstart.
 func (h *hyper) stopPod(pod Pod) error {
-	for _, c := range pod.containers {
-		state, err := pod.storage.fetchContainerState(pod.id, c.id)
-		if err != nil {
-			return err
-		}
-
-		if state.State != StateRunning {
-			continue
-		}
-
-		if err := h.killOneContainer(c.id, syscall.SIGKILL, true); err != nil {
-			return err
-		}
-
-		if err := h.stopOneContainer(pod.id, *c); err != nil {
-			return err
-		}
-	}
-
 	if err := h.stopPauseContainer(pod.id); err != nil {
 		return err
 	}

--- a/pod.go
+++ b/pod.go
@@ -904,6 +904,25 @@ func (p *Pod) stop() error {
 	}
 	defer p.proxy.disconnect()
 
+	for _, c := range p.containers {
+		state, err := p.storage.fetchContainerState(p.id, c.id)
+		if err != nil {
+			return err
+		}
+
+		if state.State != StateRunning {
+			continue
+		}
+
+		if err := p.agent.killContainer(*p, *c, syscall.SIGKILL, true); err != nil {
+			return err
+		}
+
+		if err := p.agent.stopContainer(*p, *c); err != nil {
+			return err
+		}
+	}
+
 	if err := p.agent.stopPod(*p); err != nil {
 		return err
 	}

--- a/pod.go
+++ b/pod.go
@@ -918,6 +918,11 @@ func (p *Pod) stop() error {
 			return err
 		}
 
+		// Wait for the end of container
+		if err := waitForShim(c.process.Pid); err != nil {
+			return err
+		}
+
 		if err := p.agent.stopContainer(*p, *c); err != nil {
 			return err
 		}


### PR DESCRIPTION
In case we are stopping a pod or a container, for every container,
we send a SIGKILL signal and then we try to remove the container.
Unfortunately, if the process inside the container takes some time
to be killed, the removal of the container can sometimes fail.

This patch ensures that we are waiting for the end of the shim
process after we sent the SIGKILL signal. In case we hit a timeout,
the stop() will fail.

Fixes #318