### PR TITLE
qemu: Add pc machine type as supported

### DIFF
--- a/qemu.go
+++ b/qemu.go
@@ -60,6 +60,9 @@ const (
 	// QemuPCLite is the QEMU pc-lite machine type
 	QemuPCLite = defaultQemuMachineType
 
+	// QemuPC is the QEMU pc machine type
+	QemuPC = "pc"
+
 	// QemuQ35 is the QEMU Q35 machine type
 	QemuQ35 = "q35"
 )
@@ -67,12 +70,17 @@ const (
 // Mapping between machine types and QEMU binary paths.
 var qemuPaths = map[string]string{
 	QemuPCLite: "/usr/bin/qemu-lite-system-x86_64",
-	QemuQ35:    defaultQemuPath,
+	QemuPC:     defaultQemuPath,
+	QemuQ35:    "/usr/bin/qemu-35-system-x86_64",
 }
 
 var supportedQemuMachines = []ciaoQemu.Machine{
 	{
 		Type:         QemuPCLite,
+		Acceleration: "kvm,kernel_irqchip,nvdimm",
+	},
+	{
+		Type:         QemuPC,
 		Acceleration: "kvm,kernel_irqchip,nvdimm",
 	},
 	{

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -497,9 +497,11 @@ func TestQemuMachineTypes(t *testing.T) {
 
 	data := []testData{
 		{"pc-lite", true},
+		{"pc", true},
 		{"q35", true},
 
 		{"PC-LITE", false},
+		{"PC", false},
 		{"Q35", false},
 		{"", false},
 		{" ", false},


### PR DESCRIPTION
We might need to switch to the pc machine type in the future. This
commits takes care of adding this new type as supported.

Fixes #320