### PR TITLE
qemu: fix breakage of old binaries

### DIFF
--- a/qemu.go
+++ b/qemu.go
@@ -148,6 +148,7 @@ var kernelDefaultParams = []Param{
 	{"iommu", "off"},
 	{"cryptomgr.notests", ""},
 	{"net.ifnames", "0"},
+	{"vsyscall", "emulate"},
 }
 
 // kernelDefaultParamsNonDebug is a list of the default kernel

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -57,7 +57,7 @@ func testQemuBuildKernelParams(t *testing.T, kernelParams []Param, expected stri
 	}
 }
 
-var testQemuKernelParamsBase = "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off cryptomgr.notests net.ifnames=0"
+var testQemuKernelParamsBase = "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off cryptomgr.notests net.ifnames=0 vsyscall=emulate"
 var testQemuKernelParamsNonDebug = "quiet systemd.show_status=false"
 var testQemuKernelParamsDebug = "debug systemd.show_status=true systemd.log_level=debug"
 


### PR DESCRIPTION
clear container kernel 4.5-50 breaks old binaries, for example centos6.
Fix this by using vsyscall=emulate

Signed-off-by: WANG Chao <chao.wang@ucloud.cn>