### PR TITLE
hypervisor: export SerializeParams and DeserializeParams

### DIFF
--- a/hypervisor.go
+++ b/hypervisor.go
@@ -18,6 +18,7 @@ package virtcontainers
 
 import (
 	"fmt"
+	"strings"
 )
 
 // HypervisorType describes an hypervisor type.
@@ -180,7 +181,8 @@ func appendParam(params []Param, parameter string, value string) []Param {
 	return append(params, Param{parameter, value})
 }
 
-func serializeParams(params []Param, delim string) []string {
+// SerializeParams converts []Param to []string
+func SerializeParams(params []Param, delim string) []string {
 	var parameters []string
 
 	for _, p := range params {
@@ -199,6 +201,25 @@ func serializeParams(params []Param, delim string) []string {
 	}
 
 	return parameters
+}
+
+// DeserializeParams converts []string to []Param
+func DeserializeParams(parameters []string) []Param {
+	var params []Param
+
+	for _, param := range parameters {
+		if param == "" {
+			continue
+		}
+		p := strings.SplitN(param, "=", 2)
+		if len(p) == 2 {
+			params = append(params, Param{Key: p[0], Value: p[1]})
+		} else {
+			params = append(params, Param{Key: p[0], Value: ""})
+		}
+	}
+
+	return params
 }
 
 // hypervisor is the virtcontainers hypervisor interface.

--- a/hypervisor_test.go
+++ b/hypervisor_test.go
@@ -208,7 +208,7 @@ func TestAppendParams(t *testing.T) {
 }
 
 func testSerializeParams(t *testing.T, params []Param, delim string, expected []string) {
-	result := serializeParams(params, delim)
+	result := SerializeParams(params, delim)
 	if reflect.DeepEqual(result, expected) == false {
 		t.Fatal()
 	}
@@ -274,6 +274,58 @@ func TestSerializeParams(t *testing.T) {
 	expected := []string{"param1=value1"}
 
 	testSerializeParams(t, params, "=", expected)
+}
+
+func testDeserializeParams(t *testing.T, parameters []string, expected []Param) {
+	result := DeserializeParams(parameters)
+	if reflect.DeepEqual(result, expected) == false {
+		t.Fatal()
+	}
+}
+
+func TestDeserializeParamsNil(t *testing.T) {
+	var parameters []string
+	var expected []Param
+
+	testDeserializeParams(t, parameters, expected)
+}
+
+func TestDeserializeParamsNoParamNoValue(t *testing.T) {
+	parameters := []string{
+		"",
+	}
+
+	var expected []Param
+
+	testDeserializeParams(t, parameters, expected)
+}
+
+func TestDeserializeParamsNoValue(t *testing.T) {
+	parameters := []string{
+		"param1",
+	}
+	expected := []Param{
+		{
+			Key: "param1",
+		},
+	}
+
+	testDeserializeParams(t, parameters, expected)
+}
+
+func TestDeserializeParams(t *testing.T) {
+	parameters := []string{
+		"param1=value1",
+	}
+
+	expected := []Param{
+		{
+			Key:   "param1",
+			Value: "value1",
+		},
+	}
+
+	testDeserializeParams(t, parameters, expected)
 }
 
 func TestAddKernelParamValid(t *testing.T) {

--- a/qemu.go
+++ b/qemu.go
@@ -177,7 +177,7 @@ func (q *qemu) buildKernelParams(config HypervisorConfig) error {
 
 	params = append(params, config.KernelParams...)
 
-	q.kernelParams = serializeParams(params, "=")
+	q.kernelParams = SerializeParams(params, "=")
 
 	return nil
 }


### PR DESCRIPTION
Add an exported function DeserializeParams(), and export
SerializeParams().

This patch is laying the ground work for [https://github.com/clearcontainers/runtime/pull/369](url)