### PR TITLE
Globally improves the handling of container/pod states

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1210,7 +1211,7 @@ func TestStopContainerFailingNoContainer(t *testing.T) {
 	}
 }
 
-func TestStopContainerFromContReadySuccessful(t *testing.T) {
+func testKillContainerFromContReadySuccessful(t *testing.T, signal syscall.Signal) {
 	cleanUp()
 
 	contID := "100"
@@ -1234,10 +1235,20 @@ func TestStopContainerFromContReadySuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c, err = StopContainer(p.id, contID)
-	if err != nil {
+	if err := KillContainer(p.id, contID, signal, false); err != nil {
 		t.Fatal()
 	}
+}
+
+func TestKillContainerFromContReadySuccessful(t *testing.T) {
+	// SIGUSR1
+	testKillContainerFromContReadySuccessful(t, syscall.SIGUSR1)
+	// SIGUSR2
+	testKillContainerFromContReadySuccessful(t, syscall.SIGUSR2)
+	// SIGKILL
+	testKillContainerFromContReadySuccessful(t, syscall.SIGKILL)
+	// SIGTERM
+	testKillContainerFromContReadySuccessful(t, syscall.SIGTERM)
 }
 
 func TestEnterContainerNoopAgentSuccessful(t *testing.T) {

--- a/api_test.go
+++ b/api_test.go
@@ -606,7 +606,7 @@ func TestListPodNoPodDirectory(t *testing.T) {
 	}
 }
 
-func TestStatusPodSuccessful(t *testing.T) {
+func TestStatusPodSuccessfulStateReady(t *testing.T) {
 	cleanUp()
 
 	config := newTestPodConfigNoop()
@@ -633,7 +633,7 @@ func TestStatusPodSuccessful(t *testing.T) {
 					State: StateReady,
 					URL:   "",
 				},
-				PID:         0,
+				PID:         1000,
 				RootFs:      filepath.Join(testDir, testBundle),
 				Annotations: containerAnnotations,
 			},
@@ -641,6 +641,64 @@ func TestStatusPodSuccessful(t *testing.T) {
 	}
 
 	p, err := CreatePod(config)
+	if p == nil || err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := StatusPod(p.id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Copy the start time as we can't pretend we know what that
+	// value will be.
+	expectedStatus.ContainersStatus[0].StartTime = status.ContainersStatus[0].StartTime
+
+	if reflect.DeepEqual(status, expectedStatus) == false {
+		t.Fatalf("Got pod status %v\n expecting %v", status, expectedStatus)
+	}
+}
+
+func TestStatusPodSuccessfulStateRunning(t *testing.T) {
+	cleanUp()
+
+	config := newTestPodConfigNoop()
+	hypervisorConfig := HypervisorConfig{
+		KernelPath:     filepath.Join(testDir, testKernel),
+		ImagePath:      filepath.Join(testDir, testImage),
+		HypervisorPath: filepath.Join(testDir, testHypervisor),
+	}
+
+	expectedStatus := PodStatus{
+		ID: testPodID,
+		State: State{
+			State: StateRunning,
+			URL:   "noopProxyURL",
+		},
+		Hypervisor:       MockHypervisor,
+		HypervisorConfig: hypervisorConfig,
+		Agent:            NoopAgentType,
+		Annotations:      podAnnotations,
+		ContainersStatus: []ContainerStatus{
+			{
+				ID: containerID,
+				State: State{
+					State: StateStopped,
+					URL:   "",
+				},
+				PID:         1000,
+				RootFs:      filepath.Join(testDir, testBundle),
+				Annotations: containerAnnotations,
+			},
+		},
+	}
+
+	p, err := CreatePod(config)
+	if p == nil || err != nil {
+		t.Fatal(err)
+	}
+
+	p, err = StartPod(p.id)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -1398,7 +1456,7 @@ func TestStatusContainerSuccessful(t *testing.T) {
 	}
 }
 
-func TestStatusContainer(t *testing.T) {
+func TestStatusContainerStateReady(t *testing.T) {
 	cleanUp()
 
 	// (homage to a great album! ;)
@@ -1441,7 +1499,79 @@ func TestStatusContainer(t *testing.T) {
 			State: StateReady,
 			URL:   "",
 		},
-		PID:         0,
+		PID:         1000,
+		RootFs:      filepath.Join(testDir, testBundle),
+		Annotations: containerAnnotations,
+	}
+
+	status, err := statusContainer(p2, contID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Copy the start time as we can't pretend we know what that
+	// value will be.
+	expectedStatus.StartTime = status.StartTime
+
+	if reflect.DeepEqual(status, expectedStatus) == false {
+		t.Fatalf("Got container status %v, expected %v", status, expectedStatus)
+	}
+}
+
+func TestStatusContainerStateRunning(t *testing.T) {
+	cleanUp()
+
+	// (homage to a great album! ;)
+	contID := "101"
+	config := newTestPodConfigNoop()
+
+	p, err := CreatePod(config)
+	if p == nil || err != nil {
+		t.Fatal(err)
+	}
+
+	p, err = StartPod(p.id)
+	if p == nil || err != nil {
+		t.Fatal(err)
+	}
+
+	podDir := filepath.Join(configStoragePath, p.id)
+	_, err = os.Stat(podDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	contConfig := newTestContainerConfigNoop(contID)
+
+	_, c, err := CreateContainer(p.id, contConfig)
+	if c == nil || err != nil {
+		t.Fatal(err)
+	}
+
+	c, err = StartContainer(p.id, c.id)
+	if c == nil || err != nil {
+		t.Fatal(err)
+	}
+
+	contDir := filepath.Join(podDir, contID)
+	_, err = os.Stat(contDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// fresh lookup
+	p2, err := fetchPod(p.id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedStatus := ContainerStatus{
+		ID: contID,
+		State: State{
+			State: StateStopped,
+			URL:   "",
+		},
+		PID:         1000,
 		RootFs:      filepath.Join(testDir, testBundle),
 		Annotations: containerAnnotations,
 	}

--- a/container.go
+++ b/container.go
@@ -478,6 +478,15 @@ func (c *Container) stop() error {
 		return err
 	}
 
+	// In case the container status has been updated implicitly because
+	// the container process has terminated, it might be possible that
+	// someone try to stop the container, and we don't want to issue an
+	// error in that case. This should be a no-op.
+	if state.State == StateStopped {
+		virtLog.Info("Container already stopped, nothing to do")
+		return nil
+	}
+
 	if state.State != StateRunning {
 		return fmt.Errorf("Container not running, impossible to stop")
 	}

--- a/container.go
+++ b/container.go
@@ -478,17 +478,6 @@ func (c *Container) stop() error {
 		return err
 	}
 
-	// In case our container is "ready", there is no point in trying to
-	// stop it because nothing has been started. However, this is a valid
-	// case and we handle this by updating the container state only.
-	if state.State == StateReady {
-		if err := state.validTransition(StateReady, StateStopped); err != nil {
-			return err
-		}
-
-		return c.setContainerState(StateStopped)
-	}
-
 	if state.State != StateRunning {
 		return fmt.Errorf("Container not running, impossible to stop")
 	}
@@ -555,9 +544,41 @@ func (c *Container) enter(cmd Cmd) (*Process, error) {
 }
 
 func (c *Container) kill(signal syscall.Signal, all bool) error {
-	state, err := c.fetchState("signal")
+	podState, err := c.pod.storage.fetchPodState(c.pod.id)
 	if err != nil {
 		return err
+	}
+
+	if podState.State != StateReady && podState.State != StateRunning {
+		return fmt.Errorf("Pod not ready or running, impossible to signal the container")
+	}
+
+	state, err := c.pod.storage.fetchContainerState(c.podID, c.id)
+	if err != nil {
+		return err
+	}
+
+	// In case our container is "ready", there is no point in trying to
+	// send any signal because nothing has been started. However, this is
+	// a valid case that we handle by doing nothing or by killing the shim
+	// and updating the container state, according to the signal.
+	if state.State == StateReady {
+		if signal != syscall.SIGTERM && signal != syscall.SIGKILL {
+			virtLog.Infof("Container ready, sending signal %s is a no-op", signal)
+			return nil
+		}
+
+		// Calling into stopShim() will send a SIGKILL to the shim.
+		// This signal will be forwarded to the proxy and it will be
+		// handled by the proxy itself. Indeed, because there is no
+		// process running inside the VM, there is no point in sending
+		// this signal to our agent. Instead, the proxy will take care
+		// of that signal by killing the shim (sending an exit code).
+		if err := stopShim(c.process.Pid); err != nil {
+			return err
+		}
+
+		return c.setContainerState(StateStopped)
 	}
 
 	if state.State != StateRunning {

--- a/noop_shim.go
+++ b/noop_shim.go
@@ -21,5 +21,5 @@ type noopShim struct{}
 // start is the noopShim start implementation for testing purpose.
 // It does nothing.
 func (s *noopShim) start(pod Pod, params ShimParams) (int, error) {
-	return 0, nil
+	return 1000, nil
 }

--- a/noop_shim_test.go
+++ b/noop_shim_test.go
@@ -24,7 +24,7 @@ func TestNoopShimStart(t *testing.T) {
 	s := &noopShim{}
 	pod := Pod{}
 	params := ShimParams{}
-	expected := 0
+	expected := 1000
 
 	pid, err := s.start(pod, params)
 	if err != nil {

--- a/pod.go
+++ b/pod.go
@@ -914,8 +914,10 @@ func (p *Pod) stop() error {
 	}
 
 	for _, c := range p.containers {
-		if err := c.stop(); err != nil {
-			return err
+		if c.state.State == StateRunning || c.state.State == StatePaused {
+			if err := c.stop(); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR fixes several small issues but all related as they globally fix/improve the way we handle a container (or pod) stop/kill and also the updates of the container state. This is needed for reworking properly our runtime implementation.

Fixes #327 
Fixes #328 
Fixes #329 
Fixes #330 
Fixes #331 
Fixes #332 