### PR TITLE
1.0.0-rc.4 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+1.0.0-rc.4:
+	Added new project approvers
+	Fixed gometalinter
+	Increased unit test coverage
+	Added "pc" machine type for Qemu hypervisor
+	Fixed "kill" and "stop" container
+
 1.0.0-rc.3:
 	Added support for assigning the container rootfs underlying block device to the VM (when using devicemapper)
 	Changed qemu to use virtio-net vhost by default


### PR DESCRIPTION
Added new project approvers
Fixed gometalinter
Increased unit test coverage
Added "pc" machine type for Qemu hypervisor
Fixed "kill" and "stop" container

Shortlog:

1140aca hypervisor: export SerializeParams and DeserializeParams
89577b2 pod: Allow to stop a pod in ready state as a special case
8fdcb90 pod: Ignore container ready or stopped when stopping the pod
72a0be6 pod: Factorize pod stop() function
7f61c04 container: Don't issue an error if trying to stop a stopped container
10c592f container: Signal a ready container is valid but not stopping it
ae8fcbb api: Update the container status when retrieving its status
4e5128a create: Split hyperstart init function to perform setup only at create
57bec7d stop: Wait for end of container process before to remove
284dd91 qemu: Add pc machine type as supported
8d8ccbd hyperstart: Move generic pod stopping code
b22c37f tests: Increase unit test coverage for hook.go
1b3d2f0 tests: Add option to panic mock hook
6b29134 tests: Increase unit test coverage for cc_shim.go.
8b7fe13 gometalinter: Enable some missing checks
daa17ff gometalinter: Fix gocyclo issues
62ddd81 gometalinter: Fix go vet issues
b37d339 virtc: Remove blank lines
82e42b7 CI: Add a new reviewer to pullapprove
1c8c7e6 shim: Stop forwarding output in detach mode
41ad8af CI: Add additional approver
ceb467e hypervisor: Add Default{VCPUs, MemSz} to HypervisorConfig
427b84f CI: Add additional project approver