### PR TITLE
hyperstart: move hyper and tty socket to per-pod runtime storage path

### DIFF
--- a/hyperstart.go
+++ b/hyperstart.go
@@ -27,7 +27,7 @@ import (
 	"github.com/containers/virtcontainers/pkg/hyperstart"
 )
 
-var defaultSockPathTemplates = []string{"/tmp/hyper-pod-%s.sock", "/tmp/tty-pod%s.sock"}
+var defaultSockPathTemplates = []string{"%s/%s/hyper.sock", "%s/%s/tty.sock"}
 var defaultChannelTemplate = "sh.hyper.channel.%d"
 var defaultDeviceIDTemplate = "channel%d"
 var defaultIDTemplate = "charch%d"
@@ -58,8 +58,8 @@ func (c *HyperConfig) validate(pod Pod) bool {
 		virtLog.Infof("No sockets from configuration")
 
 		podSocketPaths := []string{
-			fmt.Sprintf(defaultSockPathTemplates[0], pod.id),
-			fmt.Sprintf(defaultSockPathTemplates[1], pod.id),
+			fmt.Sprintf(defaultSockPathTemplates[0], runStoragePath, pod.id),
+			fmt.Sprintf(defaultSockPathTemplates[1], runStoragePath, pod.id),
 		}
 
 		c.SockCtlName = podSocketPaths[0]


### PR DESCRIPTION
Currently we have hyper/tty socket in /tmp/{hyper,tty}-pod-id.sock. We should
move them to /run/virtcontainers/pods/id/{hyper,tty}.sock to be unified.

Fixes #270

Signed-off-by: WANG Chao <chao.wang@ucloud.cn>