### PR TITLE
hyperstart: add suport for user, group and additional groups

### DIFF
--- a/hyperstart.go
+++ b/hyperstart.go
@@ -114,10 +114,13 @@ func (h *hyper) buildHyperContainerProcess(cmd Cmd) (*hyperstart.Process, error)
 	}
 
 	process := &hyperstart.Process{
-		Terminal: cmd.Interactive,
-		Args:     cmd.Args,
-		Envs:     envVars,
-		Workdir:  cmd.WorkDir,
+		Terminal:         cmd.Interactive,
+		Args:             cmd.Args,
+		Envs:             envVars,
+		Workdir:          cmd.WorkDir,
+		User:             cmd.User,
+		Group:            cmd.PrimaryGroup,
+		AdditionalGroups: cmd.SupplementaryGroups,
 	}
 
 	return process, nil


### PR DESCRIPTION
this patch adds the user, group and additional groups in the process
structure used to create a container (newcontainer command)

partially fixes https://github.com/clearcontainers/runtime/issues/386

Signed-off-by: Julio Montes <julio.montes@intel.com>