### PR TITLE
agent: Make the error message from agent generic.

### DIFF
--- a/pkg/hyperstart/hyperstart.go
+++ b/pkg/hyperstart/hyperstart.go
@@ -439,7 +439,7 @@ func (h *Hyperstart) CodeFromCmd(cmd string) (uint32, error) {
 func (h *Hyperstart) CheckReturnedCode(recvCode, expectedCode uint32) error {
 	if recvCode != expectedCode {
 		if recvCode == ErrorCode {
-			return fmt.Errorf("ERROR received from Hyperstart")
+			return fmt.Errorf("ERROR received from VM agent")
 		}
 
 		return fmt.Errorf("CMD ID received %d not matching expected %d", recvCode, expectedCode)


### PR DESCRIPTION
Since we have two different agents now implementing
hyperstart protocol, make the error message in case of
the agent returning an error, a bit more generic to
avoid confusion.

Fixes #350

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>