### PR TITLE
oci: Remove error return from StatusToOCIState()

### DIFF
--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -431,8 +431,8 @@ func ContainerConfig(ocispec CompatOCISpec, bundlePath, cid, console string, det
 }
 
 // StatusToOCIState translates a virtcontainers container status into an OCI state.
-func StatusToOCIState(status vc.ContainerStatus) (spec.State, error) {
-	state := spec.State{
+func StatusToOCIState(status vc.ContainerStatus) spec.State {
+	return spec.State{
 		Version:     spec.Version,
 		ID:          status.ID,
 		Status:      StateToOCIState(status.State),
@@ -440,8 +440,6 @@ func StatusToOCIState(status vc.ContainerStatus) (spec.State, error) {
 		Bundle:      status.Annotations[BundlePathKey],
 		Annotations: status.Annotations,
 	}
-
-	return state, nil
 }
 
 // StateToOCIState translates a virtcontainers container state into an OCI one.

--- a/pkg/oci/utils_test.go
+++ b/pkg/oci/utils_test.go
@@ -230,10 +230,7 @@ func TestVmConfig(t *testing.T) {
 }
 
 func testStatusToOCIStateSuccessful(t *testing.T, cStatus vc.ContainerStatus, expected specs.State) {
-	ociState, err := StatusToOCIState(cStatus)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ociState := StatusToOCIState(cStatus)
 
 	if reflect.DeepEqual(ociState, expected) == false {
 		t.Fatalf("Got %v\n expecting %v", ociState, expected)


### PR DESCRIPTION
StatusToOCIState() does not need to return an error as there are no
error scenarios to deal with.

Fixes #354.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>