### PR TITLE
Fix pod deletion after a failed start under docker.

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -1021,9 +1021,9 @@ func TestStartContainerFailingPodNotStarted(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c, err = StartContainer(p.ID(), contID)
-	if c != nil || err == nil {
-		t.Fatal()
+	_, err = StartContainer(p.ID(), contID)
+	if err == nil {
+		t.Fatal("Function should have failed")
 	}
 }
 

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -454,12 +454,6 @@ func (h *hyper) startPod(pod Pod) error {
 		return err
 	}
 
-	for _, c := range pod.containers {
-		if err := h.startOneContainer(pod, *c); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 

--- a/pod.go
+++ b/pod.go
@@ -687,7 +687,7 @@ func (p *Pod) startCheckStates() error {
 	return nil
 }
 
-func (p *Pod) startSetStates() error {
+func (p *Pod) startSetState() error {
 	podState := State{
 		State: StateRunning,
 		// retain existing URL value
@@ -695,11 +695,6 @@ func (p *Pod) startSetStates() error {
 	}
 
 	err := p.setPodState(podState)
-	if err != nil {
-		return err
-	}
-
-	err = p.setContainersState(podState.State)
 	if err != nil {
 		return err
 	}
@@ -795,12 +790,15 @@ func (p *Pod) start() error {
 		return err
 	}
 
-	for _, c := range p.containers {
-		c.storeMounts()
+	// Pod is started
+	if err := p.startSetState(); err != nil {
+		return err
 	}
 
-	if err := p.startSetStates(); err != nil {
-		return err
+	for _, c := range p.containers {
+		if err := c.start(); err != nil {
+			return err
+		}
 	}
 
 	virtLog.Infof("Started Pod %s", p.ID())


### PR DESCRIPTION
cc-runtime was failing to start a container with a non exiting container ( expected ) but delete cleanup was not properly handled.
This PR add fixes for:
https://github.com/clearcontainers/runtime/issues/507

1. Because the start the container failed, we should stop the shim (indicate the process is not running)
2. The runtime should use oci config.json only at create after that it uses its state file to perform following operations. We were saving the config.json path in virtcontainers annotations, lets save the json content. 
     This allow cc-runtime to get information related with the config even if does not exist anymore.
