### PR TITLE
oci: Set hostname to the one passed in spec file

### DIFF
--- a/hyperstart.go
+++ b/hyperstart.go
@@ -428,7 +428,7 @@ func (h *hyper) startPod(pod Pod) error {
 		return err
 	}
 
-	hostname := pod.id
+	hostname := pod.config.Hostname
 	if len(hostname) > maxHostnameLen {
 		hostname = hostname[:maxHostnameLen]
 	}

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -351,6 +351,8 @@ func PodConfig(ocispec CompatOCISpec, runtime RuntimeConfig, bundlePath, cid, co
 	podConfig := vc.PodConfig{
 		ID: cid,
 
+		Hostname: ocispec.Hostname,
+
 		Hooks: containerHooks(ocispec),
 
 		VMConfig: resources,

--- a/pkg/oci/utils_test.go
+++ b/pkg/oci/utils_test.go
@@ -124,7 +124,8 @@ func TestMinimalPodConfig(t *testing.T) {
 	}
 
 	expectedPodConfig := vc.PodConfig{
-		ID: containerID,
+		ID:       containerID,
+		Hostname: "testHostname",
 
 		HypervisorType: vc.QemuHypervisor,
 		AgentType:      vc.HyperstartAgent,

--- a/pkg/oci/utils_test_config.go
+++ b/pkg/oci/utils_test_config.go
@@ -56,7 +56,7 @@ const minimalConfig = `
 		"path": "rootfs",
 		"readonly": true
 	},
-	"hostname": "runc",
+	"hostname": "testHostname",
 	"mounts": [
 		{
 			"destination": "/proc",

--- a/pod.go
+++ b/pod.go
@@ -296,6 +296,8 @@ type PodStatus struct {
 type PodConfig struct {
 	ID string
 
+	Hostname string
+
 	// Field specific to OCI specs, needed to setup all the hooks
 	Hooks Hooks
 


### PR DESCRIPTION
Hostname was incorrectly being set to the pod-id.
It should instead be set to the hostname passed in the spec
file. The hostname passed is usually the shortened pod-id.

This should fix the command prompt seen when exec'ed into
a container to be the same as runc.

Fixes #361.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>