### PR TITLE
qemu: Typo fix

### DIFF
--- a/qemu.go
+++ b/qemu.go
@@ -456,7 +456,7 @@ func (q *qemu) init(config HypervisorConfig) error {
 		return err
 	}
 
-	virtLog.Info("Running inside a VM = %t", nested)
+	virtLog.Info("Running inside a VM = %v", nested)
 	q.nestedRun = nested
 
 	return nil


### PR DESCRIPTION
%v should work for booleans.

Fixes #363

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>