### PR TITLE
log: Downgrade pod, container and hyperstart config dumps

### DIFF
--- a/container.go
+++ b/container.go
@@ -258,7 +258,7 @@ func fetchContainer(pod *Pod, containerID string) (*Container, error) {
 		return nil, err
 	}
 
-	virtLog.Infof("Info structure: %+v", config)
+	virtLog.Debugf("Container config: %+v", config)
 
 	return createContainer(pod, config)
 }

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -84,7 +84,7 @@ func (c *HyperConfig) validate(pod Pod) bool {
 		c.PauseBinPath = filepath.Join(defaultPauseBinDir, pauseBinName)
 	}
 
-	virtLog.Infof("Hyperstart config %v", c)
+	virtLog.Debugf("Hyperstart config %v", c)
 
 	return true
 }

--- a/pod.go
+++ b/pod.go
@@ -637,7 +637,7 @@ func fetchPod(podID string) (*Pod, error) {
 		return nil, err
 	}
 
-	virtLog.Infof("Info structure: %+v", config)
+	virtLog.Debugf("Pod config: %+v", config)
 
 	return createPod(config)
 }

--- a/qemu.go
+++ b/qemu.go
@@ -456,7 +456,7 @@ func (q *qemu) init(config HypervisorConfig) error {
 		return err
 	}
 
-	virtLog.Info("Running inside a VM = %v", nested)
+	virtLog.Debugf("Running inside a VM = %v", nested)
 	q.nestedRun = nested
 
 	return nil


### PR DESCRIPTION
From Info to Debug. They clutter any runtime log using virtcontainers
at Info level.

Fixes #365

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>