### PR TITLE
Memory Preallocation: Add support for pre-allocation

### DIFF
--- a/hypervisor.go
+++ b/hypervisor.go
@@ -151,6 +151,9 @@ type HypervisorConfig struct {
 	// DefaultMem specifies default memory size in MiB for the VM.
 	// Pod configuration VMConfig.Memory overwrites this.
 	DefaultMemSz uint32
+
+	// MemPrealloc specifies if the memory should be pre-allocated
+	MemPrealloc bool
 }
 
 func (conf *HypervisorConfig) valid() (bool, error) {

--- a/hypervisor.go
+++ b/hypervisor.go
@@ -154,6 +154,14 @@ type HypervisorConfig struct {
 
 	// MemPrealloc specifies if the memory should be pre-allocated
 	MemPrealloc bool
+
+	// Realtime Used to enable/disable realtime
+	Realtime bool
+
+	// Mlock is used to control memory locking when Realtime is enabled
+	// Realtime=true and Mlock=false, allows for swapping out of VM memory
+	// enabling higher density
+	Mlock bool
 }
 
 func (conf *HypervisorConfig) valid() (bool, error) {

--- a/qemu.go
+++ b/qemu.go
@@ -559,6 +559,7 @@ func (q *qemu) createPod(podConfig PodConfig) error {
 		NoDefaults:   true,
 		NoGraphic:    true,
 		Daemonize:    true,
+		MemPrealloc:  q.config.MemPrealloc,
 	}
 
 	kernel := ciaoQemu.Kernel{

--- a/qemu.go
+++ b/qemu.go
@@ -560,6 +560,8 @@ func (q *qemu) createPod(podConfig PodConfig) error {
 		NoGraphic:    true,
 		Daemonize:    true,
 		MemPrealloc:  q.config.MemPrealloc,
+		Realtime:     q.config.Realtime,
+		Mlock:        q.config.Mlock,
 	}
 
 	kernel := ciaoQemu.Kernel{


### PR DESCRIPTION
Add support for pre-allocating all the RAM for the VM. This will reserve the RAM at VM startup.
Also add support for realtime and mlock.

Enabling prealloc, realtime and mlock gives the lowest latecy.
Disabling prealloc, enabling realtime and disabling mlock gives highest density as the memory will be swapped.

This PR depends on vendoring the updated qemu package. https://github.com/01org/ciao/pull/1428 and
https://github.com/01org/ciao/pull/1430


Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>