### PR TITLE
Nesting: Disable nesting checks

### DIFF
--- a/hypervisor.go
+++ b/hypervisor.go
@@ -162,6 +162,10 @@ type HypervisorConfig struct {
 	// Realtime=true and Mlock=false, allows for swapping out of VM memory
 	// enabling higher density
 	Mlock bool
+
+	// DisableNestingChecks is used to override customizations performed
+	// when running on top of another VMM.
+	DisableNestingChecks bool
 }
 
 func (conf *HypervisorConfig) valid() (bool, error) {

--- a/qemu.go
+++ b/qemu.go
@@ -457,7 +457,13 @@ func (q *qemu) init(config HypervisorConfig) error {
 	}
 
 	virtLog.Debugf("Running inside a VM = %v", nested)
-	q.nestedRun = nested
+
+	if config.DisableNestingChecks {
+		//Intentionally ignore the nesting check
+		q.nestedRun = false
+	} else {
+		q.nestedRun = nested
+	}
 
 	return nil
 }


### PR DESCRIPTION
This is used to disable the customizations performed when
we are running on top of another VM. This can be used when
running on top of KVM to obtain the best performance.

This check should not be disabled when running on hypervisors
other than KVM. Doing so will result in failure to launch.

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>