### PR TITLE
hyperstart: Pass the read only flag to the rootfs bind mount

### DIFF
--- a/hyperstart.go
+++ b/hyperstart.go
@@ -526,7 +526,7 @@ func (h *hyper) startOneContainer(pod Pod, c Container) error {
 		container.Image = driveName
 	} else {
 
-		if err := h.bindMountContainerRootfs(pod.id, c.id, c.rootFs, false); err != nil {
+		if err := h.bindMountContainerRootfs(pod.id, c.id, c.rootFs, c.config.ReadonlyRootfs); err != nil {
 			h.bindUnmountAllRootfs(pod)
 			return err
 		}


### PR DESCRIPTION
Or else docker --read-only is not supported.

Fixes: clearcontainers/runtime #614

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>