### PR TITLE
Huge Page Support: Add support for huge pages

### DIFF
--- a/hypervisor.go
+++ b/hypervisor.go
@@ -155,6 +155,9 @@ type HypervisorConfig struct {
 	// MemPrealloc specifies if the memory should be pre-allocated
 	MemPrealloc bool
 
+	// HugePages specifies if the memory should be pre-allocated from huge pages
+	HugePages bool
+
 	// Realtime Used to enable/disable realtime
 	Realtime bool
 

--- a/qemu.go
+++ b/qemu.go
@@ -566,6 +566,7 @@ func (q *qemu) createPod(podConfig PodConfig) error {
 		NoGraphic:    true,
 		Daemonize:    true,
 		MemPrealloc:  q.config.MemPrealloc,
+		HugePages:    q.config.HugePages,
 		Realtime:     q.config.Realtime,
 		Mlock:        q.config.Mlock,
 	}


### PR DESCRIPTION
Add support to launch virtual machines where the RAM is
allocated using huge pages. This is useful for running
with a user mode networking stack, and for custom setups
which require high performance and low latency.

Note: Needs revendoring of ciao/qemu changes https://github.com/ciao-project/ciao/pull/1449

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>