### PR TITLE
logging: Add source field

### DIFF
--- a/api.go
+++ b/api.go
@@ -32,7 +32,7 @@ var virtLog = logrus.FieldLogger(logrus.New())
 
 // SetLogger sets the logger for virtcontainers package.
 func SetLogger(logger logrus.FieldLogger) {
-	virtLog = logger
+	virtLog = logger.WithField("source", "virtcontainers")
 }
 
 // CreatePod is the virtcontainers pod creation entry point.


### PR DESCRIPTION
Make SetLogger() add a "source=" field to the provided logger to allow
individual log entries to be attributable to this package.

Fixes #386.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>