### PR TITLE
1.0.2 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+1.0.2:
+	Added James Hunt as maintainer
+	Added huge pages support
+	Added option for disabling nesting optimizations
+	Fixed the rootfs readonly support
+
 1.0.1:
 	Added QEMU memory locking support
 


### PR DESCRIPTION
Added James Hunt as maintainer
Added huge pages support
Added option for disabling nesting optimizations
Fixed the rootfs readonly support

Shortlog:

ad8449a vendor: Weekly update
27902cf Huge Page Support: Add support for huge pages
e6b2988 logging: Add source field
0b6d279 OWNERS: Add James O. D. Hunt
ab657b5 hyperstart: Pass the read only flag to the rootfs bind mount
bcb61c9 approvers: dlespiau no longer working on this
742c575 Nesting: Disable nesting checks

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>