### PR TITLE
pod: startup: Wait longer for the VM to start

### DIFF
--- a/pod.go
+++ b/pod.go
@@ -707,6 +707,9 @@ func (p *Pod) startSetState() error {
 func (p *Pod) startVM(netNsPath string) error {
 	vmStartedCh := make(chan struct{})
 	vmStoppedCh := make(chan struct{})
+	const timeout = time.Duration(10) * time.Second
+
+	virtLog.Info("Starting VM")
 
 	go func() {
 		p.network.run(netNsPath, func() error {
@@ -719,8 +722,8 @@ func (p *Pod) startVM(netNsPath string) error {
 	select {
 	case <-vmStartedCh:
 		break
-	case <-time.After(time.Second):
-		return fmt.Errorf("Did not receive the pod started notification")
+	case <-time.After(timeout):
+		return fmt.Errorf("Did not receive the pod started notification (timeout %ds)", timeout)
 	}
 
 	virtLog.Infof("VM started")
@@ -885,6 +888,8 @@ func (p *Pod) resumeSetStates() error {
 
 // stopVM stops the agent inside the VM and shut down the VM itself.
 func (p *Pod) stopVM() error {
+	virtLog.Info("Stopping VM")
+
 	if _, _, err := p.proxy.connect(*p, false); err != nil {
 		return err
 	}

--- a/qemu.go
+++ b/qemu.go
@@ -660,7 +660,9 @@ func (q *qemu) startPod(startCh, stopCh chan struct{}) error {
 func (q *qemu) stopPod() error {
 	cfg := ciaoQemu.QMPConfig{Logger: qmpLogger{}}
 	q.qmpControlCh.disconnectCh = make(chan struct{})
+	const timeout = time.Duration(1) * time.Second
 
+	virtLog.Info("Stopping Pod")
 	qmp, _, err := ciaoQemu.QMPStart(q.qmpControlCh.ctx, q.qmpControlCh.path, cfg, q.qmpControlCh.disconnectCh)
 	if err != nil {
 		virtLog.Errorf("Failed to connect to QEMU instance %v", err)
@@ -681,8 +683,8 @@ func (q *qemu) stopPod() error {
 	select {
 	case <-q.qmpControlCh.disconnectCh:
 		break
-	case <-time.After(time.Second):
-		return fmt.Errorf("Did not receive the VM disconnection notification")
+	case <-time.After(timeout):
+		return fmt.Errorf("Did not receive the VM disconnection notification (timeout %ds)", timeout)
 	}
 
 	return nil


### PR DESCRIPTION
VMs can take a little while to get going depending on the
circumstances - such as a very busy or a large (cores and RAM)
VM - 1s is not long enough to wait in such cases. Bump the
startup timeout (it is better to wait 'too long' to realise
something broke, rather than firing false failures)

For now we make the concious decision to leave the VM shutdown
timeout at 1s.

Fixes: #390

Signed-off-by: Graham Whaley <graham.whaley@intel.com>