### PR TITLE
Networking: Ignore invalid and unconfigured interfaces

### DIFF
--- a/network.go
+++ b/network.go
@@ -499,6 +499,15 @@ func getIfacesFromNetNs(networkNSPath string) ([]netIfaceAddrs, error) {
 				return err
 			}
 
+			// Ignore unconfigured network interfaces
+			// These are either base tunnel devices
+			// that are not namespaced like
+			// gre0, gretap0, sit0, ipip0, tunl0
+			// or incorrectly setup interfaces
+			if (addrs == nil) || (len(addrs) == 0) {
+				continue
+			}
+
 			netIface := netIfaceAddrs{
 				iface: iface,
 				addrs: addrs,

--- a/network_test.go
+++ b/network_test.go
@@ -307,25 +307,7 @@ func TestGetIfacesFromNetNsSuccessfulBridge(t *testing.T) {
 		},
 	}
 
-	expected := []netIfaceAddrs{
-		{
-			iface: net.Interface{
-				Index: 1,
-				MTU:   65536,
-				Name:  "lo",
-				Flags: net.FlagLoopback,
-			},
-		},
-		{
-			iface: net.Interface{
-				Index:        2,
-				MTU:          testMTU,
-				Name:         testNetIface,
-				HardwareAddr: hwAddr,
-				Flags:        net.FlagBroadcast | net.FlagMulticast,
-			},
-		},
-	}
+	expected := []netIfaceAddrs(nil)
 
 	testGetIfacesFromNetNsSuccessful(t, link, expected)
 }


### PR DESCRIPTION
Ignore the non namespaced tunnel base devices like gre0, tunl0,
sit0, ipip0 etc. Also ignore any devices that do not have ip
address configured.

Fixes https://github.com/containers/virtcontainers/issues/391

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>