### PR TITLE
DONOTMERGE api: Do not stop the container when checking for status

### DIFF
--- a/api.go
+++ b/api.go
@@ -590,8 +590,12 @@ func statusContainer(pod *Pod, containerID string) (ContainerStatus, error) {
 				}
 
 				if !running {
-					if err := container.stop(); err != nil {
-						return ContainerStatus{}, err
+					err = container.state.validTransition(container.state.State, StateStopped)
+					if err == nil {
+						err = container.setContainerState(StateStopped)
+						if err != nil {
+							return ContainerStatus{}, err
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Stopping an already stopped container or a VM that's shutting down
can lead to blocking connections while we force the proxy to connect
to an existing but unavailable VM.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>