### PR TITLE
api: Fix pod race conditions

### DIFF
--- a/api.go
+++ b/api.go
@@ -325,6 +325,12 @@ func StatusPod(podID string) (PodStatus, error) {
 		return PodStatus{}, errNeedPodID
 	}
 
+	lockFile, err := lockPod(podID)
+	if err != nil {
+		return PodStatus{}, err
+	}
+	defer unlockPod(lockFile)
+
 	pod, err := fetchPod(podID)
 	if err != nil {
 		return PodStatus{}, err
@@ -566,6 +572,12 @@ func StatusContainer(podID, containerID string) (ContainerStatus, error) {
 	if containerID == "" {
 		return ContainerStatus{}, errNeedContainerID
 	}
+
+	lockFile, err := lockPod(podID)
+	if err != nil {
+		return ContainerStatus{}, err
+	}
+	defer unlockPod(lockFile)
 
 	pod, err := fetchPod(podID)
 	if err != nil {

--- a/qemu.go
+++ b/qemu.go
@@ -674,7 +674,7 @@ func (q *qemu) startPod(startCh, stopCh chan struct{}) error {
 func (q *qemu) stopPod() error {
 	cfg := ciaoQemu.QMPConfig{Logger: qmpLogger{}}
 	q.qmpControlCh.disconnectCh = make(chan struct{})
-	const timeout = time.Duration(1) * time.Second
+	const timeout = time.Duration(10) * time.Second
 
 	virtLog.Info("Stopping Pod")
 	qmp, _, err := ciaoQemu.QMPStart(q.qmpControlCh.ctx, q.qmpControlCh.path, cfg, q.qmpControlCh.disconnectCh)


### PR DESCRIPTION
This PR allows to fix the CRI-O testing issues that have been observed recently. The root cause of this is the lack of locking regarding the Pod resource when using `StatusPod()` or `StatusContainer()` functions.