### PR TITLE
Implement custom devices marshalling routines and revert RO rootfs support

### DIFF
--- a/container.go
+++ b/container.go
@@ -155,8 +155,24 @@ func (c *ContainerConfig) UnmarshalJSON(b []byte) error {
 				}
 
 				switch deviceType {
-				case deviceGeneric:
+				case DeviceGeneric:
 					device := newGenericDevice(info)
+					if err != nil {
+						virtLog.Errorf("Could not create new device %v", err)
+						continue
+					}
+
+					c.Devices = append(c.Devices, device)
+				case DeviceVFIO:
+					device := newVFIODevice(info)
+					if err != nil {
+						virtLog.Errorf("Could not create new device %v", err)
+						continue
+					}
+
+					c.Devices = append(c.Devices, device)
+				case DeviceBlock:
+					device := newBlockDevice(info)
 					if err != nil {
 						virtLog.Errorf("Could not create new device %v", err)
 						continue

--- a/device.go
+++ b/device.go
@@ -27,6 +27,12 @@ import (
 	"github.com/go-ini/ini"
 )
 
+const (
+	deviceVFIO    = "vfio"
+	deviceBlock   = "block"
+	deviceGeneric = "generic"
+)
+
 // Defining this as a variable instead of a const, to allow
 // overriding this in the tests.
 var sysIOMMUPath = "/sys/kernel/iommu_groups"
@@ -70,7 +76,7 @@ type DeviceInfo struct {
 	Minor int64
 
 	// FileMode permission bits for the device.
-	FileMode *os.FileMode
+	FileMode os.FileMode
 
 	// id of the device owner.
 	UID uint32
@@ -79,21 +85,69 @@ type DeviceInfo struct {
 	GID uint32
 }
 
+func newDeviceInfo(m map[string]interface{}) (DeviceInfo, error) {
+	var d DeviceInfo
+
+	s, ok := m["HostPath"]
+	if ok {
+		d.HostPath = s.(string)
+	}
+
+	s, ok = m["ContainerPath"]
+	if ok {
+		d.ContainerPath = s.(string)
+	}
+
+	s, ok = m["DevType"]
+	if ok {
+		d.DevType = s.(string)
+	}
+
+	s, ok = m["Major"]
+	if ok {
+		d.Major = int64(s.(float64))
+	}
+
+	s, ok = m["Minor"]
+	if ok {
+		d.Minor = int64(s.(float64))
+	}
+
+	s, ok = m["UID"]
+	if ok {
+		d.UID = uint32(s.(float64))
+	}
+
+	s, ok = m["GID"]
+	if ok {
+		d.GID = uint32(s.(float64))
+	}
+
+	s, ok = m["FileMode"]
+	if ok {
+		d.FileMode = os.FileMode(s.(float64))
+	}
+
+	return d, nil
+}
+
 // VFIODevice is a vfio device meant to be passed to the hypervisor
 // to be used by the Virtual Machine.
 type VFIODevice struct {
-	DeviceInfo
-	BDF string
+	DeviceType string
+	DeviceInfo DeviceInfo
+	BDF        string
 }
 
 func newVFIODevice(devInfo DeviceInfo) *VFIODevice {
-	d := &VFIODevice{}
-	d.DeviceInfo = devInfo
-	return d
+	return &VFIODevice{
+		DeviceType: deviceVFIO,
+		DeviceInfo: devInfo,
+	}
 }
 
 func (device *VFIODevice) attach(h hypervisor) error {
-	vfioGroup := filepath.Base(device.HostPath)
+	vfioGroup := filepath.Base(device.DeviceInfo.HostPath)
 	iommuDevicesPath := filepath.Join(sysIOMMUPath, vfioGroup, "devices")
 
 	deviceFiles, err := ioutil.ReadDir(iommuDevicesPath)
@@ -126,13 +180,15 @@ func (device *VFIODevice) detach(h hypervisor) error {
 
 // BlockDevice refers to a block storage device implementation.
 type BlockDevice struct {
-	DeviceInfo
+	DeviceType string
+	DeviceInfo DeviceInfo
 }
 
 func newBlockDevice(devInfo DeviceInfo) *BlockDevice {
-	d := &BlockDevice{}
-	d.DeviceInfo = devInfo
-	return d
+	return &BlockDevice{
+		DeviceType: deviceBlock,
+		DeviceInfo: devInfo,
+	}
 }
 
 func (device *BlockDevice) attach(h hypervisor) error {
@@ -145,13 +201,15 @@ func (device BlockDevice) detach(h hypervisor) error {
 
 // GenericDevice refers to a device that is neither a VFIO device or block device.
 type GenericDevice struct {
-	DeviceInfo
+	DeviceType string
+	DeviceInfo DeviceInfo
 }
 
 func newGenericDevice(devInfo DeviceInfo) *GenericDevice {
-	d := &GenericDevice{}
-	d.DeviceInfo = devInfo
-	return d
+	return &GenericDevice{
+		DeviceType: deviceGeneric,
+		DeviceInfo: devInfo,
+	}
 }
 
 func (device *GenericDevice) attach(h hypervisor) error {
@@ -243,8 +301,11 @@ func NewDevice(path, devType string, major, minor int64, fileMode *os.FileMode, 
 		UID:           uid,
 		GID:           gid,
 		DevType:       devType,
-		FileMode:      fileMode,
 		ContainerPath: path,
+	}
+
+	if fileMode != nil {
+		devInfo.FileMode = *fileMode
 	}
 
 	hostPath, err := GetHostPathFunc(devInfo)

--- a/device.go
+++ b/device.go
@@ -28,9 +28,14 @@ import (
 )
 
 const (
-	deviceVFIO    = "vfio"
-	deviceBlock   = "block"
-	deviceGeneric = "generic"
+	// DeviceVFIO is the VFIO device type
+	DeviceVFIO = "vfio"
+
+	// DeviceBlock is the block device type
+	DeviceBlock = "block"
+
+	// DeviceGeneric is a generic device type
+	DeviceGeneric = "generic"
 )
 
 // Defining this as a variable instead of a const, to allow
@@ -141,7 +146,7 @@ type VFIODevice struct {
 
 func newVFIODevice(devInfo DeviceInfo) *VFIODevice {
 	return &VFIODevice{
-		DeviceType: deviceVFIO,
+		DeviceType: DeviceVFIO,
 		DeviceInfo: devInfo,
 	}
 }
@@ -186,7 +191,7 @@ type BlockDevice struct {
 
 func newBlockDevice(devInfo DeviceInfo) *BlockDevice {
 	return &BlockDevice{
-		DeviceType: deviceBlock,
+		DeviceType: DeviceBlock,
 		DeviceInfo: devInfo,
 	}
 }
@@ -207,7 +212,7 @@ type GenericDevice struct {
 
 func newGenericDevice(devInfo DeviceInfo) *GenericDevice {
 	return &GenericDevice{
-		DeviceType: deviceGeneric,
+		DeviceType: DeviceGeneric,
 		DeviceInfo: devInfo,
 	}
 }

--- a/device_test.go
+++ b/device_test.go
@@ -121,13 +121,13 @@ func testNewDevice(t *testing.T) {
 
 	vfioDev, ok := device.(*VFIODevice)
 	assert.True(t, ok)
-	assert.Equal(t, vfioDev.HostPath, path)
-	assert.Equal(t, vfioDev.ContainerPath, path)
-	assert.Equal(t, vfioDev.DevType, "c")
-	assert.Equal(t, vfioDev.Major, major)
-	assert.Equal(t, vfioDev.Minor, minor)
-	assert.Equal(t, vfioDev.UID, 2)
-	assert.Equal(t, vfioDev.GID, 2)
+	assert.Equal(t, vfioDev.DeviceInfo.HostPath, path)
+	assert.Equal(t, vfioDev.DeviceInfo.ContainerPath, path)
+	assert.Equal(t, vfioDev.DeviceInfo.DevType, "c")
+	assert.Equal(t, vfioDev.DeviceInfo.Major, major)
+	assert.Equal(t, vfioDev.DeviceInfo.Minor, minor)
+	assert.Equal(t, vfioDev.DeviceInfo.UID, 2)
+	assert.Equal(t, vfioDev.DeviceInfo.GID, 2)
 }
 
 func TestGetBDF(t *testing.T) {

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -526,7 +526,7 @@ func (h *hyper) startOneContainer(pod Pod, c Container) error {
 		container.Image = driveName
 	} else {
 
-		if err := h.bindMountContainerRootfs(pod.id, c.id, c.rootFs, c.config.ReadonlyRootfs); err != nil {
+		if err := h.bindMountContainerRootfs(pod.id, c.id, c.rootFs, false); err != nil {
 			h.bindUnmountAllRootfs(pod)
 			return err
 		}

--- a/pkg/oci/utils_test.go
+++ b/pkg/oci/utils_test.go
@@ -142,6 +142,7 @@ func TestMinimalPodConfig(t *testing.T) {
 
 	vfioDevice := vc.VFIODevice{}
 	vfioDevice.DeviceInfo = devInfo
+	vfioDevice.DeviceType = vc.DeviceVFIO
 
 	expectedDevices := []vc.Device{
 		&vfioDevice,


### PR DESCRIPTION
The agent does not fully support RO rootfs

 Unmarshalling device interfaces is not possible with our device structures.
 We need to implement our custom marshalling and unmarshalling routines
 in order to properly create the right devices from a stored container config.
