### PR TITLE
1.0.3 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+1.0.3:
+	Added initial device assignment framework
+	Added VFIO devices assignment initial support
+	Fixed pod locking
+	Fixed unconfigured interfaces handling
+
 1.0.2:
 	Added James Hunt as maintainer
 	Added huge pages support


### PR DESCRIPTION
Added initial device assignment framework
Added VFIO devices assignment initial support
Fixed pod locking
Fixed unconfigured interfaces handling

Shortlog

3802796 tests: Fix oci tests for device handling.
64e868c container: Implement custom devices marshalling routines
7b8ee42 hyperstart: Temporarily revert rootfs ro support
f2ba9f1 Networking: Ignore invalid and unconfigured interfaces
24c8394 api: Add missing pod locks
51a6d33 qemu: Increase the timeout when stopping the VM
77b5ef7 devices: Add attachDevices and detachDevices for pods and container.
f23109c vfio: Handle attaching vfio devices.
7e607e2 qemu: Add vfio-passthrough to qemu.
3a40fdd tests: Add tests for creating devices.
98af546 vendor: Vendor github.com/go-ini/ini
efc00b9 devices: Parse Linux devices from oci spec.
a9f589f pod: VMs: more logging, better timeouts

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>