### PR TITLE
shim: Add ability to enable debug output

### DIFF
--- a/cc_shim.go
+++ b/cc_shim.go
@@ -28,7 +28,8 @@ type ccShim struct{}
 // CCShimConfig is the structure providing specific configuration
 // for ccShim implementation.
 type CCShimConfig struct {
-	Path string
+	Path  string
+	Debug bool
 }
 
 var consoleFileMode = os.FileMode(0660)
@@ -58,7 +59,12 @@ func (s *ccShim) start(pod Pod, params ShimParams) (int, error) {
 		return -1, fmt.Errorf("URL cannot be empty")
 	}
 
-	cmd := exec.Command(config.Path, "-t", params.Token, "-u", params.URL)
+	args := []string{config.Path, "-t", params.Token, "-u", params.URL}
+	if config.Debug {
+		args = append(args, "-d")
+	}
+
+	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Env = os.Environ()
 
 	if !params.Detach {


### PR DESCRIPTION
Add a new option to `CCShimConfig` to allow `cc-shim` debug output
to be enabled.

Fixes #401.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>