### PR TITLE
qemu: support custom bios

### DIFF
--- a/hypervisor.go
+++ b/hypervisor.go
@@ -127,6 +127,9 @@ type HypervisorConfig struct {
 	// ImagePath is the guest image host path.
 	ImagePath string
 
+	// FirmwarePath is the bios host path
+	FirmwarePath string
+
 	// HypervisorPath is the hypervisor executable host path.
 	HypervisorPath string
 

--- a/hypervisor.go
+++ b/hypervisor.go
@@ -130,6 +130,9 @@ type HypervisorConfig struct {
 	// FirmwarePath is the bios host path
 	FirmwarePath string
 
+	// MachineAccelerators are machine specific accelerators
+	MachineAccelerators string
+
 	// HypervisorPath is the hypervisor executable host path.
 	HypervisorPath string
 

--- a/qemu.go
+++ b/qemu.go
@@ -87,7 +87,7 @@ var supportedQemuMachines = []ciaoQemu.Machine{
 	},
 	{
 		Type:         QemuQ35,
-		Acceleration: "kvm,kernel_irqchip,nvdimm,nosmm,nosmbus,nosata,nopit,nofw",
+		Acceleration: "kvm,kernel_irqchip,nvdimm,nosmm,nosmbus,nosata,nopit",
 	},
 }
 
@@ -648,6 +648,7 @@ func (q *qemu) createPod(podConfig PodConfig) error {
 		Knobs:       knobs,
 		VGA:         "none",
 		GlobalParam: "kvm-pit.lost_tick_policy=discard",
+		Bios:        podConfig.HypervisorConfig.FirmwarePath,
 	}
 
 	q.qemuConfig = qemuConfig

--- a/qemu.go
+++ b/qemu.go
@@ -567,6 +567,14 @@ func (q *qemu) createPod(podConfig PodConfig) error {
 		return err
 	}
 
+	accelerators := podConfig.HypervisorConfig.MachineAccelerators
+	if accelerators != "" {
+		if !strings.HasPrefix(accelerators, ",") {
+			accelerators = fmt.Sprintf(",%s", accelerators)
+		}
+		machine.Acceleration += accelerators
+	}
+
 	smp := q.setCPUResources(podConfig)
 
 	memory, err := q.setMemoryResources(podConfig)

--- a/qemu.go
+++ b/qemu.go
@@ -58,6 +58,8 @@ const defaultQemuPath = "/usr/bin/qemu-system-x86_64"
 
 const defaultQemuMachineType = "pc-lite"
 
+const defaultQemuMachineAccelerators = "kvm,kernel_irqchip,nvdimm"
+
 const (
 	// QemuPCLite is the QEMU pc-lite machine type
 	QemuPCLite = defaultQemuMachineType
@@ -79,15 +81,15 @@ var qemuPaths = map[string]string{
 var supportedQemuMachines = []ciaoQemu.Machine{
 	{
 		Type:         QemuPCLite,
-		Acceleration: "kvm,kernel_irqchip,nvdimm",
+		Acceleration: defaultQemuMachineAccelerators,
 	},
 	{
 		Type:         QemuPC,
-		Acceleration: "kvm,kernel_irqchip,nvdimm",
+		Acceleration: defaultQemuMachineAccelerators,
 	},
 	{
 		Type:         QemuQ35,
-		Acceleration: "kvm,kernel_irqchip,nvdimm",
+		Acceleration: defaultQemuMachineAccelerators,
 	},
 }
 

--- a/qemu.go
+++ b/qemu.go
@@ -87,7 +87,7 @@ var supportedQemuMachines = []ciaoQemu.Machine{
 	},
 	{
 		Type:         QemuQ35,
-		Acceleration: "kvm,kernel_irqchip,nvdimm,nosmm,nosmbus,nosata,nopit",
+		Acceleration: "kvm,kernel_irqchip,nvdimm",
 	},
 }
 


### PR DESCRIPTION
In order to support custom BIOS, nofw option
must be removed and the Bios must be set with
the path to it

partially fixes https://github.com/clearcontainers/runtime/pull/687

Signed-off-by: Julio Montes <julio.montes@intel.com>