### PR TITLE
Refactor device handling

### DIFF
--- a/device.go
+++ b/device.go
@@ -59,6 +59,7 @@ const (
 type Device interface {
 	attach(hypervisor) error
 	detach(hypervisor) error
+	deviceType() string
 }
 
 // DeviceInfo is an embedded type that contains device data common to all types of devices.
@@ -183,6 +184,10 @@ func (device *VFIODevice) detach(h hypervisor) error {
 	return nil
 }
 
+func (device *VFIODevice) deviceType() string {
+	return device.DeviceType
+}
+
 // BlockDevice refers to a block storage device implementation.
 type BlockDevice struct {
 	DeviceType string
@@ -204,6 +209,10 @@ func (device BlockDevice) detach(h hypervisor) error {
 	return nil
 }
 
+func (device *BlockDevice) deviceType() string {
+	return device.DeviceType
+}
+
 // GenericDevice refers to a device that is neither a VFIO device or block device.
 type GenericDevice struct {
 	DeviceType string
@@ -223,6 +232,10 @@ func (device *GenericDevice) attach(h hypervisor) error {
 
 func (device *GenericDevice) detach(h hypervisor) error {
 	return nil
+}
+
+func (device *GenericDevice) deviceType() string {
+	return device.DeviceType
 }
 
 // isVFIO checks if the device provided is a vfio group.

--- a/device.go
+++ b/device.go
@@ -91,52 +91,6 @@ type DeviceInfo struct {
 	GID uint32
 }
 
-func newDeviceInfo(m map[string]interface{}) (DeviceInfo, error) {
-	var d DeviceInfo
-
-	s, ok := m["HostPath"]
-	if ok {
-		d.HostPath = s.(string)
-	}
-
-	s, ok = m["ContainerPath"]
-	if ok {
-		d.ContainerPath = s.(string)
-	}
-
-	s, ok = m["DevType"]
-	if ok {
-		d.DevType = s.(string)
-	}
-
-	s, ok = m["Major"]
-	if ok {
-		d.Major = int64(s.(float64))
-	}
-
-	s, ok = m["Minor"]
-	if ok {
-		d.Minor = int64(s.(float64))
-	}
-
-	s, ok = m["UID"]
-	if ok {
-		d.UID = uint32(s.(float64))
-	}
-
-	s, ok = m["GID"]
-	if ok {
-		d.GID = uint32(s.(float64))
-	}
-
-	s, ok = m["FileMode"]
-	if ok {
-		d.FileMode = os.FileMode(s.(float64))
-	}
-
-	return d, nil
-}
-
 // VFIODevice is a vfio device meant to be passed to the hypervisor
 // to be used by the Virtual Machine.
 type VFIODevice struct {
@@ -310,34 +264,24 @@ func GetHostPath(devInfo DeviceInfo) (string, error) {
 // GetHostPathFunc is function pointer used to mock GetHostPath in tests.
 var GetHostPathFunc = GetHostPath
 
-// NewDevice returns a device interface implementation based on the host path of the device.
-// The hostpath itself is inferred based on the major-minor number of the device.
-func NewDevice(path, devType string, major, minor int64, fileMode *os.FileMode, uid, gid uint32) (Device, error) {
-	devInfo := DeviceInfo{
-		Major:         major,
-		Minor:         minor,
-		UID:           uid,
-		GID:           gid,
-		DevType:       devType,
-		ContainerPath: path,
+func newDevices(devInfos []DeviceInfo) ([]Device, error) {
+	var devices []Device
+
+	for _, devInfo := range devInfos {
+		hostPath, err := GetHostPathFunc(devInfo)
+		if err != nil {
+			return nil, err
+		}
+
+		devInfo.HostPath = hostPath
+		device := createDevice(devInfo)
+		devices = append(devices, device)
 	}
 
-	if fileMode != nil {
-		devInfo.FileMode = *fileMode
-	}
-
-	hostPath, err := GetHostPathFunc(devInfo)
-	if err != nil {
-		return nil, err
-	}
-
-	devInfo.HostPath = hostPath
-
-	device := createDevice(devInfo)
-	return device, nil
+	return devices, nil
 }
 
-// bdf returns the BDF of pci device
+// getBDF returns the BDF of pci device
 // Expected input strng format is [<domain>]:[<bus>][<slot>].[<func>] eg. 0000:02:10.0
 func getBDF(deviceSysStr string) (string, error) {
 	tokens := strings.Split(deviceSysStr, ":")

--- a/device.go
+++ b/device.go
@@ -126,9 +126,12 @@ func (device *VFIODevice) attach(h hypervisor) error {
 
 		device.BDF = deviceBDF
 
-		if err := h.addDevice(device, vfioDev); err != nil {
+		if err := h.addDevice(*device, vfioDev); err != nil {
+			virtLog.Errorf("Error while adding device : %v\n", err)
 			return err
 		}
+
+		virtLog.Infof("Device group %s attached via vfio passthrough", device.DeviceInfo.HostPath)
 	}
 
 	return nil

--- a/device_test.go
+++ b/device_test.go
@@ -92,7 +92,7 @@ func testCreateDevice(t *testing.T) {
 	assert.True(t, ok)
 }
 
-func testNewDevice(t *testing.T) {
+func testNewDevices(t *testing.T) {
 	savedSysDevPrefix := sysDevPrefix
 
 	major := int64(252)
@@ -116,10 +116,20 @@ func testNewDevice(t *testing.T) {
 	err = ioutil.WriteFile(ueventPath, content, 0644)
 	assert.Nil(t, err)
 
-	device, err := NewDevice(path, "c", major, minor, nil, 2, 2)
+	deviceInfo := DeviceInfo{
+		ContainerPath: path,
+		Major:         major,
+		Minor:         minor,
+		UID:           2,
+		GID:           2,
+		DevType:       "c",
+	}
+
+	devices, err := newDevices([]DeviceInfo{deviceInfo})
 	assert.Nil(t, err)
 
-	vfioDev, ok := device.(*VFIODevice)
+	assert.Equal(t, len(devices), 1)
+	vfioDev, ok := devices[0].(*VFIODevice)
 	assert.True(t, ok)
 	assert.Equal(t, vfioDev.DeviceInfo.HostPath, path)
 	assert.Equal(t, vfioDev.DeviceInfo.ContainerPath, path)

--- a/filesystem.go
+++ b/filesystem.go
@@ -547,6 +547,12 @@ func (fs *filesystem) fetchResource(podSpecific bool, podID, containerID string,
 		return nil, err
 	}
 
+	return fs.doFetchResource(containerID, path, resource)
+}
+
+func (fs *filesystem) doFetchResource(containerID, path string, resource podResource) (interface{}, error) {
+	var err error
+
 	switch resource {
 	case configFileType:
 		if containerID == "" {

--- a/filesystem.go
+++ b/filesystem.go
@@ -48,6 +48,9 @@ const (
 
 	// mountsFileType represents a mount file type
 	mountsFileType
+
+	// devicesFileType represents a device file type
+	devicesFileType
 )
 
 // configFile is the file name used for every JSON pod configuration.
@@ -66,6 +69,9 @@ const processFile = "process.json"
 const lockFileName = "lock"
 
 const mountsFile = "mounts.json"
+
+// devicesFile is the file name storing a container's devices.
+const devicesFile = "devices.json"
 
 // dirMode is the permission bits used for creating a directory
 const dirMode = os.FileMode(0750)
@@ -110,6 +116,8 @@ type resourceStorage interface {
 	storeContainerProcess(podID, containerID string, process Process) error
 	fetchContainerMounts(podID, containerID string) ([]Mount, error)
 	storeContainerMounts(podID, containerID string, mounts []Mount) error
+	fetchContainerDevices(podID, containerID string) ([]Device, error)
+	storeContainerDevices(podID, containerID string, devices []Device) error
 }
 
 // filesystem is a resourceStorage interface implementation for a local filesystem.
@@ -175,6 +183,58 @@ func (fs *filesystem) storeFile(file string, data interface{}) error {
 	return nil
 }
 
+// TypedDevice is used as an intermediate representation for marshalling
+// and unmarshalling Device implementations.
+type TypedDevice struct {
+	Type string
+
+	// Data is assigned the Device object.
+	// This being declared as RawMessage prevents it from being  marshalled/unmarshalled.
+	// We do that explicitly depending on Type.
+	Data json.RawMessage
+}
+
+// storeDeviceFile is used to provide custom marshalling for Device objects.
+// Device is first marshalled into TypedDevice to include the type
+// of the Device object.
+func (fs *filesystem) storeDeviceFile(file string, data interface{}) error {
+	if file == "" {
+		return errNeedFile
+	}
+
+	f, err := os.Create(file)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	devices, ok := data.([]Device)
+	if !ok {
+		return fmt.Errorf("Incorrect data type received, Expected []Device")
+	}
+
+	var typedDevices []TypedDevice
+	for _, d := range devices {
+		tempJSON, _ := json.Marshal(d)
+		typedDevice := TypedDevice{
+			Type: d.deviceType(),
+			Data: tempJSON,
+		}
+		typedDevices = append(typedDevices, typedDevice)
+	}
+
+	jsonOut, err := json.Marshal(typedDevices)
+	if err != nil {
+		return fmt.Errorf("Could not marshal devices: %s", err)
+	}
+
+	if _, err := f.Write(jsonOut); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (fs *filesystem) fetchFile(file string, data interface{}) error {
 	if file == "" {
 		return errNeedFile
@@ -190,6 +250,65 @@ func (fs *filesystem) fetchFile(file string, data interface{}) error {
 		return err
 	}
 
+	return nil
+}
+
+// fetchDeviceFile is used for custom unmarshalling of device interface objects.
+func (fs *filesystem) fetchDeviceFile(file string, devices *[]Device) error {
+	if file == "" {
+		return errNeedFile
+	}
+
+	fileData, err := ioutil.ReadFile(file)
+	if err != nil {
+		return err
+	}
+
+	var typedDevices []TypedDevice
+	err = json.Unmarshal([]byte(string(fileData)), &typedDevices)
+
+	if err != nil {
+		return err
+	}
+
+	var tempDevices []Device
+	for _, d := range typedDevices {
+		virtLog.Infof("Device type found in devices file : %s", d.Type)
+
+		switch d.Type {
+		case DeviceVFIO:
+			var device VFIODevice
+			err := json.Unmarshal(d.Data, &device)
+			if err != nil {
+				return err
+			}
+			tempDevices = append(tempDevices, &device)
+			virtLog.Infof("VFIO device unmarshalled [%v]", device)
+
+		case DeviceBlock:
+			var device BlockDevice
+			err := json.Unmarshal(d.Data, &device)
+			if err != nil {
+				return err
+			}
+			tempDevices = append(tempDevices, &device)
+			virtLog.Infof("Block Device unmarshalled [%v]", device)
+
+		case DeviceGeneric:
+			var device GenericDevice
+			err := json.Unmarshal(d.Data, &device)
+			if err != nil {
+				return err
+			}
+			tempDevices = append(tempDevices, &device)
+			virtLog.Infof("Generic device unmarshalled [%v]", device)
+
+		default:
+			return fmt.Errorf("Unknown device type, could not unmarshal")
+		}
+	}
+
+	*devices = tempDevices
 	return nil
 }
 
@@ -224,7 +343,7 @@ func resourceDir(podSpecific bool, podID, containerID string, resource podResour
 	case configFileType:
 		path = configStoragePath
 		break
-	case stateFileType, networkFileType, processFileType, lockFileType, mountsFileType:
+	case stateFileType, networkFileType, processFileType, lockFileType, mountsFileType, devicesFileType:
 		path = runStoragePath
 		break
 	default:
@@ -267,6 +386,9 @@ func (fs *filesystem) resourceURI(podSpecific bool, podID, containerID string, r
 		break
 	case mountsFileType:
 		filename = mountsFile
+		break
+	case devicesFileType:
+		filename = devicesFile
 		break
 	default:
 		return "", "", errInvalidResource
@@ -373,6 +495,19 @@ func (fs *filesystem) storeMountResource(podSpecific bool, podID, containerID st
 	return fs.storeFile(mountsFile, file)
 }
 
+func (fs *filesystem) storeDeviceResource(podSpecific bool, podID, containerID string, resource podResource, file interface{}) error {
+	if resource != devicesFileType {
+		return errInvalidResource
+	}
+
+	devicesFile, _, err := fs.resourceURI(podSpecific, podID, containerID, devicesFileType)
+	if err != nil {
+		return err
+	}
+
+	return fs.storeDeviceFile(devicesFile, file)
+}
+
 func (fs *filesystem) storeResource(podSpecific bool, podID, containerID string, resource podResource, data interface{}) error {
 	if err := fs.commonResourceChecks(podSpecific, podID, containerID, resource); err != nil {
 		return err
@@ -393,6 +528,9 @@ func (fs *filesystem) storeResource(podSpecific bool, podID, containerID string,
 
 	case []Mount:
 		return fs.storeMountResource(podSpecific, podID, containerID, resource, file)
+
+	case []Device:
+		return fs.storeDeviceResource(podSpecific, podID, containerID, resource, file)
 
 	default:
 		return fmt.Errorf("Invalid resource data type")
@@ -464,6 +602,15 @@ func (fs *filesystem) fetchResource(podSpecific bool, podID, containerID string,
 		}
 
 		return mounts, nil
+
+	case devicesFileType:
+		devices := []Device{}
+		err = fs.fetchDeviceFile(path, &devices)
+		if err != nil {
+			return nil, err
+		}
+
+		return devices, nil
 	}
 	return nil, errInvalidResource
 }
@@ -642,8 +789,34 @@ func (fs *filesystem) fetchContainerMounts(podID, containerID string) ([]Mount, 
 	}
 }
 
+func (fs *filesystem) fetchContainerDevices(podID, containerID string) ([]Device, error) {
+	if podID == "" {
+		return []Device{}, errNeedPodID
+	}
+
+	if containerID == "" {
+		return []Device{}, errNeedContainerID
+	}
+
+	data, err := fs.fetchResource(false, podID, containerID, devicesFileType)
+	if err != nil {
+		return []Device{}, err
+	}
+
+	switch devices := data.(type) {
+	case []Device:
+		return devices, nil
+	default:
+		return []Device{}, fmt.Errorf("Unknown devices type : [%T]", devices)
+	}
+}
+
 func (fs *filesystem) storeContainerMounts(podID, containerID string, mounts []Mount) error {
 	return fs.storeContainerResource(podID, containerID, mountsFileType, mounts)
+}
+
+func (fs *filesystem) storeContainerDevices(podID, containerID string, devices []Device) error {
+	return fs.storeContainerResource(podID, containerID, devicesFileType, devices)
 }
 
 func (fs *filesystem) deleteContainerResources(podID, containerID string, resources []podResource) error {

--- a/pkg/oci/utils_test.go
+++ b/pkg/oci/utils_test.go
@@ -132,7 +132,6 @@ func TestMinimalPodConfig(t *testing.T) {
 
 	devInfo := vc.DeviceInfo{
 		ContainerPath: "/dev/vfio/17",
-		HostPath:      "/dev/vfio/17",
 		Major:         242,
 		Minor:         0,
 		DevType:       "c",
@@ -140,12 +139,8 @@ func TestMinimalPodConfig(t *testing.T) {
 		GID:           0,
 	}
 
-	vfioDevice := vc.VFIODevice{}
-	vfioDevice.DeviceInfo = devInfo
-	vfioDevice.DeviceType = vc.DeviceVFIO
-
-	expectedDevices := []vc.Device{
-		&vfioDevice,
+	expectedDeviceInfo := []vc.DeviceInfo{
+		devInfo,
 	}
 
 	expectedContainerConfig := vc.ContainerConfig{
@@ -158,8 +153,8 @@ func TestMinimalPodConfig(t *testing.T) {
 			BundlePathKey:    tempBundlePath,
 			ContainerTypeKey: string(vc.PodSandbox),
 		},
-		Mounts:  expectedMounts,
-		Devices: expectedDevices,
+		Mounts:      expectedMounts,
+		DeviceInfos: expectedDeviceInfo,
 	}
 
 	expectedNetworkConfig := vc.NetworkConfig{
@@ -675,7 +670,7 @@ func TestDeviceTypeFailure(t *testing.T) {
 		},
 	}
 
-	_, err := containerDevices(ociSpec)
+	_, err := containerDeviceInfos(ociSpec)
 	assert.NotNil(t, err, "This test should fail as device type [%s] is invalid ", invalidDeviceType)
 }
 
@@ -700,7 +695,7 @@ func TestDevicePathEmpty(t *testing.T) {
 		},
 	}
 
-	_, err := containerDevices(ociSpec)
+	_, err := containerDeviceInfos(ociSpec)
 	assert.NotNil(t, err, "This test should fail as path cannot be empty for device")
 }
 

--- a/pod_test.go
+++ b/pod_test.go
@@ -1267,25 +1267,21 @@ func TestPodAttachDevicesVFIO(t *testing.T) {
 	}
 	vfioDevice := newVFIODevice(deviceInfo)
 
-	containers := []ContainerConfig{
-		{
-			ID: "100",
-			Devices: []Device{
-				vfioDevice,
-			},
+	c := &Container{
+		id: "100",
+		devices: []Device{
+			vfioDevice,
 		},
 	}
 
-	hConfig := newHypervisorConfig(nil, nil)
-	pod, err := testCreatePod(t, testPodID, MockHypervisor, hConfig, NoopAgentType, NoopNetworkModel, NetworkConfig{}, containers, nil)
-	if err != nil {
-		t.Fatal(err)
+	containers := []*Container{c}
+
+	pod := Pod{
+		containers: containers,
+		hypervisor: &mockHypervisor{},
 	}
 
-	c := pod.GetContainer("100")
-	if c == nil {
-		t.Fatal()
-	}
+	containers[0].pod = &pod
 
 	err = pod.attachDevices()
 	assert.Nil(t, err, "Error while attaching devices %s", err)


### PR DESCRIPTION
Refactor the way devices are handled so that we store an invariable config set in the configuration.
This PR moves the Device interfaces from ContainerConfig to Container and create the device implementations at create stage.
Devices are store separately in "devices.json". This simplifies the custom marshalling and unmarshalling to an extent.