### PR TITLE
vendor: update ciao

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -5,7 +5,7 @@
   branch = "master"
   name = "github.com/01org/ciao"
   packages = ["qemu","ssntp/uuid"]
-  revision = "221e8b626c089e06ba37e095fac372b779077e5d"
+  revision = "44068003db570d97b20b7de0ed0686a9eee0cc0f"
 
 [[projects]]
   name = "github.com/clearcontainers/proxy"

--- a/vendor/github.com/01org/ciao/CONTRIBUTING.md
+++ b/vendor/github.com/01org/ciao/CONTRIBUTING.md
@@ -71,13 +71,13 @@ We request you give quality assurance some consideration by:
 ## Issue tracking
 
 If you have a problem, please let us know.  IRC is a perfectly fine place
-to quickly informally bring something up, if you get a response.  The
+to quickly and informally bring something up.  The
 [mailing list](https://lists.clearlinux.org/mailman/listinfo/ciao-devel)
-is a more durable communication channel.
+is a more reliable communication channel.
 
 If it's a bug not already documented, by all means please [open an
 issue in github](https://github.com/ciao-project/ciao/issues/new) so we all get visibility
-the problem and work toward resolution.
+of the problem and work toward resolution.
 
 For feature requests we're also using github issues, with the label
 "enhancement".

--- a/vendor/github.com/01org/ciao/packages.json
+++ b/vendor/github.com/01org/ciao/packages.json
@@ -56,7 +56,7 @@
 	},
 	"github.com/intel/tfortools": {
 		"url": "https://github.com/intel/tfortools.git",
-		"version": "2aef60e",
+		"version": "v0.1.0",
 		"license": "Apache v2.0"
 	},
 	"github.com/mattn/go-sqlite3": {

--- a/vendor/github.com/01org/ciao/qemu/qemu.go
+++ b/vendor/github.com/01org/ciao/qemu/qemu.go
@@ -837,6 +837,9 @@ type Config struct {
 	// Knobs is a set of qemu boolean settings.
 	Knobs Knobs
 
+	// Bios is the -bios parameter
+	Bios string
+
 	// fds is a list of open file descriptors to be passed to the spawned qemu process
 	fds []*os.File
 
@@ -1082,6 +1085,13 @@ func (config *Config) appendKnobs() {
 	}
 }
 
+func (config *Config) appendBios() {
+	if config.Bios != "" {
+		config.qemuParams = append(config.qemuParams, "-bios")
+		config.qemuParams = append(config.qemuParams, config.Bios)
+	}
+}
+
 // LaunchQemu can be used to launch a new qemu instance.
 //
 // The Config parameter contains a set of qemu parameters and settings.
@@ -1105,6 +1115,7 @@ func LaunchQemu(config Config, logger QMPLog) (string, error) {
 	config.appendVGA()
 	config.appendKnobs()
 	config.appendKernel()
+	config.appendBios()
 
 	return LaunchCustomQemu(config.Ctx, config.Path, config.qemuParams, config.fds, logger)
 }

--- a/vendor/github.com/01org/ciao/ssntp/README.md
+++ b/vendor/github.com/01org/ciao/ssntp/README.md
@@ -326,17 +326,6 @@ The AttachVolume command payload includes a volume UUID and an instance UUID.
 +-----------------------------------------------------------------------------+
 ```
 
-#### DetachVolume ####
-DetachVolume is a command sent to ciao-launcher for detaching a storage volume
-from a specific running or paused instance.
-
-The DetachVolume command payload includes a volume UUID and an instance UUID.
-
-```
-+-----------------------------------------------------------------------------+
-| Major | Minor | Type  | Operand |  Payload Length | YAML formatted payload  |
-|       |       | (0x0) |  (0xb)  |                 |                         |
-+-----------------------------------------------------------------------------+
 ```
 
 #### Restore ####

--- a/vendor/github.com/01org/ciao/ssntp/ssntp.go
+++ b/vendor/github.com/01org/ciao/ssntp/ssntp.go
@@ -42,7 +42,7 @@ type Type uint8
 
 // Command is the SSNTP Command operand.
 // It can be CONNECT, START, STOP, STATS, EVACUATE, DELETE, RESTART,
-// AssignPublicIP, ReleasePublicIP, CONFIGURE, AttachVolume or DetachVolume.
+// AssignPublicIP, ReleasePublicIP, CONFIGURE or AttachVolume.
 type Command uint8
 
 // Status is the SSNTP Status operand.
@@ -218,18 +218,6 @@ const (
 	//	|       |       | (0x0) |  (0xa)  |                 |                         |
 	//	+-----------------------------------------------------------------------------+
 	AttachVolume
-
-	// DetachVolume is a command sent to ciao-launcher for detaching a storage volume
-	// from a specific running or paused instance.
-	//
-	// The DetachVolume command payload includes a volume UUID and an instance UUID.
-	//
-	//                                       SSNTP DetachVolume Command frame
-	//	+-----------------------------------------------------------------------------+
-	//	| Major | Minor | Type  | Operand |  Payload Length | YAML formatted payload  |
-	//	|       |       | (0x0) |  (0xb)  |                 |                         |
-	//	+-----------------------------------------------------------------------------+
-	DetachVolume
 
 	// Restore is used to ask a specific CIAO agent that had previously been placed into
 	// maintenance mode by an EVACUATE command to start accepting new instances once more.
@@ -539,10 +527,6 @@ const (
 	// a volume to an instance.
 	AttachVolumeFailure
 
-	// DetachVolumeFailure is sent by launcher agents to report a failure to detach
-	// a volume from an instance.
-	DetachVolumeFailure
-
 	// AssignPublicIPFailure is sent by the CNCI when a an external IP
 	// cannot be assigned.
 	AssignPublicIPFailure
@@ -599,8 +583,6 @@ func (command Command) String() string {
 		return "CONFIGURE"
 	case AttachVolume:
 		return "Attach storage volume"
-	case DetachVolume:
-		return "Detach storage volume"
 	case Restore:
 		return "Restore"
 	}

--- a/vendor/github.com/01org/ciao/ssntp/ssntp_test.go
+++ b/vendor/github.com/01org/ciao/ssntp/ssntp_test.go
@@ -2477,7 +2477,6 @@ func TestCommandStringer(t *testing.T) {
 		{ReleasePublicIP, "Release public IP"},
 		{CONFIGURE, "CONFIGURE"},
 		{AttachVolume, "Attach storage volume"},
-		{DetachVolume, "Detach storage volume"},
 	}
 
 	for _, test := range stringTests {


### PR DESCRIPTION
To allow the use of custom bios in virtcontainer we need to
update ciao to the latest commit

short log:
c73deac bios: add support for custom bios
19f008d ciao-deploy: Keep going if any unjoin step fails
9998583 configuration: Remove "compute_fqdn" from configuration
0b88648 ciao-controller: Use certificate common name as canonical name
b760589 storage_bat: Test that detaching from active instance fails
a524e08 singlevm: Do not access $GOPATH directly
1c4a091 singlevm: Move singlevm to use ciao-deploy setup
3d858df ciao-deploy: When an SSH command fails report stdout/stderr
9716e2d testutil: Remove unused code
47defc0 misc: remove remnants of ssntp.DetachVolume/ssntp.DetachVolumeFailure
6e2f8bb Add node failure stats to ciao nodes
5d50323 ciao-controller: update unit test to detach from exited instance
cf94e6b ciao-controller: return instance ID from doAttachVolumeCommand helper
2b51033 ciao-controller: Only support detach from exited instances
28ea819 storage_bat: Only detach volumes from exited instances
ac61fbd ciao-controller: Only update volume to detaching before client send
67be73b ceph_bat: Use system configuration file to determine cephID
7f7ae45 ciao-launcher: Transmit nodeID in failure payloads
e2b025e testutil, payloads: Add NodeUUID to launcher generated errors
3bde736 report Node Hostname information with node list/show
f67444e ciao-deploy: use absolute path for launcher when resetting
5381cf2 ciao-launcher: Clean up internal directory after reset
764e15e ciao-launcher: Retain network settings for hard-reset
86d2daa vendor: Update tfortools to version v0.1.0
0eb45f0 Revert "ciao-launcher: Add --mgmt-net and --compute-net options"
17669e0 Revert "singlevm: Specify mgmt and compute networks during cleanup"
f9d2ebe ciao-launcher: Set DNS server for containers
e725dc9 Update CONTRIBUTING.md
9909268 ciao-controller: do not use a pointer for instance state lock

Signed-off-by: Julio Montes <julio.montes@intel.com>