### PR TITLE
shim: Pass container ID using CLI option

### DIFF
--- a/cc_shim.go
+++ b/cc_shim.go
@@ -59,7 +59,11 @@ func (s *ccShim) start(pod Pod, params ShimParams) (int, error) {
 		return -1, fmt.Errorf("URL cannot be empty")
 	}
 
-	args := []string{config.Path, "-t", params.Token, "-u", params.URL}
+	if params.Container == "" {
+		return -1, fmt.Errorf("Container cannot be empty")
+	}
+
+	args := []string{config.Path, "-c", params.Container, "-t", params.Token, "-u", params.URL}
 	if config.Debug {
 		args = append(args, "-d")
 	}

--- a/cc_shim_test.go
+++ b/cc_shim_test.go
@@ -31,6 +31,9 @@ import (
 	. "github.com/containers/virtcontainers/pkg/mock"
 )
 
+// These tests don't care about the format of the container ID
+const testContainer = "testContainer"
+
 var testShimPath = "/usr/bin/virtcontainers/bin/test/shim"
 var testProxyURL = "foo:///foo/clear-containers/proxy.sock"
 var testWrongConsolePath = "/foo/wrong-console"
@@ -130,6 +133,24 @@ func TestCCShimStartParamsURLEmptyFailure(t *testing.T) {
 	testCCShimStart(t, pod, params, true)
 }
 
+func TestCCShimStartParamsContainerEmptyFailure(t *testing.T) {
+	pod := Pod{
+		config: &PodConfig{
+			ShimType: CCShimType,
+			ShimConfig: CCShimConfig{
+				Path: getMockCCShimBinPath(),
+			},
+		},
+	}
+
+	params := ShimParams{
+		Token: "testToken",
+		URL:   "unix://is/awesome",
+	}
+
+	testCCShimStart(t, pod, params, true)
+}
+
 func TestCCShimStartParamsInvalidCommand(t *testing.T) {
 	dir, err := ioutil.TempDir("", "")
 	if err != nil {
@@ -175,9 +196,10 @@ func startCCShimStartWithoutConsoleSuccessful(t *testing.T, detach bool) (*os.Fi
 	}
 
 	params := ShimParams{
-		Token:  "testToken",
-		URL:    testProxyURL,
-		Detach: detach,
+		Container: testContainer,
+		Token:     "testToken",
+		URL:       testProxyURL,
+		Detach:    detach,
 	}
 
 	return rStdout, wStdout, saveStdout, pod, params, nil
@@ -335,9 +357,10 @@ func TestCCShimStartWithConsoleSuccessful(t *testing.T) {
 	}
 
 	params := ShimParams{
-		Token:   "testToken",
-		URL:     testProxyURL,
-		Console: console,
+		Container: testContainer,
+		Token:     "testToken",
+		URL:       testProxyURL,
+		Console:   console,
 	}
 
 	testCCShimStart(t, pod, params, false)

--- a/container.go
+++ b/container.go
@@ -702,10 +702,11 @@ func (c *Container) createShimProcess(token, url string, cmd Cmd) (*Process, err
 	}
 
 	shimParams := ShimParams{
-		Token:   token,
-		URL:     url,
-		Console: cmd.Console,
-		Detach:  cmd.Detach,
+		Container: c.id,
+		Token:     token,
+		URL:       url,
+		Console:   cmd.Console,
+		Detach:    cmd.Detach,
 	}
 
 	pid, err := c.pod.shim.start(*(c.pod), shimParams)

--- a/pod.go
+++ b/pod.go
@@ -759,10 +759,11 @@ func (p *Pod) startShims() error {
 
 	for idx := range p.containers {
 		shimParams := ShimParams{
-			Token:   proxyInfos[idx].Token,
-			URL:     url,
-			Console: p.containers[idx].config.Cmd.Console,
-			Detach:  p.containers[idx].config.Cmd.Detach,
+			Container: p.containers[idx].id,
+			Token:     proxyInfos[idx].Token,
+			URL:       url,
+			Console:   p.containers[idx].config.Cmd.Console,
+			Detach:    p.containers[idx].config.Cmd.Detach,
 		}
 
 		pid, err := p.shim.start(*p, shimParams)

--- a/shim.go
+++ b/shim.go
@@ -41,10 +41,11 @@ var waitForShimTimeout = 5.0
 // ShimParams is the structure providing specific parameters needed
 // for the execution of the shim binary.
 type ShimParams struct {
-	Token   string
-	URL     string
-	Console string
-	Detach  bool
+	Container string
+	Token     string
+	URL       string
+	Console   string
+	Detach    bool
 }
 
 // Set sets a shim type based on the input string.

--- a/shim/mock/shim.go
+++ b/shim/mock/shim.go
@@ -48,11 +48,13 @@ func main() {
 
 	tokenFlag := flag.String("t", "", "Proxy token")
 	urlFlag := flag.String("u", "", "Proxy URL")
+	containerFlag := flag.String("c", "", "Container ID")
 
 	flag.Parse()
 
 	fmt.Fprintf(f, "INFO: Token = %s\n", *tokenFlag)
 	fmt.Fprintf(f, "INFO: URL = %s\n", *urlFlag)
+	fmt.Fprintf(f, "INFO: Container = %s\n", *containerFlag)
 
 	if *tokenFlag == "" {
 		fmt.Fprintf(f, "ERROR: Token should not be empty\n")
@@ -66,6 +68,11 @@ func main() {
 
 	if _, err := url.Parse(*urlFlag); err != nil {
 		fmt.Fprintf(f, "ERROR: Could not parse the URL %q: %s\n", *urlFlag, err)
+		os.Exit(1)
+	}
+
+	if *containerFlag == "" {
+		fmt.Fprintf(f, "ERROR: Container should not be empty\n")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Pass the container ID to `cc-shim`, using its existing `-c` option,
to allow it to produce more useful log messages.

Fixes #414.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>