### PR TITLE
ci: Fix call to virtcontainers-setup.sh

### DIFF
--- a/.ci/ci-setup.sh
+++ b/.ci/ci-setup.sh
@@ -61,7 +61,7 @@ echo -e "Create symbolic link ${cc_img_path}/${cc_img_link_name}"
 chronic sudo ln -fs ${cc_img_path}/${containers_img} ${cc_img_path}/${cc_img_link_name}
 
 echo "Setup virtcontainers environment"
-chronic sudo -E bash utils/virtcontainers-setup.sh
+chronic sudo -E PATH=$PATH bash utils/virtcontainers-setup.sh
 
 echo "Install virtcontainers"
 chronic make


### PR DESCRIPTION
Specify to sudo the PATH to use to execute the
virtcontainers-setup.sh script. If we do not specify the PATH,
the system will not find `go`

Fixes: #407

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>