### PR TITLE
Block device support for --device

### DIFF
--- a/container.go
+++ b/container.go
@@ -857,7 +857,7 @@ func (c *Container) removeDrive() (err error) {
 
 func (c *Container) attachDevices() error {
 	for _, device := range c.devices {
-		if err := device.attach(c.pod.hypervisor); err != nil {
+		if err := device.attach(c.pod.hypervisor, c); err != nil {
 			return err
 		}
 	}

--- a/device.go
+++ b/device.go
@@ -286,11 +286,9 @@ func isVFIO(hostPath string) bool {
 }
 
 // isBlock checks if the device is a block device.
-func isBlock(hostPath string) bool {
-	for _, blockPath := range blockPaths {
-		if strings.HasPrefix(hostPath, blockPath) && len(hostPath) > len(blockPath) {
-			return true
-		}
+func isBlock(devInfo DeviceInfo) bool {
+	if devInfo.DevType == "b" {
+		return true
 	}
 
 	return false
@@ -301,7 +299,7 @@ func createDevice(devInfo DeviceInfo) Device {
 
 	if isVFIO(path) {
 		return newVFIODevice(devInfo)
-	} else if isBlock(path) {
+	} else if isBlock(devInfo) {
 		return newBlockDevice(devInfo)
 	} else {
 		deviceLogger().WithField("device", path).Info("Device has not been passed to the container")

--- a/device.go
+++ b/device.go
@@ -58,7 +58,7 @@ const (
 
 // Device is the virtcontainers device interface.
 type Device interface {
-	attach(hypervisor) error
+	attach(hypervisor, *Container) error
 	detach(hypervisor) error
 	deviceType() string
 }
@@ -90,6 +90,10 @@ type DeviceInfo struct {
 
 	// id of the device group.
 	GID uint32
+
+	// Hotplugged is used to store device state indicating if the
+	// device was hotplugged.
+	Hotplugged bool
 }
 
 // VFIODevice is a vfio device meant to be passed to the hypervisor
@@ -111,7 +115,7 @@ func newVFIODevice(devInfo DeviceInfo) *VFIODevice {
 	}
 }
 
-func (device *VFIODevice) attach(h hypervisor) error {
+func (device *VFIODevice) attach(h hypervisor, c *Container) error {
 	vfioGroup := filepath.Base(device.DeviceInfo.HostPath)
 	iommuDevicesPath := filepath.Join(sysIOMMUPath, vfioGroup, "devices")
 
@@ -166,7 +170,7 @@ func newBlockDevice(devInfo DeviceInfo) *BlockDevice {
 	}
 }
 
-func (device *BlockDevice) attach(h hypervisor) error {
+func (device *BlockDevice) attach(h hypervisor, c *Container) error {
 	return nil
 }
 
@@ -191,7 +195,7 @@ func newGenericDevice(devInfo DeviceInfo) *GenericDevice {
 	}
 }
 
-func (device *GenericDevice) attach(h hypervisor) error {
+func (device *GenericDevice) attach(h hypervisor, c *Container) error {
 	return nil
 }
 

--- a/device_test.go
+++ b/device_test.go
@@ -53,25 +53,18 @@ func TestIsVFIO(t *testing.T) {
 
 func TestIsBlock(t *testing.T) {
 	type testData struct {
-		path     string
+		devType  string
 		expected bool
 	}
 
 	data := []testData{
-		{"/dev/sda", true},
-		{"/dev/sdbb", true},
-		{"/dev/hda", true},
-		{"/dev/hdb", true},
-		{"/dev/vf", false},
-		{"/dev/vdj", true},
-		{"/dev/vdzzz", true},
-		{"/dev/ida", false},
-		{"/dev/ida/", false},
-		{"/dev/ida/c0d0p10", true},
+		{"b", true},
+		{"c", false},
+		{"u", false},
 	}
 
 	for _, d := range data {
-		isBlock := isBlock(d.path)
+		isBlock := isBlock(DeviceInfo{DevType: d.devType})
 		assert.Equal(t, d.expected, isBlock)
 	}
 }
@@ -79,6 +72,7 @@ func TestIsBlock(t *testing.T) {
 func TestCreateDevice(t *testing.T) {
 	devInfo := DeviceInfo{
 		HostPath: "/dev/vfio/8",
+		DevType:  "b",
 	}
 
 	device := createDevice(devInfo)
@@ -91,6 +85,7 @@ func TestCreateDevice(t *testing.T) {
 	assert.True(t, ok)
 
 	devInfo.HostPath = "/dev/tty"
+	devInfo.DevType = "c"
 	device = createDevice(devInfo)
 	_, ok = device.(*GenericDevice)
 	assert.True(t, ok)
@@ -254,7 +249,7 @@ func TestAttachBlockDevice(t *testing.T) {
 	deviceInfo := DeviceInfo{
 		HostPath:      path,
 		ContainerPath: path,
-		DevType:       "c",
+		DevType:       "b",
 	}
 
 	device := createDevice(deviceInfo)

--- a/device_test.go
+++ b/device_test.go
@@ -222,7 +222,7 @@ func TestAttachVFIODevice(t *testing.T) {
 	assert.True(t, ok)
 
 	hypervisor := &mockHypervisor{}
-	err = device.attach(hypervisor)
+	err = device.attach(hypervisor, &Container{})
 	assert.Nil(t, err)
 
 	err = device.detach(hypervisor)
@@ -242,7 +242,7 @@ func TestAttachGenericDevice(t *testing.T) {
 	assert.True(t, ok)
 
 	hypervisor := &mockHypervisor{}
-	err := device.attach(hypervisor)
+	err := device.attach(hypervisor, &Container{})
 	assert.Nil(t, err)
 
 	err = device.detach(hypervisor)
@@ -262,7 +262,7 @@ func TestAttachBlockDevice(t *testing.T) {
 	assert.True(t, ok)
 
 	hypervisor := &mockHypervisor{}
-	err := device.attach(hypervisor)
+	err := device.attach(hypervisor, &Container{})
 	assert.Nil(t, err)
 
 	err = device.detach(hypervisor)

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -556,6 +556,21 @@ func (h *hyper) startOneContainer(pod Pod, c Container) error {
 		return err
 	}
 
+	// Append container mounts for block devices passed with --device.
+	for _, device := range c.devices {
+		d, ok := device.(*BlockDevice)
+
+		if ok {
+			fsmapDesc := &hyperstart.FsmapDescriptor{
+				Source:       d.VirtPath,
+				Path:         d.DeviceInfo.ContainerPath,
+				AbsolutePath: true,
+				DockerVolume: false,
+			}
+			fsmap = append(fsmap, fsmapDesc)
+		}
+	}
+
 	// Assign fsmap for hyperstart to mount these at the correct location within the container
 	container.Fsmap = fsmap
 

--- a/pkg/hyperstart/types.go
+++ b/pkg/hyperstart/types.go
@@ -132,6 +132,7 @@ type FsmapDescriptor struct {
 	Path         string `json:"path"`
 	ReadOnly     bool   `json:"readOnly"`
 	DockerVolume bool   `json:"dockerVolume"`
+	AbsolutePath bool   `json:"absolutePath"`
 }
 
 // EnvironmentVar holds an environment variable and its value.

--- a/pod.go
+++ b/pod.go
@@ -1016,6 +1016,20 @@ func (p *Pod) getAndSetPodBlockIndex() (int, error) {
 	return currentIndex, nil
 }
 
+// decrementPodBlockIndex decrements the current pod block index.
+// This is used to recover from failure while adding a block device.
+func (p *Pod) decrementPodBlockIndex() error {
+	p.state.BlockIndex--
+
+	// update on-disk state
+	err := p.storage.storePodResource(p.id, stateFileType, p.state)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (p *Pod) getContainer(containerID string) (*Container, error) {
 	if containerID == "" {
 		return &Container{}, errNeedContainerID


### PR DESCRIPTION
Add support for passing block devices to a container with --device. This PR passes block devices to the VM using virtio-block.