### PR TITLE
logging: Log less by default

### DIFF
--- a/hyperstart.go
+++ b/hyperstart.go
@@ -84,8 +84,6 @@ func (c *HyperConfig) validate(pod Pod) bool {
 		c.PauseBinPath = filepath.Join(defaultPauseBinDir, pauseBinName)
 	}
 
-	virtLog.Debugf("Hyperstart config %v", c)
-
 	return true
 }
 
@@ -339,7 +337,7 @@ func (h *hyper) init(pod *Pod, config interface{}) (err error) {
 	switch c := config.(type) {
 	case HyperConfig:
 		if c.validate(*pod) == false {
-			return fmt.Errorf("Invalid configuration")
+			return fmt.Errorf("Invalid hyperstart configuration: %v", c)
 		}
 		h.config = c
 	default:

--- a/pod.go
+++ b/pod.go
@@ -631,7 +631,7 @@ func (p *Pod) storePod() error {
 }
 
 // fetchPod fetches a pod config from a pod ID and returns a pod.
-func fetchPod(podID string) (*Pod, error) {
+func fetchPod(podID string) (pod *Pod, err error) {
 	if podID == "" {
 		return nil, errNeedPodID
 	}
@@ -642,9 +642,12 @@ func fetchPod(podID string) (*Pod, error) {
 		return nil, err
 	}
 
-	virtLog.Debugf("Pod config: %+v", config)
+	pod, err = createPod(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pod with config %+v: %v", config, err)
+	}
 
-	return createPod(config)
+	return pod, nil
 }
 
 // delete deletes an already created pod.


### PR DESCRIPTION
Don't log huge objects unless a problem occurs to quieten down the
amount of log output generated by default.

Fixes #424.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>