### PR TITLE
ci: Fix go-vet errors

### DIFF
--- a/.ci/ci-jobs.sh
+++ b/.ci/ci-jobs.sh
@@ -22,8 +22,8 @@ export CI=true
 
 make check
 
-sudo -E go test -bench=.
+sudo -E PATH=$PATH go test -bench=.
 
-sudo -E go test -bench=CreateStartStopDeletePodQemuHypervisorNoopAgentNetworkCNI -benchtime=60s
+sudo -E PATH=$PATH go test -bench=CreateStartStopDeletePodQemuHypervisorNoopAgentNetworkCNI -benchtime=60s
 
-sudo -E go test -bench=CreateStartStopDeletePodQemuHypervisorHyperstartAgentNetworkCNI -benchtime=60s
+sudo -E PATH=$PATH go test -bench=CreateStartStopDeletePodQemuHypervisorHyperstartAgentNetworkCNI -benchtime=60s

--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -165,10 +165,22 @@ var podConfigFlags = []cli.Flag{
 }
 
 var ccKernelParams = []vc.Param{
-	{"init", "/usr/lib/systemd/systemd"},
-	{"systemd.unit", "cc-agent.target"},
-	{"systemd.mask", "systemd-networkd.service"},
-	{"systemd.mask", "systemd-networkd.socket"},
+	{
+		Key:   "init",
+		Value: "/usr/lib/systemd/systemd",
+	},
+	{
+		Key:   "systemd.unit",
+		Value: "cc-agent.target",
+	},
+	{
+		Key:   "systemd.mask",
+		Value: "systemd-networkd.service",
+	},
+	{
+		Key:   "systemd.mask",
+		Value: "systemd-networkd.socket",
+	},
 }
 
 func buildKernelParams(config *vc.HypervisorConfig) error {

--- a/pkg/oci/utils_test.go
+++ b/pkg/oci/utils_test.go
@@ -636,7 +636,10 @@ func TestAddKernelParamValid(t *testing.T) {
 	var config RuntimeConfig
 
 	expected := []vc.Param{
-		{"foo", "bar"},
+		{
+			Key:   "foo",
+			Value: "bar",
+		},
 	}
 
 	err := config.AddKernelParam(expected[0])
@@ -649,7 +652,10 @@ func TestAddKernelParamInvalid(t *testing.T) {
 	var config RuntimeConfig
 
 	invalid := []vc.Param{
-		{"", "bar"},
+		{
+			Key:   "",
+			Value: "bar",
+		},
 	}
 
 	err := config.AddKernelParam(invalid[0])

--- a/pkg/vcMock/pod.go
+++ b/pkg/vcMock/pod.go
@@ -45,7 +45,7 @@ func (p *Pod) URL() string {
 
 // GetAllContainers implements the VCPod function of the same name.
 func (p *Pod) GetAllContainers() []vc.VCContainer {
-	var ifa []vc.VCContainer = make([]vc.VCContainer, len(p.MockContainers))
+	var ifa = make([]vc.VCContainer, len(p.MockContainers))
 
 	for i, v := range p.MockContainers {
 		ifa[i] = v


### PR DESCRIPTION
Azure CI is failing due to go-vet errors of "composite literal uses
unkeyed fields". Use keyed fields in structs to fix the issue.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>