### PR TITLE
Ignore sysfs missing uevent file error, ignore "/dev/vfio/vfio"

### DIFF
--- a/device.go
+++ b/device.go
@@ -205,6 +205,11 @@ func (device *GenericDevice) deviceType() string {
 
 // isVFIO checks if the device provided is a vfio group.
 func isVFIO(hostPath string) bool {
+	// Ignore /dev/vfio/vfio character device
+	if strings.HasPrefix(hostPath, filepath.Join(vfioPath, "vfio")) {
+		return false
+	}
+
 	if strings.HasPrefix(hostPath, vfioPath) && len(hostPath) > len(vfioPath) {
 		return true
 	}

--- a/device.go
+++ b/device.go
@@ -236,6 +236,7 @@ func createDevice(devInfo DeviceInfo) Device {
 	} else if isBlock(path) {
 		return newBlockDevice(devInfo)
 	} else {
+		deviceLogger().WithField("device", path).Info("Device has not been passed to the container")
 		return newGenericDevice(devInfo)
 	}
 }

--- a/device_test.go
+++ b/device_test.go
@@ -39,6 +39,8 @@ func TestIsVFIO(t *testing.T) {
 		{"/dev/vfio", false},
 		{"/dev/vf", false},
 		{"/dev", false},
+		{"/dev/vfio/vfio", false},
+		{"/dev/vfio/vfio/12", false},
 	}
 
 	for _, d := range data {


### PR DESCRIPTION
Ability to obtain device names from major-minor number of device
was added in kernel 2.6.27 version:
torvalds/linux@e105b8b

But for certain devices like /dev/cuse, /dev/fuse, this sysfs
interface may not exist. This may also depend on the kernel
version used.

We are primarily using this sysfs interface to obtain device name in
case the renamed device name was passed to the runtime.

To accomodate these devices, which are passed by docker by default
for priveleged/non-priveleged containers, we ignore the missing file
error for /sys/dev files and assume device name passed in the oci spec
file for such devices is not the renamed device name.
