### PR TITLE
lock: Improve locking strategy

### DIFF
--- a/api.go
+++ b/api.go
@@ -103,7 +103,7 @@ func DeletePod(podID string) (VCPod, error) {
 		return nil, errNeedPodID
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rwLockPod(podID)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func StartPod(podID string) (VCPod, error) {
 		return nil, errNeedPodID
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rwLockPod(podID)
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +195,7 @@ func StopPod(podID string) (VCPod, error) {
 		return nil, errNeedPod
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rwLockPod(podID)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func RunPod(podConfig PodConfig) (VCPod, error) {
 		return nil, err
 	}
 
-	lockFile, err := lockPod(p.id)
+	lockFile, err := rwLockPod(p.id)
 	if err != nil {
 		return nil, err
 	}
@@ -331,7 +331,7 @@ func StatusPod(podID string) (PodStatus, error) {
 		return PodStatus{}, errNeedPodID
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rwLockPod(podID)
 	if err != nil {
 		return PodStatus{}, err
 	}
@@ -372,7 +372,7 @@ func CreateContainer(podID string, containerConfig ContainerConfig) (VCPod, VCCo
 		return nil, nil, errNeedPodID
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rwLockPod(podID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -417,7 +417,7 @@ func DeleteContainer(podID, containerID string) (VCContainer, error) {
 		return nil, errNeedContainerID
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rwLockPod(podID)
 	if err != nil {
 		return nil, err
 	}
@@ -466,7 +466,7 @@ func StartContainer(podID, containerID string) (VCContainer, error) {
 		return nil, errNeedContainerID
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rwLockPod(podID)
 	if err != nil {
 		return nil, err
 	}
@@ -504,7 +504,7 @@ func StopContainer(podID, containerID string) (VCContainer, error) {
 		return nil, errNeedContainerID
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rwLockPod(podID)
 	if err != nil {
 		return nil, err
 	}
@@ -542,7 +542,7 @@ func EnterContainer(podID, containerID string, cmd Cmd) (VCPod, VCContainer, *Pr
 		return nil, nil, nil, errNeedContainerID
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rwLockPod(podID)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -579,7 +579,7 @@ func StatusContainer(podID, containerID string) (ContainerStatus, error) {
 		return ContainerStatus{}, errNeedContainerID
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rwLockPod(podID)
 	if err != nil {
 		return ContainerStatus{}, err
 	}
@@ -641,7 +641,7 @@ func KillContainer(podID, containerID string, signal syscall.Signal, all bool) e
 		return errNeedContainerID
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rwLockPod(podID)
 	if err != nil {
 		return err
 	}
@@ -690,7 +690,7 @@ func ProcessListContainer(podID, containerID string, options ProcessListOptions)
 		return nil, errNeedContainerID
 	}
 
-	lockFile, err := lockPod(podID)
+	lockFile, err := rwLockPod(podID)
 	if err != nil {
 		return nil, err
 	}

--- a/api_test.go
+++ b/api_test.go
@@ -664,7 +664,7 @@ func TestStatusPodSuccessfulStateRunning(t *testing.T) {
 			{
 				ID: containerID,
 				State: State{
-					State: StateStopped,
+					State: StateRunning,
 					URL:   "",
 				},
 				PID:         1000,
@@ -1462,6 +1462,8 @@ func TestStatusContainerStateReady(t *testing.T) {
 		Annotations: containerAnnotations,
 	}
 
+	defer p2.wg.Wait()
+
 	status, err := statusContainer(p2, contID)
 	if err != nil {
 		t.Fatal(err)
@@ -1526,13 +1528,15 @@ func TestStatusContainerStateRunning(t *testing.T) {
 	expectedStatus := ContainerStatus{
 		ID: contID,
 		State: State{
-			State: StateStopped,
+			State: StateRunning,
 			URL:   "",
 		},
 		PID:         1000,
 		RootFs:      filepath.Join(testDir, testBundle),
 		Annotations: containerAnnotations,
 	}
+
+	defer p2.wg.Wait()
 
 	status, err := statusContainer(p2, contID)
 	if err != nil {

--- a/pod.go
+++ b/pod.go
@@ -431,6 +431,8 @@ type Pod struct {
 	lockFile *os.File
 
 	annotationsLock *sync.RWMutex
+
+	wg *sync.WaitGroup
 }
 
 // ID returns the pod identifier string.
@@ -600,6 +602,7 @@ func doFetchPod(podConfig PodConfig) (*Pod, error) {
 		configPath:      filepath.Join(configStoragePath, podConfig.ID),
 		state:           State{},
 		annotationsLock: &sync.RWMutex{},
+		wg:              &sync.WaitGroup{},
 	}
 
 	containers, err := newContainers(p, podConfig.Containers)


### PR DESCRIPTION
This PR introduces shared locks so that it can improve the locking strategy. Basically, it takes a shared lock when a function only needs to read from the system, and it takes an exclusive lock when a function needs to modify what's written on the system.

Fixes #421 