### PR TITLE
pod: Hotplug all pod container rootfs with devicemapper

### DIFF
--- a/api.go
+++ b/api.go
@@ -82,6 +82,12 @@ func CreatePod(podConfig PodConfig) (VCPod, error) {
 		return nil, err
 	}
 
+	// Hotplug all pod containers rootfs if the hypervisor supports it
+	err = p.hotplugDrives()
+	if err != nil {
+		return nil, err
+	}
+
 	// Start shims
 	if err := p.startShims(); err != nil {
 		return nil, err

--- a/container_test.go
+++ b/container_test.go
@@ -213,22 +213,12 @@ func TestContainerAddDriveDir(t *testing.T) {
 		checkStorageDriver = savedFunc
 	}()
 
-	err = container.addDrive(true)
-	if err != nil {
-		t.Fatalf("Error with addDrive :%v", err)
-	}
-
-	if container.state.Fstype == "" || container.state.HotpluggedDrive {
-		t.Fatal()
-	}
-
 	container.state.Fstype = ""
 	container.state.HotpluggedDrive = false
 
-	// hotplugged case, when create is passed as false
-	err = container.addDrive(false)
+	err = container.hotplugDrive()
 	if err != nil {
-		t.Fatalf("Error with addDrive :%v", err)
+		t.Fatalf("Error with hotplugDrive :%v", err)
 	}
 
 	if container.state.Fstype == "" || !container.state.HotpluggedDrive {

--- a/pod.go
+++ b/pod.go
@@ -1192,7 +1192,7 @@ func (p *Pod) hotplugDrives() error {
 	}
 
 	for _, c := range p.containers {
-		if err := c.addDrive(false); err != nil {
+		if err := c.hotplugDrive(); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
When mixing cold and hot plugged devicemapper drives, orchestration
engines can get confused and removing pods can fail as the assumption
that a stopped pod pause container rootfs can be unmounted fails with
virtual machines.
    
Fixes #435
