### PR TITLE
1.0.4 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+1.0.4:
+	Added shim debug output
+	Added support for custom qemu accelerators
+	Added structured logging
+	Added drive hotplug support for all containers
+	Fixed pod block index accounting
+	Fixed vendoring model
+
 1.0.3:
 	Added initial device assignment framework
 	Added VFIO devices assignment initial support


### PR DESCRIPTION
Added shim debug output
Added support for custom qemu accelerators
Added structured logging
Added drive hotplug support for all containers
Fixed pod block index accounting
Fixed vendoring model

Shortlog

c490764 container: Rename addDrive to hotplugDrive
e848de5 pod: Hotplug all pod container rootfs with devicemapper
d7e3297 pod: Do not overwrite pod state
8b229ca tests: Add tests to check the changes made to ignore uevent error
6eb81de log: Log devices that are not passed to the container.
8a998f8 devices: Add corner case check for /dev/vfio/vfio
f7d0732 devices: Ignore error from missing sysfs path under /sys/dev
3ae5af6 .ci: Pass go env variables to sudo.
8098674 ci: Fix go-vet errors
ccd0c75 logging: Use structured logging
7867430 logging: Log less by default
c03bca6 Vendoring: Use revision locked vendoring model
971215d ci: Fix call to virtcontainers-setup.sh
1b5888f shim: Pass container ID using CLI option
7148059 docs: Describe how vfio devices can be passed
c286dbb device: Call addDevice after dereferencing pointer receiver.
caefa12 devices: Refactor device handling
95f3ae9 filesystem: Split function to reduce cyclomatic complexity
4640741 filesystem: Custom marshal and unmarshal device interface objects
e0fef66 qemu: add default machine accelerators
cdc77cc qemu: remove newer machine accelerators
c1291fb qemu: support for custom machine accelerators
93014e4 qemu: support custom bios
e1fa974 vendor: update ciao
df5e866 shim: Add ability to enable debug output

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>