### PR TITLE
WIP: Add support for macvlan and ipvlan networking modes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -76,7 +76,7 @@
 [[projects]]
   name = "github.com/vishvananda/netlink"
   packages = [".","nl"]
-  revision = "177f1ceba557262b3f1c3aba4df93a29199fb4eb"
+  revision = "b7fbf1f5291ecf8ae5179d3202e914cb98cfe400"
 
 [[projects]]
   name = "github.com/vishvananda/netns"
@@ -96,6 +96,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "52bc4229f63ca78c2086df724034421cf56f51e281edb843f319fb0644af36d3"
+  inputs-digest = "82781172d7b56c5605cb416f72f21b8cd71ae5f49ef87cfe940e8f7b3d0f3c21"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -114,7 +114,7 @@
 
 [[constraint]]
   name = "github.com/vishvananda/netlink"
-  revision = "177f1ceba557262b3f1c3aba4df93a29199fb4eb"
+  revision = "b7fbf1f5291ecf8ae5179d3202e914cb98cfe400"
 
 [[constraint]]
   name = "github.com/vishvananda/netns"

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -172,7 +172,7 @@ func (h *hyper) buildNetworkInterfacesAndRoutes(pod Pod) ([]hyperstart.NetworkIf
 		return []hyperstart.NetworkIface{}, []hyperstart.Route{}, nil
 	}
 
-	netIfaces, err := getIfacesFromNetNs(networkNS.NetNsPath)
+	netIfaces, err := getIfacesFromNetNsAll(networkNS.NetNsPath)
 	if err != nil {
 		return []hyperstart.NetworkIface{}, []hyperstart.Route{}, err
 	}

--- a/network.go
+++ b/network.go
@@ -268,28 +268,32 @@ func getLinkByName(netHandle *netlink.Handle, name string, expectedLink netlink.
 		return nil, fmt.Errorf("LinkByName() failed for %s name %s: %s", expectedLink.Type(), name, err)
 	}
 
-	switch expectedLink.Type() {
-	case (&netlink.Bridge{}).Type():
-		if l, ok := link.(*netlink.Bridge); ok {
-			return l, nil
-		}
-	case (&netlink.Tuntap{}).Type():
-		if l, ok := link.(*netlink.GenericLink); ok {
-			return l, nil
-		}
-	case (&netlink.Veth{}).Type():
-		if l, ok := link.(*netlink.Veth); ok {
-			return l, nil
-		}
-	case (&netlink.Macvtap{}).Type():
-		if l, ok := link.(*netlink.Macvtap); ok {
-			return l, nil
-		}
-	default:
-		return nil, fmt.Errorf("Unsupported link type %s", expectedLink.Type())
-	}
+	return link, nil
 
-	return nil, fmt.Errorf("Incorrect link type %s, expecting %s", link.Type(), expectedLink.Type())
+	/*
+		switch expectedLink.Type() {
+		case (&netlink.Bridge{}).Type():
+			if l, ok := link.(*netlink.Bridge); ok {
+				return l, nil
+			}
+		case (&netlink.Tuntap{}).Type():
+			if l, ok := link.(*netlink.GenericLink); ok {
+				return l, nil
+			}
+		case (&netlink.Veth{}).Type():
+			if l, ok := link.(*netlink.Veth); ok {
+				return l, nil
+			}
+		case (&netlink.Macvtap{}).Type():
+			if l, ok := link.(*netlink.Macvtap); ok {
+				return l, nil
+			}
+		default:
+			return nil, fmt.Errorf("Unsupported link type %s", expectedLink.Type())
+		}
+
+		return nil, fmt.Errorf("Incorrect link type %s, expecting %s", link.Type(), expectedLink.Type())
+	*/
 }
 
 func xconnectVMNetwork(netPair *NetworkInterfacePair, connect bool) error {
@@ -428,10 +432,14 @@ func tapNetworkPair(netPair *NetworkInterfacePair) error {
 		return fmt.Errorf("Could not set TAP MTU %d: %s", vethLinkAttrs.MTU, err)
 	}
 
-	hardAddr, err := net.ParseMAC(netPair.VirtIface.HardAddr)
+	//hardAddr, err := net.ParseMAC(netPair.VirtIface.HardAddr)
+	hardAddr, err := net.ParseMAC(netPair.TAPIface.HardAddr)
 	if err != nil {
 		return err
 	}
+	hardAddr[0] = 0x02
+	hardAddr[1] = 0x00
+
 	if err := netHandle.LinkSetHardwareAddr(vethLink, hardAddr); err != nil {
 		return fmt.Errorf("Could not set MAC address %s for veth interface %s: %s",
 			netPair.VirtIface.HardAddr, netPair.VirtIface.Name, err)

--- a/qemu.go
+++ b/qemu.go
@@ -310,11 +310,28 @@ func (q *qemu) appendSocket(devices []ciaoQemu.Device, socket Socket) []ciaoQemu
 	return devices
 }
 
+func networkModelToQemuType(model NetInterworkingModel) ciaoQemu.NetDeviceType {
+	switch model {
+	case ModelBridged:
+		return ciaoQemu.TAP
+	case ModelMacVtap:
+		return ciaoQemu.MACVTAP
+	//case ModelEnlightened:
+	// Here the Network plugin will create a VM native interface
+	// which could be MacVtap, IpVtap, SRIOV, veth-tap, vhost-user
+	// In these cases we will determine the interface type here
+	// and pass in the native interface through
+	default:
+		//TAP should work for most other cases
+		return ciaoQemu.TAP
+	}
+}
+
 func (q *qemu) appendNetworks(devices []ciaoQemu.Device, endpoints []Endpoint) []ciaoQemu.Device {
 	for idx, endpoint := range endpoints {
 		devices = append(devices,
 			ciaoQemu.NetDevice{
-				Type:          ciaoQemu.TAP,
+				Type:          networkModelToQemuType(endpoint.NetPair.NetInterworkingModel),
 				Driver:        ciaoQemu.VirtioNetPCI,
 				ID:            fmt.Sprintf("network-%d", idx),
 				IFName:        endpoint.NetPair.TAPIface.Name,
@@ -323,6 +340,7 @@ func (q *qemu) appendNetworks(devices []ciaoQemu.Device, endpoints []Endpoint) [
 				Script:        "no",
 				VHost:         true,
 				DisableModern: q.nestedRun,
+				FDs:           endpoint.NetPair.VMFds,
 			},
 		)
 	}

--- a/utils.go
+++ b/utils.go
@@ -19,6 +19,7 @@ package virtcontainers
 import (
 	"crypto/rand"
 	"fmt"
+	"os"
 	"os/exec"
 )
 
@@ -63,4 +64,17 @@ func reverseString(s string) string {
 	}
 
 	return string(r)
+}
+
+func cleanupFds(fds []*os.File, numFds int) {
+
+	maxFds := len(fds)
+
+	if numFds < maxFds {
+		maxFds = numFds
+	}
+
+	for i := 0; i < maxFds; i++ {
+		_ = fds[i].Close()
+	}
 }

--- a/vendor/github.com/vishvananda/netlink/handle_test.go
+++ b/vendor/github.com/vishvananda/netlink/handle_test.go
@@ -132,6 +132,31 @@ func TestHandleTimeout(t *testing.T) {
 	}
 }
 
+func TestHandleReceiveBuffer(t *testing.T) {
+	h, err := NewHandle()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer h.Delete()
+	if err := h.SetSocketReceiveBufferSize(65536, false); err != nil {
+		t.Fatal(err)
+	}
+	sizes, err := h.GetSocketReceiveBufferSize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sizes) != len(h.sockets) {
+		t.Fatalf("Unexpected number of socket buffer sizes: %d (expected %d)",
+			len(sizes), len(h.sockets))
+	}
+	for _, s := range sizes {
+		if s < 65536 || s > 2*65536 {
+			t.Fatalf("Unexpected socket receive buffer size: %d (expected around %d)",
+				s, 65536)
+		}
+	}
+}
+
 func verifySockTimeVal(t *testing.T, fd int, tv syscall.Timeval) {
 	var (
 		tr syscall.Timeval

--- a/vendor/github.com/vishvananda/netlink/link.go
+++ b/vendor/github.com/vishvananda/netlink/link.go
@@ -37,6 +37,7 @@ type LinkAttrs struct {
 	EncapType    string
 	Protinfo     *Protinfo
 	OperState    LinkOperState
+	NetNsID      int
 }
 
 // LinkOperState represents the values of the IFLA_OPERSTATE link

--- a/vendor/github.com/vishvananda/netlink/link_linux.go
+++ b/vendor/github.com/vishvananda/netlink/link_linux.go
@@ -851,6 +851,10 @@ func (h *Handle) linkModify(link Link, flags int) error {
 		msg.Change |= syscall.IFF_MULTICAST
 		msg.Flags |= syscall.IFF_MULTICAST
 	}
+	if base.Index != 0 {
+		msg.Index = int32(base.Index)
+	}
+
 	req.AddData(msg)
 
 	if base.ParentIndex != 0 {
@@ -1268,6 +1272,8 @@ func LinkDeserialize(hdr *syscall.NlMsghdr, m []byte) (Link, error) {
 			}
 		case syscall.IFLA_OPERSTATE:
 			base.OperState = LinkOperState(uint8(attr.Value[0]))
+		case nl.IFLA_LINK_NETNSID:
+			base.NetNsID = int(native.Uint32(attr.Value[0:4]))
 		}
 	}
 

--- a/vendor/github.com/vishvananda/netlink/link_test.go
+++ b/vendor/github.com/vishvananda/netlink/link_test.go
@@ -38,6 +38,12 @@ func testLinkAddDel(t *testing.T, link Link) {
 
 	rBase := result.Attrs()
 
+	if base.Index != 0 {
+		if base.Index != rBase.Index {
+			t.Fatalf("index is %d, should be %d", rBase.Index, base.Index)
+		}
+	}
+
 	if vlan, ok := link.(*Vlan); ok {
 		other, ok := result.(*Vlan)
 		if !ok {
@@ -258,6 +264,13 @@ func compareVxlan(t *testing.T, expected, actual *Vxlan) {
 			t.Fatal("Vxlan.PortHigh doesn't match")
 		}
 	}
+}
+
+func TestLinkAddDelWithIndex(t *testing.T) {
+	tearDown := setUpNetlinkTest(t)
+	defer tearDown()
+
+	testLinkAddDel(t, &Dummy{LinkAttrs{Index: 1000, Name: "foo"}})
 }
 
 func TestLinkAddDelDummy(t *testing.T) {

--- a/vendor/github.com/vishvananda/netlink/nl/nl_linux.go
+++ b/vendor/github.com/vishvananda/netlink/nl/nl_linux.go
@@ -621,6 +621,20 @@ func (s *NetlinkSocket) Receive() ([]syscall.NetlinkMessage, error) {
 	return syscall.ParseNetlinkMessage(rb)
 }
 
+// SetSendTimeout allows to set a send timeout on the socket
+func (s *NetlinkSocket) SetSendTimeout(timeout *syscall.Timeval) error {
+	// Set a send timeout of SOCKET_SEND_TIMEOUT, this will allow the Send to periodically unblock and avoid that a routine
+	// remains stuck on a send on a closed fd
+	return syscall.SetsockoptTimeval(int(s.fd), syscall.SOL_SOCKET, syscall.SO_SNDTIMEO, timeout)
+}
+
+// SetReceiveTimeout allows to set a receive timeout on the socket
+func (s *NetlinkSocket) SetReceiveTimeout(timeout *syscall.Timeval) error {
+	// Set a read timeout of SOCKET_READ_TIMEOUT, this will allow the Read to periodically unblock and avoid that a routine
+	// remains stuck on a recvmsg on a closed fd
+	return syscall.SetsockoptTimeval(int(s.fd), syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, timeout)
+}
+
 func (s *NetlinkSocket) GetPid() (uint32, error) {
 	fd := int(atomic.LoadInt32(&s.fd))
 	lsa, err := syscall.Getsockname(fd)


### PR DESCRIPTION
This a PoC branch that shows that with minor changes clear containers can support the docker macvlan  network plugin
- https://docs.docker.com/engine/userguide/networking/get-started-macvlan/

This needs a minor change to how we manage mac address allocations.
It also needs the link discovery logic to be generic.
