### PR TITLE
qemu: Fix incorrectly formatted log message

### DIFF
--- a/qemu.go
+++ b/qemu.go
@@ -488,7 +488,7 @@ func (q *qemu) init(config HypervisorConfig) error {
 		return err
 	}
 
-	q.Logger().WithField("inside-vm", nested).Debug("Checking nesting environment")
+	q.Logger().WithField("inside-vm", fmt.Sprintf("%t", nested)).Debug("Checking nesting environment")
 
 	if config.DisableNestingChecks {
 		//Intentionally ignore the nesting check


### PR DESCRIPTION
The message that shows if running inside a VM was being displayed as a
raw golang variable ("%!q(bool=true)") rather than a "true"/"false"
string.

Fixes #449.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>