### PR TITLE
proxy: Retry if unable to connect.

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
 )
 
 // ProxyType describes a proxy type.
@@ -32,6 +33,10 @@ const (
 	// NoopProxyType is the noopProxy.
 	NoopProxyType ProxyType = "noopProxy"
 )
+
+func proxyLogger() *logrus.Entry {
+	return virtLog.WithField("subsystem", "proxy")
+}
 
 // Set sets a proxy type based on the input string.
 func (pType *ProxyType) Set(value string) error {


### PR DESCRIPTION
If a proxy cannot be connected to, retry for a period of time until a
timeout (5 seconds) is reached. Output rate-limited log messages to show
connect progress when an immediate connection is not possible.

Fixes: #446.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>