### PR TITLE
ci: Remove chronic from setup.sh

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -34,8 +34,8 @@ sudo -E PATH=$PATH bash -c ".ci/setup.sh"
 popd
 
 echo "Setup virtcontainers environment"
-chronic sudo -E PATH=$PATH bash -c "${cidir}/../utils/virtcontainers-setup.sh"
+sudo -E PATH=$PATH bash -c "${cidir}/../utils/virtcontainers-setup.sh"
 
 echo "Install virtcontainers"
-chronic make
-chronic sudo make install
+make
+sudo make install


### PR DESCRIPTION
chronic command is not available in Fedora and to support Fedora
in our CI we can get rid of this tool in this part of the setup.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>