### PR TITLE
ci: restore the use of chronic

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -34,8 +34,8 @@ sudo -E PATH=$PATH bash -c ".ci/setup.sh"
 popd
 
 echo "Setup virtcontainers environment"
-sudo -E PATH=$PATH bash -c "${cidir}/../utils/virtcontainers-setup.sh"
+chronic sudo -E PATH=$PATH bash -c "${cidir}/../utils/virtcontainers-setup.sh"
 
 echo "Install virtcontainers"
-make
-sudo make install
+chronic make
+chronic sudo make install


### PR DESCRIPTION
As chronic is actually available on Fedora with the moreutils
package, lets restore the use of chronic in this script.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>