### PR TITLE
Multi OS support

### DIFF
--- a/asset.go
+++ b/asset.go
@@ -1,0 +1,168 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"crypto/sha512"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/containers/virtcontainers/pkg/annotations"
+)
+
+type assetType string
+
+func (t assetType) annotations() (string, string, error) {
+	switch t {
+	case kernelAsset:
+		return annotations.KernelPath, annotations.KernelHash, nil
+	case imageAsset:
+		return annotations.ImagePath, annotations.ImageHash, nil
+	}
+
+	return "", "", fmt.Errorf("Wrong asset type %s", t)
+}
+
+const (
+	kernelAsset assetType = "kernel"
+	imageAsset  assetType = "image"
+)
+
+type asset struct {
+	path         string
+	computedHash string
+	kind         assetType
+}
+
+func (a *asset) valid() bool {
+	if !filepath.IsAbs(a.path) {
+		return false
+	}
+
+	switch a.kind {
+	case kernelAsset:
+		return true
+	case imageAsset:
+		return true
+	}
+
+	return false
+}
+
+// hash returns the hex encoded string for the asset hash
+func (a *asset) hash(hashType string) (string, error) {
+	var hashEncodedLen int
+	var hash string
+
+	// We read the actual asset content
+	bytes, err := ioutil.ReadFile(a.path)
+	if err != nil {
+		return "", err
+	}
+
+	if len(bytes) == 0 {
+		return "", fmt.Errorf("Empty asset file at %s", a.path)
+	}
+
+	// Build the asset hash and convert it to a string.
+	// We only support SHA512 for now.
+	switch hashType {
+	case annotations.SHA512:
+		virtLog.Debugf("Computing %v hash", a.path)
+		hashComputed := sha512.Sum512(bytes)
+		hashEncodedLen = hex.EncodedLen(len(hashComputed))
+		hashEncoded := make([]byte, hashEncodedLen)
+		hex.Encode(hashEncoded, hashComputed[:])
+		hash = string(hashEncoded[:])
+		virtLog.Debugf("%v hash: %s", a.path, hash)
+	default:
+		return "", fmt.Errorf("Invalid hash type %s", hashType)
+	}
+
+	a.computedHash = hash
+
+	return hash, nil
+}
+
+func (a *asset) override(podConfig *PodConfig) error {
+	if a == nil || a.path == "" {
+		virtLog.Debug("Using default asset as no custom value specified")
+		return nil
+	}
+
+	if !a.valid() {
+		return fmt.Errorf("Invalid %s at %s", a.kind, a.path)
+	}
+
+	switch a.kind {
+	case kernelAsset:
+		podConfig.HypervisorConfig.KernelPath = a.path
+	case imageAsset:
+		podConfig.HypervisorConfig.ImagePath = a.path
+	}
+
+	return nil
+}
+
+// newAsset returns a new asset from the pod annotations.
+func newAsset(podConfig *PodConfig, t assetType) (*asset, error) {
+	pathAnnotation, hashAnnotation, err := t.annotations()
+	if err != nil {
+		return nil, err
+	}
+
+	if pathAnnotation == "" || hashAnnotation == "" {
+		return nil, fmt.Errorf("Missing annotation paths for %s", t)
+	}
+
+	path, ok := podConfig.Annotations[pathAnnotation]
+	if !ok || path == "" {
+		return nil, nil
+	}
+
+	if !filepath.IsAbs(path) {
+		return nil, fmt.Errorf("%s is not an absolute path", path)
+	}
+
+	a := &asset{path: path, kind: t}
+
+	hash, ok := podConfig.Annotations[hashAnnotation]
+	if !ok || hash == "" {
+		return a, nil
+	}
+
+	// We have a hash annotation, we need to verify the asset against it.
+	hashType, ok := podConfig.Annotations[annotations.AssetHashType]
+	if !ok {
+		virtLog.Warningf("Unrecognized hash type: %s, switching to %s", hashType, annotations.SHA512)
+		hashType = annotations.SHA512
+	}
+
+	hashComputed, err := a.hash(hashType)
+	if err != nil {
+		return a, err
+	}
+
+	// If our computed asset hash does not match the passed annotation, we must exit.
+	if hashComputed != hash {
+		return nil, fmt.Errorf("Invalid hash for %s: computed %s, expecting %s]", a.path, hashComputed, hash)
+	}
+
+	return a, nil
+}

--- a/asset.go
+++ b/asset.go
@@ -34,14 +34,20 @@ func (t assetType) annotations() (string, string, error) {
 		return annotations.KernelPath, annotations.KernelHash, nil
 	case imageAsset:
 		return annotations.ImagePath, annotations.ImageHash, nil
+	case hypervisorAsset:
+		return annotations.HypervisorPath, annotations.HypervisorHash, nil
+	case firmwareAsset:
+		return annotations.FirmwarePath, annotations.FirmwareHash, nil
 	}
 
 	return "", "", fmt.Errorf("Wrong asset type %s", t)
 }
 
 const (
-	kernelAsset assetType = "kernel"
-	imageAsset  assetType = "image"
+	kernelAsset     assetType = "kernel"
+	imageAsset      assetType = "image"
+	hypervisorAsset assetType = "hypervisor"
+	firmwareAsset   assetType = "firmware"
 )
 
 type asset struct {
@@ -59,6 +65,10 @@ func (a *asset) valid() bool {
 	case kernelAsset:
 		return true
 	case imageAsset:
+		return true
+	case hypervisorAsset:
+		return true
+	case firmwareAsset:
 		return true
 	}
 

--- a/asset.go
+++ b/asset.go
@@ -100,26 +100,6 @@ func (a *asset) hash(hashType string) (string, error) {
 	return hash, nil
 }
 
-func (a *asset) override(podConfig *PodConfig) error {
-	if a == nil || a.path == "" {
-		virtLog.Debug("Using default asset as no custom value specified")
-		return nil
-	}
-
-	if !a.valid() {
-		return fmt.Errorf("Invalid %s at %s", a.kind, a.path)
-	}
-
-	switch a.kind {
-	case kernelAsset:
-		podConfig.HypervisorConfig.KernelPath = a.path
-	case imageAsset:
-		podConfig.HypervisorConfig.ImagePath = a.path
-	}
-
-	return nil
-}
-
 // newAsset returns a new asset from the pod annotations.
 func newAsset(podConfig *PodConfig, t assetType) (*asset, error) {
 	pathAnnotation, hashAnnotation, err := t.annotations()

--- a/asset_test.go
+++ b/asset_test.go
@@ -1,0 +1,117 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/containers/virtcontainers/pkg/annotations"
+	"github.com/stretchr/testify/assert"
+)
+
+var assetContent = []byte("FakeAsset fake asset FAKE ASSET")
+var assetContentHash = "92549f8d2018a95a294d28a65e795ed7d1a9d150009a28cea108ae10101178676f04ab82a6950d0099e4924f9c5e41dcba8ece56b75fc8b4e0a7492cb2a8c880"
+var assetContentWrongHash = "92549f8d2018a95a294d28a65e795ed7d1a9d150009a28cea108ae10101178676f04ab82a6950d0099e4924f9c5e41dcba8ece56b75fc8b4e0a7492cb2a8c881"
+
+func TestAssetWrongHashType(t *testing.T) {
+	assert := assert.New(t)
+
+	tmpfile, err := ioutil.TempFile("", "virtcontainers-test-")
+	assert.Nil(err)
+
+	defer func() {
+		tmpfile.Close()
+		os.Remove(tmpfile.Name()) // clean up
+	}()
+
+	_, err = tmpfile.Write(assetContent)
+	assert.Nil(err)
+
+	a := &asset{
+		path: tmpfile.Name(),
+	}
+
+	h, err := a.hash("shafoo")
+	assert.Equal(h, "")
+	assert.NotNil(err)
+}
+
+func TestAssetHash(t *testing.T) {
+	assert := assert.New(t)
+
+	tmpfile, err := ioutil.TempFile("", "virtcontainers-test-")
+	assert.Nil(err)
+
+	defer func() {
+		tmpfile.Close()
+		os.Remove(tmpfile.Name()) // clean up
+	}()
+
+	_, err = tmpfile.Write(assetContent)
+	assert.Nil(err)
+
+	a := &asset{
+		path: tmpfile.Name(),
+	}
+
+	hash, err := a.hash(annotations.SHA512)
+	assert.Nil(err)
+	assert.Equal(assetContentHash, hash)
+	assert.Equal(assetContentHash, a.computedHash)
+}
+
+func TestAssetNew(t *testing.T) {
+	assert := assert.New(t)
+
+	tmpfile, err := ioutil.TempFile("", "virtcontainers-test-")
+	assert.Nil(err)
+
+	defer func() {
+		tmpfile.Close()
+		os.Remove(tmpfile.Name()) // clean up
+	}()
+
+	_, err = tmpfile.Write(assetContent)
+	assert.Nil(err)
+
+	p := &PodConfig{
+		Annotations: map[string]string{
+			annotations.KernelPath: tmpfile.Name(),
+			annotations.KernelHash: assetContentHash,
+		},
+	}
+
+	a, err := newAsset(p, imageAsset)
+	assert.Nil(err)
+	assert.Nil(a)
+
+	a, err = newAsset(p, kernelAsset)
+	assert.Nil(err)
+	assert.Equal(assetContentHash, a.computedHash)
+
+	p = &PodConfig{
+		Annotations: map[string]string{
+			annotations.KernelPath: tmpfile.Name(),
+			annotations.KernelHash: assetContentWrongHash,
+		},
+	}
+
+	a, err = newAsset(p, kernelAsset)
+	assert.NotNil(err)
+}

--- a/hypervisor.go
+++ b/hypervisor.go
@@ -178,6 +178,12 @@ type HypervisorConfig struct {
 	// DisableNestingChecks is used to override customizations performed
 	// when running on top of another VMM.
 	DisableNestingChecks bool
+
+	// customAssets is a map of assets.
+	// Each value in that map takes precedence over the configured assets.
+	// For example, if there is a value for the "kernel" key in this map,
+	// it will be used for the pod's kernel path instead of KernelPath.
+	customAssets map[assetType]*asset
 }
 
 func (conf *HypervisorConfig) valid() (bool, error) {
@@ -210,6 +216,56 @@ func (conf *HypervisorConfig) AddKernelParam(p Param) error {
 	conf.KernelParams = append(conf.KernelParams, p)
 
 	return nil
+}
+
+func (conf *HypervisorConfig) addCustomAsset(a *asset) error {
+	if a == nil || a.path == "" {
+		// We did not get a custom asset, we will use the default one.
+		return nil
+	}
+
+	if !a.valid() {
+		return fmt.Errorf("Invalid %s at %s", a.kind, a.path)
+	}
+
+	virtLog.Debugf("Using custom %v asset %s", a.kind, a.path)
+
+	if conf.customAssets == nil {
+		conf.customAssets = make(map[assetType]*asset)
+	}
+
+	conf.customAssets[a.kind] = a
+
+	return nil
+}
+
+func (conf *HypervisorConfig) assetPath(t assetType) (string, error) {
+	// Custom assets take precedence over the configured ones
+	a, ok := conf.customAssets[t]
+	if ok {
+		return a.path, nil
+	}
+
+	// We could not find a custom asset for the given type, let's
+	// fall back to the configured ones.
+	switch t {
+	case kernelAsset:
+		return conf.KernelPath, nil
+	case imageAsset:
+		return conf.ImagePath, nil
+	default:
+		return "", fmt.Errorf("Unknown asset type %v", t)
+	}
+}
+
+// KernelAssetPath returns the guest kernel path
+func (conf *HypervisorConfig) KernelAssetPath() (string, error) {
+	return conf.assetPath(kernelAsset)
+}
+
+// ImageAssetPath returns the guest image path
+func (conf *HypervisorConfig) ImageAssetPath() (string, error) {
+	return conf.assetPath(imageAsset)
 }
 
 func appendParam(params []Param, parameter string, value string) []Param {

--- a/hypervisor.go
+++ b/hypervisor.go
@@ -253,6 +253,10 @@ func (conf *HypervisorConfig) assetPath(t assetType) (string, error) {
 		return conf.KernelPath, nil
 	case imageAsset:
 		return conf.ImagePath, nil
+	case hypervisorAsset:
+		return conf.HypervisorPath, nil
+	case firmwareAsset:
+		return conf.FirmwarePath, nil
 	default:
 		return "", fmt.Errorf("Unknown asset type %v", t)
 	}
@@ -266,6 +270,16 @@ func (conf *HypervisorConfig) KernelAssetPath() (string, error) {
 // ImageAssetPath returns the guest image path
 func (conf *HypervisorConfig) ImageAssetPath() (string, error) {
 	return conf.assetPath(imageAsset)
+}
+
+// HypervisorAssetPath returns the VM hypervisor path
+func (conf *HypervisorConfig) HypervisorAssetPath() (string, error) {
+	return conf.assetPath(hypervisorAsset)
+}
+
+// FirmwareAssetPath returns the guest firmware path
+func (conf *HypervisorConfig) FirmwareAssetPath() (string, error) {
+	return conf.assetPath(firmwareAsset)
 }
 
 func appendParam(params []Param, parameter string, value string) []Param {

--- a/hypervisor.go
+++ b/hypervisor.go
@@ -262,9 +262,23 @@ func (conf *HypervisorConfig) assetPath(t assetType) (string, error) {
 	}
 }
 
+func (conf *HypervisorConfig) isCustomAsset(t assetType) bool {
+	_, ok := conf.customAssets[t]
+	if ok {
+		return true
+	}
+
+	return false
+}
+
 // KernelAssetPath returns the guest kernel path
 func (conf *HypervisorConfig) KernelAssetPath() (string, error) {
 	return conf.assetPath(kernelAsset)
+}
+
+// CustomKernelAsset returns true if the kernel asset is a custom one, false otherwise.
+func (conf *HypervisorConfig) CustomKernelAsset() bool {
+	return conf.isCustomAsset(kernelAsset)
 }
 
 // ImageAssetPath returns the guest image path
@@ -272,14 +286,29 @@ func (conf *HypervisorConfig) ImageAssetPath() (string, error) {
 	return conf.assetPath(imageAsset)
 }
 
+// CustomImageAsset returns true if the image asset is a custom one, false otherwise.
+func (conf *HypervisorConfig) CustomImageAsset() bool {
+	return conf.isCustomAsset(imageAsset)
+}
+
 // HypervisorAssetPath returns the VM hypervisor path
 func (conf *HypervisorConfig) HypervisorAssetPath() (string, error) {
 	return conf.assetPath(hypervisorAsset)
 }
 
+// CustomHypervisorAsset returns true if the hypervisor asset is a custom one, false otherwise.
+func (conf *HypervisorConfig) CustomHypervisorAsset() bool {
+	return conf.isCustomAsset(hypervisorAsset)
+}
+
 // FirmwareAssetPath returns the guest firmware path
 func (conf *HypervisorConfig) FirmwareAssetPath() (string, error) {
 	return conf.assetPath(firmwareAsset)
+}
+
+// CustomFirmwareAsset returns true if the firmware asset is a custom one, false otherwise.
+func (conf *HypervisorConfig) CustomFirmwareAsset() bool {
+	return conf.isCustomAsset(firmwareAsset)
 }
 
 func appendParam(params []Param, parameter string, value string) []Param {

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -1,0 +1,41 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package annotations
+
+const (
+	vcAnnotationsPrefix = "com.github.containers.virtcontainers."
+
+	// KernelPath is a pod annotation for passing a per container path pointing at the kernel needed to boot the container VM.
+	KernelPath = vcAnnotationsPrefix + "KernelPath"
+
+	// ImagePath is an pod annotation for passing a per container path pointing at the guest image that will run in the container VM.
+	ImagePath = vcAnnotationsPrefix + "ImagePath"
+
+	// KernelHash is a pod annotation for passing a container kernel image SHA-512 hash value.
+	KernelHash = vcAnnotationsPrefix + "KernelHash"
+
+	// ImageHash is an pod annotation for passing a container guest image SHA-512 hash value.
+	ImageHash = vcAnnotationsPrefix + "ImageHash"
+
+	// AssetHashType is the hash type used for assets verification
+	AssetHashType = vcAnnotationsPrefix + "AssetHashType"
+)
+
+const (
+	// SHA512 is the SHA-512 (64) hash algorithm
+	SHA512 string = "sha512"
+)

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -22,14 +22,26 @@ const (
 	// KernelPath is a pod annotation for passing a per container path pointing at the kernel needed to boot the container VM.
 	KernelPath = vcAnnotationsPrefix + "KernelPath"
 
-	// ImagePath is an pod annotation for passing a per container path pointing at the guest image that will run in the container VM.
+	// ImagePath is a pod annotation for passing a per container path pointing at the guest image that will run in the container VM.
 	ImagePath = vcAnnotationsPrefix + "ImagePath"
+
+	// HypervisorPath is a pod annotation for passing a per container path pointing at the hypervisor that will run the container VM.
+	HypervisorPath = vcAnnotationsPrefix + "HypervisorPath"
+
+	// FirmwarePath is a pod annotation for passing a per container path pointing at the guest firmware that will run the container VM.
+	FirmwarePath = vcAnnotationsPrefix + "FirmwarePath"
 
 	// KernelHash is a pod annotation for passing a container kernel image SHA-512 hash value.
 	KernelHash = vcAnnotationsPrefix + "KernelHash"
 
 	// ImageHash is an pod annotation for passing a container guest image SHA-512 hash value.
 	ImageHash = vcAnnotationsPrefix + "ImageHash"
+
+	// HypervisorHash is an pod annotation for passing a container hypervisor binary SHA-512 hash value.
+	HypervisorHash = vcAnnotationsPrefix + "HypervisorHash"
+
+	// FirmwareHash is an pod annotation for passing a container guest firmware SHA-512 hash value.
+	FirmwareHash = vcAnnotationsPrefix + "FirmwareHash"
 
 	// AssetHashType is the hash type used for assets verification
 	AssetHashType = vcAnnotationsPrefix + "AssetHashType"

--- a/pod.go
+++ b/pod.go
@@ -525,12 +525,36 @@ func (p *Pod) createSetStates() error {
 	return nil
 }
 
+func selectAssets(podConfig *PodConfig) error {
+	kernel, err := newAsset(podConfig, kernelAsset)
+	if err != nil {
+		return err
+	}
+
+	image, err := newAsset(podConfig, imageAsset)
+	if err != nil {
+		return err
+	}
+
+	for _, a := range []*asset{kernel, image} {
+		if err := a.override(podConfig); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // createPod creates a pod from a pod description, the containers list, the hypervisor
 // and the agent passed through the Config structure.
 // It will create and store the pod structure, and then ask the hypervisor
 // to physically create that pod i.e. starts a VM for that pod to eventually
 // be started.
 func createPod(podConfig PodConfig) (*Pod, error) {
+	if err := selectAssets(&podConfig); err != nil {
+		return nil, err
+	}
+
 	p, err := doFetchPod(podConfig)
 	if err != nil {
 		return nil, err

--- a/pod.go
+++ b/pod.go
@@ -525,7 +525,7 @@ func (p *Pod) createSetStates() error {
 	return nil
 }
 
-func selectAssets(podConfig *PodConfig) error {
+func createAssets(podConfig *PodConfig) error {
 	kernel, err := newAsset(podConfig, kernelAsset)
 	if err != nil {
 		return err
@@ -537,7 +537,7 @@ func selectAssets(podConfig *PodConfig) error {
 	}
 
 	for _, a := range []*asset{kernel, image} {
-		if err := a.override(podConfig); err != nil {
+		if err := podConfig.HypervisorConfig.addCustomAsset(a); err != nil {
 			return err
 		}
 	}
@@ -551,7 +551,7 @@ func selectAssets(podConfig *PodConfig) error {
 // to physically create that pod i.e. starts a VM for that pod to eventually
 // be started.
 func createPod(podConfig PodConfig) (*Pod, error) {
-	if err := selectAssets(&podConfig); err != nil {
+	if err := createAssets(&podConfig); err != nil {
 		return nil, err
 	}
 

--- a/pod_test.go
+++ b/pod_test.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/containers/virtcontainers/pkg/annotations"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -1288,4 +1289,51 @@ func TestPodAttachDevicesVFIO(t *testing.T) {
 
 	err = pod.detachDevices()
 	assert.Nil(t, err, "Error while detaching devices %s", err)
+}
+
+func TestPodSelectAssets(t *testing.T) {
+	assert := assert.New(t)
+
+	tmpfile, err := ioutil.TempFile("", "virtcontainers-test-")
+	assert.Nil(err)
+
+	defer func() {
+		tmpfile.Close()
+		os.Remove(tmpfile.Name()) // clean up
+	}()
+
+	_, err = tmpfile.Write(assetContent)
+	assert.Nil(err)
+
+	originalKernelPath := filepath.Join(testDir, testKernel)
+
+	hc := HypervisorConfig{
+		KernelPath: originalKernelPath,
+		ImagePath:  filepath.Join(testDir, testImage),
+	}
+
+	p := &PodConfig{
+		Annotations: map[string]string{
+			annotations.KernelPath: tmpfile.Name(),
+			annotations.KernelHash: assetContentHash,
+		},
+
+		HypervisorConfig: hc,
+	}
+
+	err = selectAssets(p)
+	assert.Nil(err)
+	assert.Equal(p.HypervisorConfig.KernelPath, tmpfile.Name())
+
+	p = &PodConfig{
+		Annotations: map[string]string{
+			annotations.KernelPath: tmpfile.Name(),
+			annotations.KernelHash: assetContentWrongHash,
+		},
+
+		HypervisorConfig: hc,
+	}
+
+	err = selectAssets(p)
+	assert.NotNil(err)
 }

--- a/pod_test.go
+++ b/pod_test.go
@@ -1291,7 +1291,7 @@ func TestPodAttachDevicesVFIO(t *testing.T) {
 	assert.Nil(t, err, "Error while detaching devices %s", err)
 }
 
-func TestPodSelectAssets(t *testing.T) {
+func TestPodCreateAssets(t *testing.T) {
 	assert := assert.New(t)
 
 	tmpfile, err := ioutil.TempFile("", "virtcontainers-test-")
@@ -1321,9 +1321,12 @@ func TestPodSelectAssets(t *testing.T) {
 		HypervisorConfig: hc,
 	}
 
-	err = selectAssets(p)
+	err = createAssets(p)
 	assert.Nil(err)
-	assert.Equal(p.HypervisorConfig.KernelPath, tmpfile.Name())
+
+	a, ok := p.HypervisorConfig.customAssets[kernelAsset]
+	assert.True(ok)
+	assert.Equal(a.path, tmpfile.Name())
 
 	p = &PodConfig{
 		Annotations: map[string]string{
@@ -1334,6 +1337,6 @@ func TestPodSelectAssets(t *testing.T) {
 		HypervisorConfig: hc,
 	}
 
-	err = selectAssets(p)
+	err = createAssets(p)
 	assert.NotNil(err)
 }

--- a/qemu.go
+++ b/qemu.go
@@ -405,7 +405,12 @@ func (q *qemu) appendConsoles(devices []ciaoQemu.Device, podConfig PodConfig) []
 }
 
 func (q *qemu) appendImage(devices []ciaoQemu.Device, podConfig PodConfig) ([]ciaoQemu.Device, error) {
-	imageFile, err := os.Open(q.config.ImagePath)
+	imagePath, err := q.config.ImageAssetPath()
+	if err != nil {
+		return nil, err
+	}
+
+	imageFile, err := os.Open(imagePath)
 	if err != nil {
 		return nil, err
 	}
@@ -421,7 +426,7 @@ func (q *qemu) appendImage(devices []ciaoQemu.Device, podConfig PodConfig) ([]ci
 		Type:     ciaoQemu.MemoryBackendFile,
 		DeviceID: "nv0",
 		ID:       "mem0",
-		MemPath:  q.config.ImagePath,
+		MemPath:  imagePath,
 		Size:     (uint64)(imageStat.Size()),
 	}
 
@@ -637,8 +642,13 @@ func (q *qemu) createPod(podConfig PodConfig) error {
 		Mlock:        q.config.Mlock,
 	}
 
+	kernelPath, err := q.config.KernelAssetPath()
+	if err != nil {
+		return err
+	}
+
 	kernel := ciaoQemu.Kernel{
-		Path:   q.config.KernelPath,
+		Path:   kernelPath,
 		Params: strings.Join(q.kernelParams, " "),
 	}
 

--- a/qemu.go
+++ b/qemu.go
@@ -466,7 +466,11 @@ func (q *qemu) getMachine(name string) (ciaoQemu.Machine, error) {
 
 // Build the QEMU binary path
 func (q *qemu) buildPath() error {
-	p := q.config.HypervisorPath
+	p, err := q.config.HypervisorAssetPath()
+	if err != nil {
+		return err
+	}
+
 	if p != "" {
 		q.path = p
 		return nil
@@ -694,6 +698,11 @@ func (q *qemu) createPod(podConfig PodConfig) error {
 		cpuModel += ",pmu=off"
 	}
 
+	firmwarePath, err := podConfig.HypervisorConfig.FirmwareAssetPath()
+	if err != nil {
+		return err
+	}
+
 	qemuConfig := ciaoQemu.Config{
 		Name:        fmt.Sprintf("pod-%s", podConfig.ID),
 		UUID:        q.forceUUIDFormat(podConfig.ID),
@@ -710,7 +719,7 @@ func (q *qemu) createPod(podConfig PodConfig) error {
 		Knobs:       knobs,
 		VGA:         "none",
 		GlobalParam: "kvm-pit.lost_tick_policy=discard",
-		Bios:        podConfig.HypervisorConfig.FirmwarePath,
+		Bios:        firmwarePath,
 	}
 
 	q.qemuConfig = qemuConfig


### PR DESCRIPTION
Based on the pod config annotations, we change the underlying
hypervisor configuration. Pod config annotations can carry a
kernel, image, hypervisor and firmware paths.
Those annotations, if valid, will supersede the hypervisor
configuration paths. If not valid, virtcontainers will error
out.

Optionally, asset SHA-512 hashes can be passed through pod
annotations as well. In that case virtcontainers will verify
that the asset binary matches the hash annotation and error
out when it does not.

More details on the architecture in #439 
    
Fixes #439

TODO:

- [X] Unit tests
- [X] Update `pkg/oci/utils.go` to convert an OCI annotations into a `PodConfig` one for assets
