### PR TITLE
shim: Display shim PID as an int

### DIFF
--- a/shim.go
+++ b/shim.go
@@ -113,7 +113,7 @@ func stopShim(pid int) error {
 		return nil
 	}
 
-	shimLogger().WithField("shim-pid", pid).Info("Stopping shim")
+	shimLogger().WithField("shim-pid", fmt.Sprintf("%d", pid)).Info("Stopping shim")
 
 	if err := syscall.Kill(pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
 		return err


### PR DESCRIPTION
Log the PID of the shim as an integer string rather than having the raw
int converted into a string (with undesirable and incorrect results).

Fixes #461.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>