### PR TITLE
1.0.5 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+1.0.5:
+	Added full CI (unit, functional and integration tests)
+	Added docker ps command support
+	Added multi-queue macvtap to the list of networking models
+	Added --device support for block devices (emulated)
+	Added pod shared locks for more efficient locking
+	Removed the ciao uuid package dependency
+
 1.0.4:
 	Added shim debug output
 	Added support for custom qemu accelerators


### PR DESCRIPTION
Added full CI (unit, functional and integration tests)
Added docker ps command support
Added multi-queue macvtap to the list of networking models
Added --device support for block devices (emulated)
Added pod shared locks for more efficient locking
Removed the ciao uuid package dependency

Shortlog:

8be82a3 ci: restore the use of chronic
f4a2ad1 virtc: Fix virtc to make it properly usable
b366203 .ci: Handle cases where backward compatibility is broken
e2f5902 lock: Use shared locking for read only cases
5e18bdf lock: Introduce shared lock possibility
809eb65 readme: update CI build badges
ad66bff ci: Remove chronic from setup.sh
eea3d36 tests: Add test to check attaching block device
dbad689 devices: Try to restore the pod block index in case of failure.
1e69ba9 devices: Add block devices to fsmap and pass them to agent.
86488e2 devices: Change check for block devices.
baeab61 device: Add support for block devices to be passed with --device
0424842 proxy: Retry if unable to connect.
8a625ec qemu: Fix incorrectly formatted log message
8910d1b Networking: Add support for multi-queue mactap
aff0a34 Revendor: netlink library revendoring
b332097 vendor/ciao: update ciao
ec539ad uuid: Remove the ciao uuid package
f76f0aa uuid: Use uuid package from repo instead of ciao.
9602046 uuid: Copy over the uuid package from ciao project.
64aafe1 devices: Pass container to devices.attach
ff99e51 mock: update mock API
48667e6 agent: implement ps command
2576cc0 CI: Add script for jenkins job
c6513bd pause: Remove all things related to pause container
29ffbb5 ci: Add Clear Containers tests to the CI of virtcontainers
d6f13e7 ci: Update virtcontainers code in runtime and proxy
c4e51e8 ci: install dependencies using Clear Containers CI setup
f005780 ci: rename ci-jobs and ci-setup scripts
c236931 qemu: Initialize qmp logger properly

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>