### PR TITLE
container: Quieten logging

### DIFF
--- a/container.go
+++ b/container.go
@@ -282,9 +282,12 @@ func fetchContainer(pod *Pod, containerID string) (*Container, error) {
 		return nil, err
 	}
 
-	pod.Logger().WithField("config", config).Debug("Container config")
+	container, err := createContainer(pod, config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create container with config %v in pod %v: %v", config, pod.id, err)
+	}
 
-	return createContainer(pod, config)
+	return container, nil
 }
 
 // storeContainer stores a container config.


### PR DESCRIPTION
Change fetchContainer() to only dump the config to the log on error.

Fixes #466.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>