### PR TITLE
.ci: Fix coveralls reports

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -36,9 +36,9 @@ go get ${vc_repo} || true
 cd "${GOPATH}/src/${vc_repo}"
 if [ "${ghprbPullId}" ] && [ "${ghprbTargetBranch}" ]
 then
-	git fetch origin "pull/${ghprbPullId}/head" && git checkout FETCH_HEAD && git rebase "origin/${ghprbTargetBranch}"
+	git fetch origin "pull/${ghprbPullId}/head" && git checkout master && git reset --hard FETCH_HEAD && git rebase "origin/${ghprbTargetBranch}"
 else
-	git fetch origin && git checkout origin/master
+	git fetch origin && git checkout master && git reset --hard origin/master
 fi
 
 # Setup environment and run the tests


### PR DESCRIPTION
Coveralls needs its report to be performed against master branch to
report properly the code coverage to Github.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>