### PR TITLE
api: Simplify drive hotplugging

### DIFF
--- a/api.go
+++ b/api.go
@@ -82,12 +82,6 @@ func CreatePod(podConfig PodConfig) (VCPod, error) {
 		return nil, err
 	}
 
-	// Hotplug all pod containers rootfs if the hypervisor supports it
-	err = p.hotplugDrives()
-	if err != nil {
-		return nil, err
-	}
-
 	// Start shims
 	if err := p.startShims(); err != nil {
 		return nil, err

--- a/pod.go
+++ b/pod.go
@@ -67,9 +67,6 @@ type State struct {
 	// File system of the rootfs incase it is block device
 	Fstype string `json:"fstype"`
 
-	// Bool to indicate if container rootfs has been checked for block storage.
-	RootfsBlockChecked bool `json:"rootfsBlockChecked"`
-
 	// Bool to indicate if the drive for a container was hotplugged.
 	HotpluggedDrive bool `json:"hotpluggedDrive"`
 }
@@ -1203,30 +1200,6 @@ func (p *Pod) attachDevices() error {
 func (p *Pod) detachDevices() error {
 	for _, container := range p.containers {
 		if err := container.detachDevices(); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// hotplugDrives can be used to pass block storage devices to the hypervisor in case of devicemapper storage.
-// The container then uses the block device as its rootfs instead of overlay.
-// The container fstype is assigned the file system type of the block device to indicate this.
-func (p *Pod) hotplugDrives() error {
-	// fetch agent capabilities and hotplug if the agent has support
-	// for block devices.
-	caps := p.agent.capabilities()
-	if !caps.isBlockDeviceSupported() {
-		return nil
-	}
-
-	if p.config.HypervisorConfig.DisableBlockDeviceUse {
-		return nil
-	}
-
-	for _, c := range p.containers {
-		if err := c.hotplugDrive(); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
The way CreatePod() was implemented, it was making an extra call
to hotplug all the drives. But when StartPod() is called, it leads
eventually to Container.start() to be invoked, resulting into a
hotplug of the drives related to this container.

A mechanism based on a flag was in place to detect if the drive had
been previously hotplugged, but there is no need for such thing
anymore. Indeed, we know that we are hotplugging only from the
container implementation.