### PR TITLE
filesystem: Fix fetchFile behaviour for devicesFileType

### DIFF
--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -221,7 +221,7 @@ func TestFilesystemFetchFileSuccessful(t *testing.T) {
 	}
 	f.Close()
 
-	err = fs.fetchFile(path, &data)
+	err = fs.fetchFile(path, podResource(-1), &data)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -243,7 +243,7 @@ func TestFilesystemFetchFileFailingNoFile(t *testing.T) {
 	path := filepath.Join(testDir, "testFilesystem")
 	os.Remove(path)
 
-	err := fs.fetchFile(path, &data)
+	err := fs.fetchFile(path, podResource(-1), &data)
 	if err == nil {
 		t.Fatal()
 	}
@@ -262,7 +262,7 @@ func TestFilesystemFetchFileFailingUnMarshalling(t *testing.T) {
 	}
 	f.Close()
 
-	err = fs.fetchFile(path, data)
+	err = fs.fetchFile(path, podResource(-1), data)
 	if err == nil {
 		t.Fatal()
 	}


### PR DESCRIPTION
In a previous patch, I have been simplifying the way we were fetching
stored information from the filesystem, but I simplified too much,
because I forgot the specific case of devicesFileType.

This commit fixes this lack of support by calling into the specific
function fetchDeviceFile() in case of devicesFileType as a resource.