### PR TITLE
container: fix device mapper hot plug in qemu 2.9

### DIFF
--- a/container.go
+++ b/container.go
@@ -785,7 +785,7 @@ func (c *Container) hotplugDrive() error {
 	}).Info("Block device detected")
 
 	// Add drive with id as container id
-	devID := fmt.Sprintf("drive-%s", c.id)
+	devID := makeBlockDevIDForHypervisor(c.id)
 	drive := Drive{
 		File:   devicePath,
 		Format: "raw",
@@ -825,7 +825,7 @@ func (c *Container) removeDrive() (err error) {
 	if c.isDriveUsed() && c.state.HotpluggedDrive {
 		c.Logger().Info("unplugging block device")
 
-		devID := fmt.Sprintf("drive-%s", c.id)
+		devID := makeBlockDevIDForHypervisor(c.id)
 		drive := Drive{
 			ID: devID,
 		}


### PR DESCRIPTION
There is a limit size of 31 character for device ids in qemu 2.9.
This patch reduce the size of the id used to hot plug container's rootfs
as block device.

fixes #479

Signed-off-by: Julio Montes <julio.montes@intel.com>