### PR TITLE
pod: Improve pod stop/delete sequence

### DIFF
--- a/hyperstart.go
+++ b/hyperstart.go
@@ -440,6 +440,15 @@ func (h *hyper) startPod(pod Pod) error {
 
 // stopPod is the agent Pod stopping implementation for hyperstart.
 func (h *hyper) stopPod(pod Pod) error {
+	proxyCmd := hyperstartProxyCmd{
+		cmd:     hyperstart.DestroyPod,
+		message: nil,
+	}
+
+	if _, err := h.proxy.sendCmd(proxyCmd); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pod.go
+++ b/pod.go
@@ -581,10 +581,6 @@ func createPod(podConfig PodConfig) (*Pod, error) {
 		return nil, err
 	}
 
-	if err := p.storage.storeHypervisorState(p.id, p.hypervisor.getState()); err != nil {
-		return nil, err
-	}
-
 	return p, nil
 }
 
@@ -629,10 +625,6 @@ func doFetchPod(podConfig PodConfig) (*Pod, error) {
 		wg:              &sync.WaitGroup{},
 	}
 
-	if err := p.hypervisor.init(p); err != nil {
-		return nil, err
-	}
-
 	containers, err := newContainers(p, podConfig.Containers)
 	if err != nil {
 		return nil, err
@@ -641,6 +633,11 @@ func doFetchPod(podConfig PodConfig) (*Pod, error) {
 	p.containers = containers
 
 	if err := p.storage.createAllResources(*p); err != nil {
+		return nil, err
+	}
+
+	if err := p.hypervisor.init(p); err != nil {
+		p.storage.deletePodResources(p.id, nil)
 		return nil, err
 	}
 

--- a/qemu.go
+++ b/qemu.go
@@ -803,7 +803,6 @@ func (q *qemu) waitPod(timeout int) error {
 func (q *qemu) stopPod() error {
 	cfg := ciaoQemu.QMPConfig{Logger: newQMPLogger()}
 	disconnectCh := make(chan struct{})
-	const timeout = time.Duration(10) * time.Second
 
 	q.Logger().Info("Stopping Pod")
 	qmp, _, err := ciaoQemu.QMPStart(q.qmpControlCh.ctx, q.qmpControlCh.path, cfg, disconnectCh)
@@ -818,19 +817,7 @@ func (q *qemu) stopPod() error {
 		return err
 	}
 
-	if err := qmp.ExecuteQuit(q.qmpMonitorCh.ctx); err != nil {
-		return err
-	}
-
-	// Wait for the VM disconnection notification
-	select {
-	case <-disconnectCh:
-		break
-	case <-time.After(timeout):
-		return fmt.Errorf("Did not receive the VM disconnection notification (timeout %ds)", timeout)
-	}
-
-	return nil
+	return qmp.ExecuteQuit(q.qmpMonitorCh.ctx)
 }
 
 func (q *qemu) togglePausePod(pause bool) error {

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -384,8 +384,17 @@ func TestQemuInit(t *testing.T) {
 		},
 	}
 
-	err := q.init(pod)
-	if err != nil {
+	// Create parent dir path for hypervisor.json
+	parentDir := filepath.Join(runStoragePath, pod.id)
+	if err := os.MkdirAll(parentDir, dirMode); err != nil {
+		t.Fatalf("Could not create parent directory %s: %v", parentDir, err)
+	}
+
+	if err := q.init(pod); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.RemoveAll(parentDir); err != nil {
 		t.Fatal(err)
 	}
 
@@ -402,6 +411,29 @@ func TestQemuInit(t *testing.T) {
 
 	if strings.Join(q.kernelParams, " ") != testQemuKernelParamsDefault {
 		t.Fatal()
+	}
+}
+
+func TestQemuInitMissingParentDirFail(t *testing.T) {
+	qemuConfig := newQemuConfig()
+	q := &qemu{}
+
+	pod := &Pod{
+		id:      "testPod",
+		storage: &filesystem{},
+		config: &PodConfig{
+			HypervisorConfig: qemuConfig,
+		},
+	}
+
+	// Ensure parent dir path for hypervisor.json does not exist.
+	parentDir := filepath.Join(runStoragePath, pod.id)
+	if err := os.RemoveAll(parentDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := q.init(pod); err == nil {
+		t.Fatal("Qemu init() expected to fail because of missing parent directory for storage")
 	}
 }
 


### PR DESCRIPTION
This PR first improves the way the tear down of the pod is performed from the agent. Until now, nothing was done and the VM was stopped without tearing down properly the things previously set up inside the VM.
Then, it modifies the QEMU implementation for the `stopPod()` method, by not waiting for the VM to exit. Instead, it send a SHUTDOWN through QMP but it does not wait for the VM since there is really nothing it can do.