### PR TITLE
One proxy per vm

### DIFF
--- a/api.go
+++ b/api.go
@@ -86,6 +86,12 @@ func createPodFromConfig(podConfig PodConfig) (*Pod, error) {
 		return nil, err
 	}
 
+	// Start the proxy
+	err = p.startProxy()
+	if err != nil {
+		return nil, err
+	}
+
 	// Start shims
 	if err := p.startShims(); err != nil {
 		return nil, err

--- a/api_test.go
+++ b/api_test.go
@@ -603,8 +603,9 @@ func TestStatusPodSuccessfulStateReady(t *testing.T) {
 	expectedStatus := PodStatus{
 		ID: testPodID,
 		State: State{
-			State: StateReady,
-			URL:   "noopProxyURL",
+			State:    StateReady,
+			URL:      "noopProxyURL",
+			ProxyPid: 0,
 		},
 		Hypervisor:       MockHypervisor,
 		HypervisorConfig: hypervisorConfig,

--- a/cc_proxy.go
+++ b/cc_proxy.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os/exec"
+	"path/filepath"
 	"time"
 
 	"github.com/clearcontainers/proxy/client"
@@ -41,7 +43,8 @@ type ccProxy struct {
 // CCProxyConfig is a structure storing information needed for
 // the Clear Containers proxy initialization.
 type CCProxyConfig struct {
-	URL string
+	Path  string
+	Debug bool
 }
 
 // connectProxyRetry repeatedly tries to connect to the proxy on the specified
@@ -96,12 +99,12 @@ func (p *ccProxy) connectProxyRetry(scheme, address string) (conn net.Conn, err 
 	}
 }
 
-func (p *ccProxy) connectProxy(proxyURL string) (*client.Client, error) {
-	if proxyURL == "" {
-		proxyURL = defaultCCProxyURL
+func (p *ccProxy) connectProxy(uri string) (*client.Client, error) {
+	if uri == "" {
+		return nil, fmt.Errorf("no proxy URI")
 	}
 
-	u, err := url.Parse(proxyURL)
+	u, err := url.Parse(uri)
 	if err != nil {
 		return nil, err
 	}
@@ -127,17 +130,44 @@ func (p *ccProxy) connectProxy(proxyURL string) (*client.Client, error) {
 	return client.NewClient(conn), nil
 }
 
+// start is the proxy start implementation for ccProxy.
+func (p *ccProxy) start(pod Pod) (int, string, error) {
+	if pod.config == nil {
+		return -1, "", fmt.Errorf("Pod config cannot be nil")
+	}
+
+	config, ok := newProxyConfig(*(pod.config)).(CCProxyConfig)
+	if !ok {
+		return -1, "", fmt.Errorf("Wrong proxy config type, should be CCProxyConfig type")
+	}
+
+	if config.Path == "" {
+		return -1, "", fmt.Errorf("Proxy path cannot be empty")
+	}
+
+	// construct the socket path the proxy instance will use
+	socketPath := filepath.Join(runStoragePath, pod.id, "proxy.sock")
+	uri := fmt.Sprintf("unix://%s", socketPath)
+
+	args := []string{config.Path, "-uri", uri}
+	if config.Debug {
+		args = append(args, "-log", "debug")
+	}
+
+	cmd := exec.Command(args[0], args[1:]...)
+	if err := cmd.Start(); err != nil {
+		return -1, "", err
+	}
+
+	return cmd.Process.Pid, uri, nil
+}
+
 // register is the proxy register implementation for ccProxy.
 func (p *ccProxy) register(pod Pod) ([]ProxyInfo, string, error) {
 	var err error
 	var proxyInfos []ProxyInfo
 
-	ccConfig, ok := newProxyConfig(*(pod.config)).(CCProxyConfig)
-	if !ok {
-		return []ProxyInfo{}, "", fmt.Errorf("Wrong proxy config type, should be CCProxyConfig type")
-	}
-
-	p.client, err = p.connectProxy(ccConfig.URL)
+	p.client, err = p.connectProxy(pod.state.URL)
 	if err != nil {
 		return []ProxyInfo{}, "", err
 	}
@@ -193,12 +223,7 @@ func (p *ccProxy) unregister(pod Pod) error {
 func (p *ccProxy) connect(pod Pod, createToken bool) (ProxyInfo, string, error) {
 	var err error
 
-	ccConfig, ok := newProxyConfig(*(pod.config)).(CCProxyConfig)
-	if !ok {
-		return ProxyInfo{}, "", fmt.Errorf("Wrong proxy config type, should be CCProxyConfig type")
-	}
-
-	p.client, err = p.connectProxy(ccConfig.URL)
+	p.client, err = p.connectProxy(pod.state.URL)
 	if err != nil {
 		return ProxyInfo{}, "", err
 	}

--- a/cc_proxy.go
+++ b/cc_proxy.go
@@ -26,7 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var defaultCCProxyURL = "unix:///run/cc-oci-runtime/proxy.sock"
+var defaultCCProxyURL = "unix:///var/run/clear-containers/proxy.sock"
 
 const (
 	// Number of seconds to wait for the proxy to respond to a connection

--- a/cc_proxy_test.go
+++ b/cc_proxy_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCCProxyStart(t *testing.T) {
+	assert := assert.New(t)
+
+	tmpdir, err := ioutil.TempDir("", "")
+	assert.NoError(err)
+	defer os.RemoveAll(tmpdir)
+
+	proxy := &ccProxy{}
+
+	type testData struct {
+		pod         Pod
+		expectedURI string
+		expectError bool
+	}
+
+	invalidPath := filepath.Join(tmpdir, "enoent")
+	expectedSocketPath := filepath.Join(runStoragePath, testPodID, "proxy.sock")
+	expectedURI := fmt.Sprintf("unix://%s", expectedSocketPath)
+
+	data := []testData{
+		{Pod{}, "", true},
+		{
+			Pod{
+				config: &PodConfig{
+					ProxyType:   "invalid",
+					ProxyConfig: "invalid",
+				},
+			}, "", true,
+		},
+		{
+			Pod{
+				config: &PodConfig{
+					ProxyType:   CCProxyType,
+					ProxyConfig: CCProxyConfig{
+					// invalid - no path
+					},
+				},
+			}, "", true,
+		},
+		{
+			Pod{
+				config: &PodConfig{
+					ProxyType: CCProxyType,
+					ProxyConfig: CCProxyConfig{
+						Path: invalidPath,
+					},
+				},
+			}, "", true,
+		},
+		{
+			Pod{
+				id: testPodID,
+				config: &PodConfig{
+					ProxyType: CCProxyType,
+					ProxyConfig: CCProxyConfig{
+						Path: "echo",
+					},
+				},
+			}, expectedURI, false,
+		},
+	}
+
+	for _, d := range data {
+		pid, uri, err := proxy.start(d.pod)
+		if d.expectError {
+			assert.Error(err)
+			continue
+		}
+
+		assert.NoError(err)
+		assert.True(pid > 0)
+		assert.Equal(d.expectedURI, uri)
+	}
+}

--- a/container.go
+++ b/container.go
@@ -714,7 +714,7 @@ func (c *Container) processList(options ProcessListOptions) (ProcessList, error)
 
 func (c *Container) createShimProcess(token, url string, cmd Cmd) (*Process, error) {
 	if c.pod.state.URL != url {
-		return &Process{}, fmt.Errorf("Pod URL %s and URL from proxy %s MUST be identical", c.pod.state.URL, url)
+		return &Process{}, fmt.Errorf("Pod URL %q and URL from proxy %q MUST be identical", c.pod.state.URL, url)
 	}
 
 	shimParams := ShimParams{

--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -79,16 +79,16 @@ var podConfigFlags = []cli.Flag{
 		Usage: "the agent's proxy",
 	},
 
+	cli.StringFlag{
+		Name:  "proxy-path",
+		Value: "",
+		Usage: "path to proxy binary",
+	},
+
 	cli.GenericFlag{
 		Name:  "shim",
 		Value: new(vc.ShimType),
 		Usage: "the shim type",
-	},
-
-	cli.StringFlag{
-		Name:  "proxy-url",
-		Value: "",
-		Usage: "the agent's proxy socket path",
 	},
 
 	cli.StringFlag{
@@ -196,7 +196,7 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 	sshdKey := context.String("sshd-auth-file")
 	hyperCtlSockName := context.String("hyper-ctl-sock-name")
 	hyperTtySockName := context.String("hyper-tty-sock-name")
-	proxyURL := context.String("proxy-url")
+	proxyPath := context.String("proxy-path")
 	shimPath := context.String("shim-path")
 	machineType := context.String("machine-type")
 	vmVCPUs := context.Uint("vm-vcpus")
@@ -281,7 +281,7 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 		agConfig = nil
 	}
 
-	proxyConfig := getProxyConfig(*proxyType, proxyURL)
+	proxyConfig := getProxyConfig(*proxyType, proxyPath)
 
 	shimConfig := getShimConfig(*shimType, shimPath)
 
@@ -321,13 +321,13 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 	return podConfig, nil
 }
 
-func getProxyConfig(proxyType vc.ProxyType, url string) interface{} {
+func getProxyConfig(proxyType vc.ProxyType, path string) interface{} {
 	var proxyConfig interface{}
 
 	switch proxyType {
 	case vc.CCProxyType:
 		proxyConfig = vc.CCProxyConfig{
-			URL: url,
+			Path: path,
 		}
 
 	default:

--- a/noop_proxy.go
+++ b/noop_proxy.go
@@ -20,6 +20,12 @@ type noopProxy struct{}
 
 var noopProxyURL = "noopProxyURL"
 
+// register is the proxy start implementation for testing purpose.
+// It does nothing.
+func (p *noopProxy) start(pod Pod) (int, string, error) {
+	return 0, noopProxyURL, nil
+}
+
 // register is the proxy register implementation for testing purpose.
 // It does nothing.
 func (p *noopProxy) register(pod Pod) ([]ProxyInfo, string, error) {

--- a/pod.go
+++ b/pod.go
@@ -72,6 +72,9 @@ type State struct {
 
 	// Bool to indicate if the drive for a container was hotplugged.
 	HotpluggedDrive bool `json:"hotpluggedDrive"`
+
+	// Process ID of the pods proxy instance
+	ProxyPid int
 }
 
 // valid checks that the pod state is valid.
@@ -757,6 +760,29 @@ func (p *Pod) startVM(netNsPath string) error {
 	})
 }
 
+// startProxy starts a proxy instance for the pod.
+//
+// Note that there is no corresponding stopProxy() since the proxy
+// stops itself.
+func (p *Pod) startProxy() error {
+	pid, uri, err := p.proxy.start(*p)
+	if err != nil {
+		return err
+	}
+
+	// save state
+	p.state.URL = uri
+	p.state.ProxyPid = pid
+
+	if err := p.setPodState(p.state); err != nil {
+		return err
+	}
+
+	p.Logger().WithField("proxy-pid", pid).Info("proxy started")
+
+	return nil
+}
+
 // startShims registers all containers to the proxy and starts one
 // shim per container.
 func (p *Pod) startShims() error {
@@ -771,11 +797,6 @@ func (p *Pod) startShims() error {
 
 	if len(proxyInfos) != len(p.containers) {
 		return fmt.Errorf("Retrieved %d proxy infos, expecting %d", len(proxyInfos), len(p.containers))
-	}
-
-	p.state.URL = url
-	if err := p.setPodState(p.state); err != nil {
-		return err
 	}
 
 	shimCount := 0

--- a/pod.go
+++ b/pod.go
@@ -802,7 +802,11 @@ func (p *Pod) startShims() error {
 		}
 	}
 
-	p.Logger().WithField("shim-count", shimCount).Info("Started shims")
+	if shimCount > 0 {
+		p.Logger().WithField("shim-count", shimCount).Info("Started shims")
+	} else {
+		p.Logger().Info("No containers, so no shims started")
+	}
 
 	return nil
 }

--- a/proxy.go
+++ b/proxy.go
@@ -93,7 +93,7 @@ func newProxyConfig(config PodConfig) interface{} {
 	}
 }
 
-// ProxyInfo holds the token and url returned by the proxy.
+// ProxyInfo holds the token returned by the proxy.
 // Each ProxyInfo relates to a process running inside a container.
 type ProxyInfo struct {
 	Token string
@@ -101,6 +101,10 @@ type ProxyInfo struct {
 
 // proxy is the virtcontainers proxy interface.
 type proxy interface {
+	// start launches a proxy instance for the specified pod, returning
+	// the PID of the process and the URL used to connect to it.
+	start(pod Pod) (int, string, error)
+
 	// register connects and registers the proxy to the given VM.
 	// It also returns information related to containers workloads.
 	register(pod Pod) ([]ProxyInfo, string, error)


### PR DESCRIPTION
proxy: Launch one proxy instance per pod
    
Create a proxy instance for each pod (virtual machine).
    
Since the proxy is now launched by virtcontainers, it is necessary to specify the path to the proxy binary
in the pod configuration.
    
Fixes #478.
