### PR TITLE
pod: Improve pod create performances

### DIFF
--- a/hypervisor.go
+++ b/hypervisor.go
@@ -446,7 +446,8 @@ func RunningOnVMM(cpuInfoPath string) (bool, error) {
 type hypervisor interface {
 	init(pod *Pod) error
 	createPod(podConfig PodConfig) error
-	startPod(startCh, stopCh chan struct{}) error
+	startPod() error
+	waitPod(timeout int) error
 	stopPod() error
 	pausePod() error
 	resumePod() error

--- a/mock_hypervisor.go
+++ b/mock_hypervisor.go
@@ -36,9 +36,11 @@ func (m *mockHypervisor) createPod(podConfig PodConfig) error {
 	return nil
 }
 
-func (m *mockHypervisor) startPod(startCh, stopCh chan struct{}) error {
-	var msg struct{}
-	startCh <- msg
+func (m *mockHypervisor) startPod() error {
+	return nil
+}
+
+func (m *mockHypervisor) waitPod(timeout int) error {
 	return nil
 }
 

--- a/mock_hypervisor_test.go
+++ b/mock_hypervisor_test.go
@@ -19,7 +19,6 @@ package virtcontainers
 import (
 	"fmt"
 	"testing"
-	"time"
 )
 
 func TestMockHypervisorInit(t *testing.T) {
@@ -36,8 +35,7 @@ func TestMockHypervisorInit(t *testing.T) {
 	}
 
 	// wrong config
-	err := m.init(pod)
-	if err == nil {
+	if err := m.init(pod); err == nil {
 		t.Fatal()
 	}
 
@@ -48,8 +46,7 @@ func TestMockHypervisorInit(t *testing.T) {
 	}
 
 	// right config
-	err = m.init(pod)
-	if err != nil {
+	if err := m.init(pod); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -59,8 +56,7 @@ func TestMockHypervisorCreatePod(t *testing.T) {
 
 	config := PodConfig{}
 
-	err := m.createPod(config)
-	if err != nil {
+	if err := m.createPod(config); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -68,24 +64,23 @@ func TestMockHypervisorCreatePod(t *testing.T) {
 func TestMockHypervisorStartPod(t *testing.T) {
 	var m *mockHypervisor
 
-	startCh := make(chan struct{})
-	stopCh := make(chan struct{})
+	if err := m.startPod(); err != nil {
+		t.Fatal(err)
+	}
+}
 
-	go m.startPod(startCh, stopCh)
+func TestMockHypervisorWaitPod(t *testing.T) {
+	var m *mockHypervisor
 
-	select {
-	case <-startCh:
-		break
-	case <-time.After(time.Second):
-		t.Fatal("Timeout waiting for start notification")
+	if err := m.waitPod(0); err != nil {
+		t.Fatal(err)
 	}
 }
 
 func TestMockHypervisorStopPod(t *testing.T) {
 	var m *mockHypervisor
 
-	err := m.stopPod()
-	if err != nil {
+	if err := m.stopPod(); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -93,8 +88,7 @@ func TestMockHypervisorStopPod(t *testing.T) {
 func TestMockHypervisorAddDevice(t *testing.T) {
 	var m *mockHypervisor
 
-	err := m.addDevice(nil, imgDev)
-	if err != nil {
+	if err := m.addDevice(nil, imgDev); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
pod: Improve pod create performances
    
In order to optimize pod creation, this patch does not wait for the
VM after it has been started. Instead, it will wait for it during the
"start" stage. This will allow our VM to be started while the caller
could potentially do other things between create and start. Globally,
this improves the boot time of our containers.