### PR TITLE
api: Refactor RunPod()

### DIFF
--- a/api.go
+++ b/api.go
@@ -276,11 +276,8 @@ func RunPod(podConfig PodConfig) (VCPod, error) {
 		return nil, err
 	}
 
-	// Execute poststart hooks inside netns
-	err = p.network.run(networkNS.NetNsPath, func() error {
-		return p.config.Hooks.postStartHooks()
-	})
-	if err != nil {
+	// Execute poststart hooks
+	if err := p.config.Hooks.postStartHooks(); err != nil {
 		return nil, err
 	}
 

--- a/api.go
+++ b/api.go
@@ -38,6 +38,10 @@ func SetLogger(logger logrus.FieldLogger) {
 // CreatePod is the virtcontainers pod creation entry point.
 // CreatePod creates a pod and its containers. It does not start them.
 func CreatePod(podConfig PodConfig) (VCPod, error) {
+	return createPodFromConfig(podConfig)
+}
+
+func createPodFromConfig(podConfig PodConfig) (*Pod, error) {
 	// Create the pod.
 	p, err := createPod(podConfig)
 	if err != nil {
@@ -168,8 +172,12 @@ func StartPod(podID string) (VCPod, error) {
 		return nil, err
 	}
 
+	return startPod(p)
+}
+
+func startPod(p *Pod) (*Pod, error) {
 	// Start it
-	err = p.start()
+	err := p.start()
 	if err != nil {
 		return nil, err
 	}
@@ -214,14 +222,7 @@ func StopPod(podID string) (VCPod, error) {
 // RunPod is the virtcontainers pod running entry point.
 // RunPod creates a pod and its containers and then it starts them.
 func RunPod(podConfig PodConfig) (VCPod, error) {
-	// Create the pod.
-	p, err := createPod(podConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	// Store it.
-	err = p.storePod()
+	p, err := createPodFromConfig(podConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -232,56 +233,7 @@ func RunPod(podConfig PodConfig) (VCPod, error) {
 	}
 	defer unlockPod(lockFile)
 
-	// Initialize the network.
-	netNsPath, netNsCreated, err := p.network.init(p.config.NetworkConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	// Execute prestart hooks inside netns
-	err = p.network.run(netNsPath, func() error {
-		return p.config.Hooks.preStartHooks()
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Add the network
-	networkNS, err := p.network.add(*p, p.config.NetworkConfig, netNsPath, netNsCreated)
-	if err != nil {
-		return nil, err
-	}
-
-	// Store the network
-	err = p.storage.storePodNetwork(p.id, networkNS)
-	if err != nil {
-		return nil, err
-	}
-
-	// Start the VM
-	err = p.startVM(netNsPath)
-	if err != nil {
-		return nil, err
-	}
-
-	// Start shims
-	if err := p.startShims(); err != nil {
-		return nil, err
-	}
-
-	// Start the pod
-	err = p.start()
-	if err != nil {
-		p.delete()
-		return nil, err
-	}
-
-	// Execute poststart hooks
-	if err := p.config.Hooks.postStartHooks(); err != nil {
-		return nil, err
-	}
-
-	return p, nil
+	return startPod(p)
 }
 
 // ListPod is the virtcontainers pod listing entry point.

--- a/api_test.go
+++ b/api_test.go
@@ -274,7 +274,7 @@ func TestCreatePodFailing(t *testing.T) {
 	config := PodConfig{}
 
 	p, err := CreatePod(config)
-	if p != nil || err == nil {
+	if p.(*Pod) != nil || err == nil {
 		t.Fatal()
 	}
 }


### PR DESCRIPTION
Introduce some private functions to allow RunPod() to behave exactly as
if CreatePod() + StartPod() had been called instead. Removing the
duplicated code ensures the behaviour between the two methods for
creating and starting a pod is consistent.

Note that this change modifies the RunPod() behaviour very slightly -
the locking is now handled later, as was previously being done by
CreatePod() + StartPod().

Fixes #485.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>