### PR TITLE
cni: Fix bug while updating endpoints after scanning net namespace

### DIFF
--- a/cni.go
+++ b/cni.go
@@ -132,6 +132,11 @@ func (n *cni) updateEndpointsFromScan(networkNS *NetworkNamespace) error {
 				prop := endpoint.Properties()
 				prop.DNS = ep.Properties().DNS
 				endpoint.SetProperties(prop)
+
+				switch e := endpoint.(type) {
+				case *VirtualEndpoint:
+					e.NetPair = ep.(*VirtualEndpoint).NetPair
+				}
 				break
 			}
 		}

--- a/cni.go
+++ b/cni.go
@@ -123,7 +123,7 @@ func (n *cni) updateEndpointsFromScan(networkNS *NetworkNamespace) error {
 		return err
 	}
 
-	for idx, endpoint := range endpoints {
+	for _, endpoint := range endpoints {
 		for _, ep := range networkNS.Endpoints {
 			if ep.Name() == endpoint.Name() {
 				// Update endpoint properties with info from
@@ -131,8 +131,7 @@ func (n *cni) updateEndpointsFromScan(networkNS *NetworkNamespace) error {
 				// cannot provide it.
 				prop := endpoint.Properties()
 				prop.DNS = ep.Properties().DNS
-				ep.SetProperties(prop)
-				endpoints[idx] = ep
+				endpoint.SetProperties(prop)
 				break
 			}
 		}


### PR DESCRIPTION
After scanning the network namespace, we need to update the scanned
endpoints with the DNS information, and use the scanned endpoints
thereafter discarding the endpoints structures we had created prior
to calling into the CNI plugin.

There was a bug in the update, which was causing the entire endpoint
structure being assigned back to the scanned endpoints causing us to
lose information from the scan including if a virtual or physical
endpoint was found in the scan.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>