### PR TITLE
Remove redundant "if" checks

### DIFF
--- a/container.go
+++ b/container.go
@@ -225,11 +225,7 @@ func (c *Container) startShim() error {
 
 	c.process = *process
 
-	if err := c.storeProcess(); err != nil {
-		return err
-	}
-
-	return nil
+	return c.storeProcess()
 }
 
 func (c *Container) storeProcess() error {
@@ -806,11 +802,7 @@ func (c *Container) hotplugDrive() error {
 		return err
 	}
 
-	if err := c.setStateFstype(fsType); err != nil {
-		return err
-	}
-
-	return nil
+	return c.setStateFstype(fsType)
 }
 
 // isDriveUsed checks if a drive has been used for container rootfs

--- a/device.go
+++ b/device.go
@@ -477,9 +477,5 @@ func bindDevicetoHost(bdf, hostDriver, vendorDeviceID string) error {
 		"driver-path": bindDriverPath,
 	}).Info("Binding back device to host driver")
 
-	if err := writeToFile(bindDriverPath, []byte(bdf)); err != nil {
-		return err
-	}
-
-	return nil
+	return writeToFile(bindDriverPath, []byte(bdf))
 }

--- a/filesystem.go
+++ b/filesystem.go
@@ -570,11 +570,7 @@ func (fs *filesystem) fetchResource(podSpecific bool, podID, containerID string,
 		return err
 	}
 
-	if err := fs.fetchFile(path, resource, data); err != nil {
-		return err
-	}
-
-	return nil
+	return fs.fetchFile(path, resource, data)
 }
 
 func (fs *filesystem) storePodResource(podID string, resource podResource, data interface{}) error {

--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -960,11 +960,7 @@ func startCCShim(process *vc.Process, shimPath, url string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	return nil
+	return cmd.Run()
 }
 
 func main() {

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -365,11 +365,7 @@ func (h *hyper) createPod(pod *Pod) (err error) {
 		return err
 	}
 
-	if err := pod.hypervisor.addDevice(sharedVolume, fsDev); err != nil {
-		return err
-	}
-
-	return nil
+	return pod.hypervisor.addDevice(sharedVolume, fsDev)
 }
 
 func (h *hyper) capabilities() capabilities {

--- a/pod.go
+++ b/pod.go
@@ -936,11 +936,7 @@ func (p *Pod) stopVM() error {
 		return err
 	}
 
-	if err := p.hypervisor.stopPod(); err != nil {
-		return err
-	}
-
-	return nil
+	return p.hypervisor.stopPod()
 }
 
 // stop stops a pod. The containers that are making the pod
@@ -977,11 +973,7 @@ func (p *Pod) stop() error {
 		return err
 	}
 
-	if err := p.stopSetStates(); err != nil {
-		return err
-	}
-
-	return nil
+	return p.stopSetStates()
 }
 
 func (p *Pod) pause() error {
@@ -989,11 +981,7 @@ func (p *Pod) pause() error {
 		return err
 	}
 
-	if err := p.pauseSetStates(); err != nil {
-		return err
-	}
-
-	return nil
+	return p.pauseSetStates()
 }
 
 func (p *Pod) resume() error {
@@ -1001,11 +989,7 @@ func (p *Pod) resume() error {
 		return err
 	}
 
-	if err := p.resumeSetStates(); err != nil {
-		return err
-	}
-
-	return nil
+	return p.resumeSetStates()
 }
 
 // list lists all pod running on the host.
@@ -1091,11 +1075,7 @@ func (p *Pod) setContainerState(containerID string, state stateString) error {
 
 	// Let container handle its state update
 	cImpl := c.(*Container)
-	if err := cImpl.setContainerState(state); err != nil {
-		return err
-	}
-
-	return nil
+	return cImpl.setContainerState(state)
 }
 
 func (p *Pod) setContainersState(state stateString) error {

--- a/qemu.go
+++ b/qemu.go
@@ -986,11 +986,7 @@ func (q *qemu) hotplugAddDevice(devInfo interface{}, devType deviceType) error {
 		return err
 	}
 
-	if err := q.pod.storage.storeHypervisorState(q.pod.id, q.state); err != nil {
-		return err
-	}
-
-	return nil
+	return q.pod.storage.storeHypervisorState(q.pod.id, q.state)
 }
 
 func (q *qemu) hotplugRemoveDevice(devInfo interface{}, devType deviceType) error {
@@ -998,11 +994,7 @@ func (q *qemu) hotplugRemoveDevice(devInfo interface{}, devType deviceType) erro
 		return err
 	}
 
-	if err := q.pod.storage.storeHypervisorState(q.pod.id, q.state); err != nil {
-		return err
-	}
-
-	return nil
+	return q.pod.storage.storeHypervisorState(q.pod.id, q.state)
 }
 
 func (q *qemu) pausePod() error {


### PR DESCRIPTION
Some "if" checks are redundant, we can remove them and return error
directly instead.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>