### PR TITLE
vendor: update ciao

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,7 +4,7 @@
 [[projects]]
   name = "github.com/ciao-project/ciao"
   packages = ["qemu"]
-  revision = "b2a8a2ecea1318ae28a0861191ec385532491b5a"
+  revision = "c6ea21083acc969871d86f012b465ea09d0cf1c4"
 
 [[projects]]
   name = "github.com/clearcontainers/proxy"

--- a/vendor/github.com/ciao-project/ciao/packages.json
+++ b/vendor/github.com/ciao-project/ciao/packages.json
@@ -86,7 +86,7 @@
 	},
 	"github.com/vishvananda/netlink": {
 		"url": "https://github.com/vishvananda/netlink.git",
-		"version": "1890b34",
+		"version": "c2a3de3",
 		"license": "Apache v2.0"
 	},
 	"github.com/vishvananda/netns": {
@@ -102,6 +102,11 @@
 	"golang.org/x/net": {
 		"url": "https://go.googlesource.com/net",
 		"version": "198e27a",
+		"license": "BSD (3 clause)"
+	},
+	"golang.org/x/sys/unix": {
+		"url": "https://github.com/golang/sys",
+		"version": "665f652",
 		"license": "BSD (3 clause)"
 	},
 	"gopkg.in/yaml.v2": {

--- a/vendor/github.com/ciao-project/ciao/qemu/examples_test.go
+++ b/vendor/github.com/ciao-project/ciao/qemu/examples_test.go
@@ -41,7 +41,7 @@ func Example() {
 	// LaunchCustomQemu should return as soon as the instance has launched as we
 	// are using the --daemonize flag.  It will set up a unix domain socket
 	// called /tmp/qmp-socket that we can use to manage the instance.
-	_, err := qemu.LaunchCustomQemu(context.Background(), "", params, nil, nil)
+	_, err := qemu.LaunchCustomQemu(context.Background(), "", params, nil, nil, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/vendor/github.com/ciao-project/ciao/qemu/qemu.go
+++ b/vendor/github.com/ciao-project/ciao/qemu/qemu.go
@@ -31,6 +31,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"context"
 )
@@ -425,7 +426,8 @@ type NetDevice struct {
 
 	// FDs represents the list of already existing file descriptors to be used.
 	// This is mostly useful for mq support.
-	FDs []*os.File
+	FDs      []*os.File
+	VhostFDs []*os.File
 
 	// VHost enables virtio device emulation from the host kernel instead of from qemu.
 	VHost bool
@@ -511,8 +513,17 @@ func (netdev NetDevice) QemuNetdevParams(config *Config) []string {
 
 	netdevParams = append(netdevParams, netdev.Type.QemuNetdevParam())
 	netdevParams = append(netdevParams, fmt.Sprintf(",id=%s", netdev.ID))
+
 	if netdev.VHost == true {
 		netdevParams = append(netdevParams, ",vhost=on")
+		if len(netdev.VhostFDs) > 0 {
+			var fdParams []string
+			qemuFDs := config.appendFDs(netdev.VhostFDs)
+			for _, fd := range qemuFDs {
+				fdParams = append(fdParams, fmt.Sprintf("%d", fd))
+			}
+			netdevParams = append(netdevParams, fmt.Sprintf(",vhostfds=%s", strings.Join(fdParams, ":")))
+		}
 	}
 
 	if len(netdev.FDs) > 0 {
@@ -1286,7 +1297,8 @@ func LaunchQemu(config Config, logger QMPLog) (string, error) {
 	config.appendKernel()
 	config.appendBios()
 
-	return LaunchCustomQemu(config.Ctx, config.Path, config.qemuParams, config.fds, logger)
+	return LaunchCustomQemu(config.Ctx, config.Path, config.qemuParams,
+		config.fds, nil, logger)
 }
 
 // LaunchCustomQemu can be used to launch a new qemu instance.
@@ -1297,16 +1309,19 @@ func LaunchQemu(config Config, logger QMPLog) (string, error) {
 // signature of this function will not need to change when launch cancellation
 // is implemented.
 //
-// config.qemuParams is a slice of options to pass to qemu-system-x86_64 and fds is a
+// params is a slice of options to pass to qemu-system-x86_64 and fds is a
 // list of open file descriptors that are to be passed to the spawned qemu
-// process.
+// process.  The attrs parameter can be used to control aspects of the
+// newly created qemu process, such as the user and group under which it
+// runs.  It may be nil.
 //
 // This function writes its log output via logger parameter.
 //
 // The function will block until the launched qemu process exits.  "", nil
 // will be returned if the launch succeeds.  Otherwise a string containing
 // the contents of stderr + a Go error object will be returned.
-func LaunchCustomQemu(ctx context.Context, path string, params []string, fds []*os.File, logger QMPLog) (string, error) {
+func LaunchCustomQemu(ctx context.Context, path string, params []string, fds []*os.File,
+	attr *syscall.SysProcAttr, logger QMPLog) (string, error) {
 	if logger == nil {
 		logger = qmpNullLogger{}
 	}
@@ -1322,6 +1337,8 @@ func LaunchCustomQemu(ctx context.Context, path string, params []string, fds []*
 		logger.Infof("Adding extra file %v", fds)
 		cmd.ExtraFiles = fds
 	}
+
+	cmd.SysProcAttr = attr
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr

--- a/vendor/github.com/ciao-project/ciao/qemu/qmp.go
+++ b/vendor/github.com/ciao-project/ciao/qemu/qmp.go
@@ -691,3 +691,34 @@ func (q *QMP) ExecutePCIDeviceAdd(ctx context.Context, blockdevID, devID, driver
 	}
 	return q.executeCommand(ctx, "device_add", args, nil)
 }
+
+// ExecuteVFIODeviceAdd adds a VFIO device to a QEMU instance
+// using the device_add command. devID is the id of the device to add.
+// Must be valid QMP identifier. bdf is the PCI bus-device-function
+// of the pci device.
+func (q *QMP) ExecuteVFIODeviceAdd(ctx context.Context, devID, bdf string) error {
+	args := map[string]interface{}{
+		"id":     devID,
+		"driver": "vfio-pci",
+		"host":   bdf,
+	}
+	return q.executeCommand(ctx, "device_add", args, nil)
+}
+
+// ExecutePCIVFIODeviceAdd adds a VFIO device to a QEMU instance using the device_add command.
+// This function can be used to hot plug VFIO devices on PCI(E) bridges, unlike
+// ExecuteVFIODeviceAdd this function receives the bus and the device address on its parent bus.
+// bus is optional. devID is the id of the device to add.Must be valid QMP identifier. bdf is the
+// PCI bus-device-function of the pci device.
+func (q *QMP) ExecutePCIVFIODeviceAdd(ctx context.Context, devID, bdf, addr, bus string) error {
+	args := map[string]interface{}{
+		"id":     devID,
+		"driver": "vfio-pci",
+		"host":   bdf,
+		"addr":   addr,
+	}
+	if bus != "" {
+		args["bus"] = bus
+	}
+	return q.executeCommand(ctx, "device_add", args, nil)
+}


### PR DESCRIPTION
This new version of ciao has support for VFIO hotplug
directly on pci.0 or on a PCI(E) bridge.

shortlog:
faba87e qmp: Add support for hot plugging VFIO devices on PCI(E) bridges
51ce599 ciao-controller: remove duplicate volume creation paths
1e98990 testutil: Bump sleep times in verify.sh
427fefa ciao-controller: Remove unused volume code
1382a13 workload_bat: Add container workload tests
de0dd64 ciao-controller: Fix a crash in instance creation
2f2a140 Revert "ciao-{controller,launcher,scheduler}: log panics to glog"
fecb4f7 payloads, configuration: remove CNCI admin password field
2ebf459 ciao-deploy: Remove setting of admin CNCI password
2394387 ciao-controller: Remove CNCI password
d75d8b0 workload_bat: Add testing for privileged containers
3a4ff41 tenant_bat: Add testing for tenant permissions
e1bb505 bat: Update for new permissions fields
b4a296d ciao-controller: Check privileged container permissions
dff07a8 ciao-cli, client: Enable privileged container permission for tenant
4a1ad8e ciao-controller: Add tenant permissions
6bfe51b bat, ciao-cli: Expose privileged container control to users
bdabf6b ciao-launcher: Implement privileged containers
19497e1 payloads: Add privileged field to workload requirements
cfe55bf ciao-controller: Update instance name regexp
9f416af datastore: Add unit test coverage of new image resolving
c470b18 ciao-cli, bat: change service field in yaml to type
e000a5e ciao-cli/bat: Use more generic term for source in workloads
67091bf workload_bat: update tests to use new image name source
f6920ee ciao-controller: Resolve source for image ID into a name
fad952f datastore: Add support for retrieving images by name
34e7923 ciao-controller: Rename types.StorageResource.SourceID to Source
fbb077f ciao-controller: Update instance creation code to use new error
b38a9fd ciao-controller: Enforce name regex check in controller
557b3f4 ciao-cli: enforce image name regexp in ciao-cli
f9a142c ciao-deploy: Update image names to match requirements
e818275 ciao-controller: Remove instance volume code
60bbd15 ciao-cli: Remove instance volume controls
ab50c1a ciao-deploy: Set groups appropriately for the master node
aeba29c ciao-deploy: Don't error out if user already exists
ce1e6d9 ciao-deploy: Ensure docker service is running on launcher nodes
cff797e ciao-deploy: Ensure tools' parent directories are present
04f823b ciao-deploy: Check in the cleanup.sh script
555cfc0 ciao-deploy: Enable systemd unit files
1cebbb1 ciao-deploy: Add unit file for osprepare
6708eab ciao-launcher: Add --osprepare and --roles options
2adae65 ciao-scheduler: Add --osprepare option
78bdb6e ciao-controller: Add --osprepare option
979eeb7 ciao-deploy: Set ciao user home dir and shell
dc0f457 ciao-deploy: Copy controller HTTPs certs
53d66bf ciao-deploy: Split up InstallToolsAndCerts
e1ac271 ciao-launcher: Run qemu processes as non-root
0f01fcf networking: Support queues for tap devices
32f0998 ciao-launcher: Run xorriso as non-root
f1b3b23 ciao-deploy: Run launcher as root with limited caps
264a91d ciao-deploy: Specify user for node child processes
c1a0782 ciao-launcher: Process child process user information
e39b026 configuration: Add the ChildUser configuration option
3e82087 qemu: Add a SysProcAttr parameter to CreateCloudInitISO
43c50ac qemu: Add a SysProcAttr parameter to LaunchCustomQemu
612864f ciao-deploy: Run ciao processes as non-root
c9db89b ciao-controller: Remove debug installation dependencies
b581508 osprepare: Remove cephfs as a core dependency
7aaa175 SingleVM: Make verify.sh run on non-prestine clusters
f58f8bc vendor: Revendor github.com/vishvananda/netlink
4f23452 ciao-launcher: Log docker network creation failures
32e72f3 ciao-launcher: Fix log messages in process_stats.go
22e4da6 ciao-launcher: Ensure VNICs get cleaned up after launch failure
f03aa1a ciao-launcher: Remove all files during hard-reset
a86aab3 BAT: Fix a race condition in TestInstanceLimited
5bbaf60 Revert "ciao-deploy: use a generic base clear image for building cnci."
208f740 ciao-deploy: use a generic base clear image for building cnci.
702b331 ciao-{controller,launcher,scheduler}: log panics to glog
dc1a92a bat: Add BAT testing of node ID/hostname workload requirements
86c08ef bat, ciao-cli: Update to reflect new node ID and hostname scheduling
d0aee2a payloads, ciao-scheduler: Allow scheduling by hostname and node id
7e7e331 payloads, ciao-launcher: Send hostname with Ready event
aa07149 ciao-cli, bat: Expose workload requirements to user
db5dcaf ciao-controller: Use payload.WorkloadRequirements in types.Workload
88d1321 ciao-vendor: Copy assembly language files
0c860c9 ciao-controller: Initialise workloads correctly on restart
8c4c6c1 payloads, ciao-{controller, scheduler, launcher}: simplify start payload
d21f575 ciao-controller: Don't allow missing instances to be deleted
dd8a0dd ciao-controller: Mark instances as missing when node is deleted
73d0b66 ciao-controller: Make state transition function a receiver on type
8e53145 ciao-scheduler: remove unused NetworkNode selection code
264203b payloads, ciao-controller: Remove StopFailure
38f80f4 payloads, ciao-controller: Remove unused Restart and RestartFailure
5ecb4a8 payloads: remove unused physical network resource
96d9e8e payloads: remove EstimatedResources from start payload
5aa9803 qemu: Add function to hotplug vfio device
486afac ciao-controller: confirm tenant in base HTTP handler
75bd5df ciao-deploy: Don't upload images as admin for BAT
37c329d testutil: Add a semaphore build script
1e6e7f0 sqlite3db: Fix minor coding style issues
a5385a2 ciao-controller: remove "public" pseudo tenant for workloads
b43b1eb datastore: rename updateWorkload() to addWorkload() and simplify
c0db14f ciao-controller: Store and retrieve workload visibility in database
813a3c5 sqlite3db: Remove tenantID contraint from workload table
6a49592 ciao-controller: Fix reporting level for instance deleted events
9891cb1 ciao-controller: Delete image metadata and data
8224e3d ciao-deploy: Fix missing \n in output
7429faa ciao-controller: refactor startWorkload to reduce complexity.
95b1aed Networking: Add vhost fd support
80c6cc5 ciao-deploy: set TasksMax in systemd service file
73833c2 ciao-controller: start instances in parallel
097a875 ciao-controller: switch to pool allocation for tenantIPs
f2c405e ciao-controller: rework tenant IP allocation
65be72a ciao-controller: report errors properly when setting logDirFlag value
0071afa ciao-controller: add a little logging for image errors
61b3344 ciao-controller: flush log buffer on exit
6f2cf2a Restrict subnet-bits value to a range between 12-30
6b617db singlevm: update the location of verify.sh
fc67855 ciao-deploy: enable mem/disk limits by default
a9e2cff ciao-controller: Remove incorrect closure of request body
dbe75d9 ciao-controller: sqlitedb: initialize Instance StateChange
731e77f ciao-controller: Fix testServersActionStart to wait for DELETE event
68b0dd7 ciao-controller: errcheck: modify unit tests to handle errors
eb83201 ciao-controller: Log whenever a request generates an error
0493ced ciao-controller: errcheck: Ensure all errors are handled or swallowed
77e8c8e ciao-controller: Ensure that instance errors are logged
018c866 datastore: errcheck: Ensure all errors are correctly handled
bbed5b9 client: simplify returned type for quotas
9a7b502 client: split client library by API (& legacy)
171014b ciao-cli: Move client code to it's own package
5b228e3 ciao-cli: Ensure required fields and receivers are exported
692a492 ciao-cli: Split volume client and command handling
40d9fff ciao-cli: split client/command trace functionality
87b016b ciao-cli: Split client/command code for tenants
a0683ae ciao-cli: split quotas functionality
489ebce ciao-cli: split node functionality into client and command code
dd0ac20 ciao-cli: split workload functionality
4638327 ciao-cli: split instance functionality out
45f32a2 ciao-cli: create helper functions for GET/DELETE/POST and parsing
148cf25 ciao-cli: split client code out for image manipulation
4e555a6 ciao-cli: split client code for external IPs
9508a90 ciao-cli: split event code for list and delete
0a3a983 ciao-cli: with a single HTTP endpoint remove unnecessary API
545458d ciao-cli: Improve error handling in core client code
93f436a ciao-cli: remove scopedToken (residual from keystone)
3218b43 ciao-cli: ensure that the field named controllerURL really is a URL
f7aa79c ciao-cli: validate that controllerURL and client certficate are set
ac555b5 ciao-cli: move core client code to new struct
c69798f ciao-controller: do not allow subnet bits to be modified if active instances

fixes #498 

Signed-off-by: Julio Montes <julio.montes@intel.com>