### PR TITLE
WIP: Vhostuser enabling

### DIFF
--- a/container.go
+++ b/container.go
@@ -781,7 +781,7 @@ func (c *Container) hotplugDrive() error {
 	}).Info("Block device detected")
 
 	// Add drive with id as container id
-	devID := makeBlockDevIDForHypervisor(c.id)
+	devID := makeNameID("drive", c.id)
 	drive := Drive{
 		File:   devicePath,
 		Format: "raw",
@@ -817,7 +817,7 @@ func (c *Container) removeDrive() (err error) {
 	if c.isDriveUsed() && c.state.HotpluggedDrive {
 		c.Logger().Info("unplugging block device")
 
-		devID := makeBlockDevIDForHypervisor(c.id)
+		devID := makeNameID("drive", c.id)
 		drive := Drive{
 			ID: devID,
 		}

--- a/device.go
+++ b/device.go
@@ -177,15 +177,6 @@ func newBlockDevice(devInfo DeviceInfo) *BlockDevice {
 	}
 }
 
-func makeBlockDevIDForHypervisor(deviceID string) string {
-	devID := fmt.Sprintf("drive-%s", deviceID)
-	if len(devID) > maxDevIDSize {
-		devID = string(devID[:maxDevIDSize])
-	}
-
-	return devID
-}
-
 func (device *BlockDevice) attach(h hypervisor, c *Container) (err error) {
 	// If VM has not been launched yet, return immediately.
 	// This is because we always want to hotplug block devices.
@@ -206,7 +197,7 @@ func (device *BlockDevice) attach(h hypervisor, c *Container) (err error) {
 	drive := Drive{
 		File:   device.DeviceInfo.HostPath,
 		Format: "raw",
-		ID:     makeBlockDevIDForHypervisor(device.DeviceInfo.ID),
+		ID:     makeNameID("drive", device.DeviceInfo.ID),
 	}
 
 	// Increment the block index for the pod. This is used to determine the name
@@ -246,7 +237,7 @@ func (device BlockDevice) detach(h hypervisor) error {
 		deviceLogger().WithField("device", device.DeviceInfo.HostPath).Info("Unplugging block device")
 
 		drive := Drive{
-			ID: makeBlockDevIDForHypervisor(device.DeviceInfo.ID),
+			ID: makeNameID("drive", device.DeviceInfo.ID),
 		}
 
 		if err := h.hotplugRemoveDevice(drive, blockDev); err != nil {

--- a/device.go
+++ b/device.go
@@ -100,16 +100,16 @@ type DeviceInfo struct {
 	ID string
 }
 
+func deviceLogger() *logrus.Entry {
+	return virtLog.WithField("subsystem", "device")
+}
+
 // VFIODevice is a vfio device meant to be passed to the hypervisor
 // to be used by the Virtual Machine.
 type VFIODevice struct {
 	DeviceType string
 	DeviceInfo DeviceInfo
 	BDF        string
-}
-
-func deviceLogger() *logrus.Entry {
-	return virtLog.WithField("subsystem", "device")
 }
 
 func newVFIODevice(devInfo DeviceInfo) *VFIODevice {
@@ -158,6 +158,48 @@ func (device *VFIODevice) detach(h hypervisor) error {
 }
 
 func (device *VFIODevice) deviceType() string {
+	return device.DeviceType
+}
+
+// VhostUserDeviceType - currently only support two types
+type VhostUserDeviceType string
+
+const (
+	//VhostUserSCSI - SCSI based vhost-user type
+	VhostUserSCSI = "vhost-user-scsi-pci"
+	//VhostUserNet - net based vhost-user type
+	VhostUserNet = "virtio-net-pci"
+)
+
+// VhostUserDevice refers to a vhost-user device implemntation.
+type VhostUserDevice struct {
+	DeviceType    string
+	DeviceInfo    DeviceInfo
+	SocketPath    string
+	HardAddr      string //valid only if VhostUserType is VhostUserNet
+	ID            string
+	VhostUserType VhostUserDeviceType
+}
+
+func (device *VhostUserDevice) attach(h hypervisor, c *Container) (err error) {
+
+	// generate a unique ID to be used for hypervisor commandline fields
+	randBytes, err := generateRandomBytes(8)
+	if err != nil {
+		return err
+	}
+	id := hex.EncodeToString(randBytes)
+
+	device.ID = id
+
+	return h.addDevice(device, vhostuserDev)
+}
+
+func (device *VhostUserDevice) detach(h hypervisor) error {
+	return nil
+}
+
+func (device *VhostUserDevice) deviceType() string {
 	return device.DeviceType
 }
 

--- a/hypervisor.go
+++ b/hypervisor.go
@@ -75,6 +75,9 @@ const (
 
 	// VFIODevice is VFIO device type
 	vfioDev
+
+	// vhostuserDev is a Vhost-user device type
+	vhostuserDev
 )
 
 // Set sets an hypervisor type based on the input string.

--- a/network.go
+++ b/network.go
@@ -17,6 +17,7 @@
 package virtcontainers
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -151,6 +152,17 @@ type PhysicalEndpoint struct {
 	VendorDeviceID     string
 }
 
+// VhostUserEndpoint represents a vhost-user socket based network interface
+type VhostUserEndpoint struct {
+	// Path to the vhost-user socket on the host system
+	SocketPath string
+	// MAC address of the interface
+	HardAddr           string
+	IfaceName          string
+	EndpointProperties NetworkInfo
+	EndpointType       EndpointType
+}
+
 // Properties returns properties for the veth interface in the network pair.
 func (endpoint *VirtualEndpoint) Properties() NetworkInfo {
 	return endpoint.EndpointProperties
@@ -198,6 +210,76 @@ func (endpoint *VirtualEndpoint) Attach(h hypervisor) error {
 func (endpoint *VirtualEndpoint) Detach() error {
 	networkLogger().Info("Detaching virtual endpoint")
 	return xconnectVMNetwork(&(endpoint.NetPair), false)
+}
+
+// Properties returns the properties of the interface.
+func (endpoint *VhostUserEndpoint) Properties() NetworkInfo {
+	return endpoint.EndpointProperties
+}
+
+// Name returns name of the interface.
+func (endpoint *VhostUserEndpoint) Name() string {
+	return endpoint.IfaceName
+}
+
+// HardwareAddr returns the mac address of the vhostuser network interface
+func (endpoint *VhostUserEndpoint) HardwareAddr() string {
+	return endpoint.HardAddr
+}
+
+// Type indentifies the endpoint as a vhostuser endpoint.
+func (endpoint *VhostUserEndpoint) Type() EndpointType {
+	return endpoint.EndpointType
+}
+
+// SetProperties sets the properties of the endpoint.
+func (endpoint *VhostUserEndpoint) SetProperties(properties NetworkInfo) {
+	endpoint.EndpointProperties = properties
+}
+
+// Attach for vhostuser endpoint
+func (endpoint *VhostUserEndpoint) Attach(h hypervisor) error {
+	networkLogger().Info("Attaching vhostuser based endpoint")
+
+	// generate a unique ID to be used for hypervisor commandline fields
+	randBytes, err := generateRandomBytes(8)
+	if err != nil {
+		return err
+	}
+	id := hex.EncodeToString(randBytes)
+
+	d := VhostUserDevice{
+		SocketPath:    endpoint.SocketPath,
+		HardAddr:      endpoint.HardAddr,
+		ID:            id,
+		VhostUserType: VhostUserNet,
+	}
+	return h.addDevice(d, vhostuserDev)
+}
+
+// Detach for vhostuser endpoint
+func (endpoint *VhostUserEndpoint) Detach() error {
+	networkLogger().Info("Detaching vhostuser based endpoint")
+	return nil
+}
+
+// Create a vhostuser endpoint
+func createVhostUserEndpoint(idx int, socket string) (*VhostUserEndpoint, error) {
+
+	if idx < 0 {
+		return &VhostUserEndpoint{}, fmt.Errorf("invalid network endpoint index: %d", idx)
+	}
+
+	// generate mac address
+	hardAddr := net.HardwareAddr{0x02, 0x00, 0xCA, 0xFE, byte(idx >> 8), byte(idx)}
+
+	vhostUserEndpoint := &VhostUserEndpoint{
+		SocketPath:   socket,
+		HardAddr:     hardAddr.String(),
+		IfaceName:    fmt.Sprintf("vhost-%d", idx),
+		EndpointType: VhostUserEndpointType,
+	}
+	return vhostUserEndpoint, nil
 }
 
 // Properties returns the properties of the physical interface.
@@ -260,6 +342,9 @@ const (
 
 	// VirtualEndpointType is the virtual network interface.
 	VirtualEndpointType EndpointType = "virtual"
+
+	// VhostUserEndpointType is the vhostuser network interface.
+	VhostUserEndpointType EndpointType = "vhost-user"
 )
 
 // Set sets an endpoint type based on the input string.
@@ -270,6 +355,9 @@ func (endpointType *EndpointType) Set(value string) error {
 		return nil
 	case "virtual":
 		*endpointType = VirtualEndpointType
+		return nil
+	case "vhost-user":
+		*endpointType = VhostUserEndpointType
 		return nil
 	default:
 		return fmt.Errorf("Unknown endpoint type %s", value)
@@ -283,6 +371,8 @@ func (endpointType *EndpointType) String() string {
 		return string(PhysicalEndpointType)
 	case VirtualEndpointType:
 		return string(VirtualEndpointType)
+	case VhostUserEndpointType:
+		return string(VhostUserEndpointType)
 	default:
 		return ""
 	}
@@ -381,6 +471,16 @@ func (n *NetworkNamespace) UnmarshalJSON(b []byte) error {
 
 			endpoints = append(endpoints, &endpoint)
 			virtLog.Infof("Virtual endpoint unmarshalled [%v]", endpoint)
+
+		case VhostUserEndpointType:
+			var endpoint VhostUserEndpoint
+			err := json.Unmarshal(e.Data, &endpoint)
+			if err != nil {
+				return err
+			}
+
+			endpoints = append(endpoints, &endpoint)
+			virtLog.Infof("VhostUser endpoint unmarshalled [%v]", endpoint)
 
 		default:
 			virtLog.Errorf("Unknown endpoint type received %s\n", e.Type)
@@ -1124,7 +1224,20 @@ func createEndpointsFromScan(networkNSPath string) ([]Endpoint, error) {
 				cnmLogger().WithField("interface", netInfo.Iface.Name).Info("Physical network interface found")
 				endpoint, err = createPhysicalEndpoint(netInfo)
 			} else {
-				endpoint, err = createVirtualNetworkEndpoint(idx, uniqueID, netInfo.Iface.Name)
+				// First pass naive approach: check each non-physical interface to determine if
+				// it is a dummy interface used to notify us the existence of a vhostuser socket
+				// on the host system.  This is a non-marignal sub-optimal solution
+				isVhostuser, socketPath, err := isVhostuserIface(netInfo)
+				if err != nil {
+					return err
+				}
+
+				if isVhostuser {
+					cnmLogger().WithField("interface", netInfo.Iface.Name).Info("Vhostuser network interface found")
+					endpoint, err = createVhostUserEndpoint(idx, socketPath)
+				} else {
+					endpoint, err = createVirtualNetworkEndpoint(idx, uniqueID, netInfo.Iface.Name)
+				}
 			}
 
 			return err
@@ -1165,6 +1278,27 @@ func isPhysicalIface(ifaceName string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// isVhostuserIface checks if an interface is a dummy placeholder
+// for a vhost-user socket
+func isVhostuserIface(netInfo NetworkInfo) (bool, string, error) {
+	if netInfo.Iface.Name == "lo" {
+		return false, "", nil
+	}
+
+	// for now, check for socket file existence at known location.
+	// Identify this be searching for a file in a path which contains
+	// the interfaces IP address.  ie:
+	//  /tmp/vhostuser_<ipv4 address>/vhu.sock
+	for _, addr := range netInfo.Addrs {
+		socketPath := fmt.Sprintf("/tmp/vhostuser_%s/vhu.sock", addr.IPNet.IP)
+		if _, err := os.Stat(socketPath); err == nil {
+			return true, socketPath, nil
+		}
+	}
+
+	return false, "", nil
 }
 
 var sysPCIDevicesPath = "/sys/bus/pci/devices"

--- a/network_test.go
+++ b/network_test.go
@@ -17,6 +17,7 @@
 package virtcontainers
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"reflect"
@@ -193,6 +194,28 @@ func TestIncorrectEndpointTypeString(t *testing.T) {
 	testEndpointTypeString(t, &endpointType, "")
 }
 
+func TestCreateVhostUserEndpoint(t *testing.T) {
+	macAddr := net.HardwareAddr{0x02, 0x00, 0xCA, 0xFE, 0x00, 0x48}
+	idx := 72
+	socket := "/tmp/vhu_192.168.0.1"
+
+	expected := &VhostUserEndpoint{
+		SocketPath:   socket,
+		HardAddr:     macAddr.String(),
+		IfaceName:    fmt.Sprintf("vhost-%d", idx),
+		EndpointType: VhostUserEndpointType,
+	}
+
+	result, err := createVhostUserEndpoint(idx, socket)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if reflect.DeepEqual(result, expected) == false {
+		t.Fatalf("\n\tGot %v\n\tExpecting %v", result, expected)
+	}
+}
+
 func TestCreateVirtualNetworkEndpoint(t *testing.T) {
 	macAddr := net.HardwareAddr{0x02, 0x00, 0xCA, 0xFE, 0x00, 0x04}
 
@@ -297,6 +320,83 @@ func TestCreateNetworkEndpointsFailure(t *testing.T) {
 		t.Fatalf("Should fail because %d endpoints is invalid",
 			numOfEndpoints)
 	}
+}
+
+func TestIsVhostuserIface(t *testing.T) {
+
+	// First test case: search for existing:
+	addresses := []netlink.Addr{
+		netlink.Addr{
+			&net.IPNet{
+				IP:   net.IPv4(192, 168, 0, 2),
+				Mask: net.IPv4Mask(192, 168, 0, 2),
+			}, "addr1", 0, 0, nil, nil, 0, 0,
+		},
+		netlink.Addr{
+			&net.IPNet{
+				IP:   net.IPv4(192, 168, 0, 1),
+				Mask: net.IPv4Mask(192, 168, 0, 1),
+			}, "addr2", 0, 0, nil, nil, 0, 0,
+		},
+	}
+
+	expectedPath := "/tmp/vhostuser_192.168.0.1"
+	expectedFileName := "vhu.sock"
+	expectedResult := fmt.Sprintf("%s/%s", expectedPath, expectedFileName)
+
+	err := os.Mkdir(expectedPath, 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = os.Create(expectedResult)
+	if err != nil {
+		t.Fatal(err)
+	}
+	netinfo := NetworkInfo{
+		Addrs: addresses,
+	}
+
+	isVhost, path, _ := isVhostuserIface(netinfo)
+
+	if isVhost != true {
+		t.Fatalf("Got %+v\nExpecting %+v", isVhost, true)
+		return
+	}
+	if path != expectedResult {
+		t.Fatalf("Got %+v\nExpecting %+v", path, expectedResult)
+		return
+	}
+
+	// Second test case: search doesn't include matching vsock:
+	addressesFalse := []netlink.Addr{
+		netlink.Addr{
+			&net.IPNet{
+				IP:   net.IPv4(192, 168, 0, 4),
+				Mask: net.IPv4Mask(192, 168, 0, 4),
+			}, "addr1", 0, 0, nil, nil, 0, 0,
+		},
+	}
+	netinfoFail := NetworkInfo{
+		Addrs: addressesFalse,
+	}
+
+	isVhost, path, _ = isVhostuserIface(netinfoFail)
+	if isVhost != false {
+		t.Fatalf("Got %+v\nExpecting %+v", isVhost, true)
+		return
+	}
+
+	err = os.Remove(expectedResult)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.Remove(expectedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 }
 
 func TestIsPhysicalIface(t *testing.T) {

--- a/qemu.go
+++ b/qemu.go
@@ -1027,3 +1027,13 @@ func (q *qemu) getPodConsole(podID string) string {
 func (q *qemu) getState() interface{} {
 	return q.state
 }
+
+//Generic function for creating a named-id for passing on the hypervisor commandline
+func makeNameID(namedType string, id string) string {
+	nameID := fmt.Sprintf("%s-%s", namedType, id)
+	if len(nameID) > maxDevIDSize {
+		nameID = string(nameID[:maxDevIDSize])
+	}
+
+	return nameID
+}

--- a/qemu.go
+++ b/qemu.go
@@ -286,6 +286,28 @@ func (q *qemu) appendBlockDevice(devices []ciaoQemu.Device, drive Drive) []ciaoQ
 	return devices
 }
 
+func (q *qemu) appendVhostuserDevice(devices []ciaoQemu.Device, vhostuserDevice VhostUserDevice) []ciaoQemu.Device {
+
+	typeDev := ""
+	// Only two types of vhost-user devices supported: net or scsi
+	if vhostuserDevice.VhostUserType == ciaoQemu.VhostUserNet {
+		typeDev = "net"
+	} else {
+		typeDev = "scsi"
+	}
+
+	devices = append(devices,
+		ciaoQemu.VhostUserDevice{
+			SocketPath:    vhostuserDevice.SocketPath,
+			CharDevID:     makeNameID("char", vhostuserDevice.ID),
+			TypeDevID:     makeNameID(typeDev, vhostuserDevice.ID),
+			Address:       vhostuserDevice.HardAddr,
+			VhostUserType: ciaoQemu.VhostUserDeviceType(vhostuserDevice.VhostUserType),
+		},
+	)
+
+	return devices
+}
 func (q *qemu) appendVFIODevice(devices []ciaoQemu.Device, vfDevice VFIODevice) []ciaoQemu.Device {
 	if vfDevice.BDF == "" {
 		return devices
@@ -1008,6 +1030,9 @@ func (q *qemu) addDevice(devInfo interface{}, devType deviceType) error {
 	case blockDev:
 		drive := devInfo.(Drive)
 		q.qemuConfig.Devices = q.appendBlockDevice(q.qemuConfig.Devices, drive)
+	case vhostuserDev:
+		vhostuserDev := devInfo.(VhostUserDevice)
+		q.qemuConfig.Devices = q.appendVhostuserDevice(q.qemuConfig.Devices, vhostuserDev)
 	case vfioDev:
 		vfDevice := devInfo.(VFIODevice)
 		q.qemuConfig.Devices = q.appendVFIODevice(q.qemuConfig.Devices, vfDevice)

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -121,10 +121,13 @@ func testQemuAppend(t *testing.T, structure interface{}, expected []ciaoQemu.Dev
 		devices = q.appendBlockDevice(devices, s)
 	case VFIODevice:
 		devices = q.appendVFIODevice(devices, s)
+	case VhostUserDevice:
+		devices = q.appendVhostuserDevice(devices, s)
+
 	}
 
 	if reflect.DeepEqual(devices, expected) == false {
-		t.Fatalf("Got %v\nExpecting %v", devices, expected)
+		t.Fatalf("\n\tGot %v\n\tExpecting %v", devices, expected)
 	}
 }
 
@@ -223,6 +226,32 @@ func TestQemuAppendVFIODevice(t *testing.T) {
 	}
 
 	testQemuAppend(t, vfDevice, expectedOut, -1, nestedVM)
+}
+
+func TestQemuAppendVhostuserDevice(t *testing.T) {
+	nestedVM := true
+	socketPath := "nonexistentpath.sock"
+	macAddress := "00:11:22:33:44:55:66"
+	id := "deadbeef"
+
+	expectedOut := []ciaoQemu.Device{
+		ciaoQemu.VhostUserDevice{
+			SocketPath:    socketPath,
+			CharDevID:     fmt.Sprintf("char-%s", id),
+			TypeDevID:     fmt.Sprintf("net-%s", id),
+			Address:       macAddress,
+			VhostUserType: VhostUserNet,
+		},
+	}
+
+	vhostuserDevice := VhostUserDevice{
+		SocketPath:    socketPath,
+		HardAddr:      macAddress,
+		ID:            id,
+		VhostUserType: VhostUserNet,
+	}
+
+	testQemuAppend(t, vhostuserDevice, expectedOut, -1, nestedVM)
 }
 
 func TestQemuAppendFSDevices(t *testing.T) {

--- a/vendor/github.com/ciao-project/ciao/qemu/qemu.go
+++ b/vendor/github.com/ciao-project/ciao/qemu/qemu.go
@@ -704,6 +704,101 @@ func (blkdev BlockDevice) QemuParams(config *Config) []string {
 	return qemuParams
 }
 
+// VhostUserDeviceType is a qemu vhost-user device type.
+type VhostUserDeviceType string
+
+const (
+	//VhostUserSCSI represents a SCSI vhostuser device type
+	VhostUserSCSI = "vhost-user-scsi-pci"
+	//VhostUserNet represents a net vhostuser device type
+	VhostUserNet = "virtio-net-pci"
+	//VhostUserBlk represents a block vhostuser device type
+	VhostUserBlk = "vhost-user-blk-pci"
+)
+
+// VhostUserDevice represents a qemu vhost-user device meant to be passed
+// in to the guest
+type VhostUserDevice struct {
+	SocketPath    string //path to vhostuser socket on host
+	CharDevID     string
+	TypeDevID     string //variable QEMU parameter based on vlaue of VhostUserType
+	Address       string //used for MAC address in net case
+	VhostUserType VhostUserDeviceType
+}
+
+// Valid returns true if there is a valid structure defined for VhostUserDevice
+func (vhostuserDev VhostUserDevice) Valid() bool {
+
+	if vhostuserDev.SocketPath == "" || vhostuserDev.CharDevID == "" {
+		return false
+	}
+
+	switch vhostuserDev.VhostUserType {
+	case VhostUserNet:
+		if vhostuserDev.TypeDevID == "" || vhostuserDev.Address == "" {
+			return false
+		}
+	case VhostUserSCSI:
+		if vhostuserDev.TypeDevID == "" {
+			return false
+		}
+	case VhostUserBlk:
+	default:
+		return false
+	}
+
+	return true
+}
+
+// QemuParams returns the qemu parameters built out of this vhostuser device.
+func (vhostuserDev VhostUserDevice) QemuParams(config *Config) []string {
+	var qemuParams []string
+	var charParams []string
+	var netParams []string
+	var devParams []string
+
+	charParams = append(charParams, "socket")
+	charParams = append(charParams, fmt.Sprintf("id=%s", vhostuserDev.CharDevID))
+	charParams = append(charParams, fmt.Sprintf("path=%s", vhostuserDev.SocketPath))
+
+	switch vhostuserDev.VhostUserType {
+	// if network based vhost device:
+	case VhostUserNet:
+		netParams = append(netParams, "type=vhost-user")
+		netParams = append(netParams, fmt.Sprintf("id=%s", vhostuserDev.TypeDevID))
+		netParams = append(netParams, fmt.Sprintf("chardev=%s", vhostuserDev.CharDevID))
+		netParams = append(netParams, "vhostforce")
+
+		devParams = append(devParams, VhostUserNet)
+		devParams = append(devParams, fmt.Sprintf("netdev=%s", vhostuserDev.TypeDevID))
+		devParams = append(devParams, fmt.Sprintf("mac=%s", vhostuserDev.Address))
+	case VhostUserSCSI:
+		devParams = append(devParams, VhostUserSCSI)
+		devParams = append(devParams, fmt.Sprintf("id=%s", vhostuserDev.TypeDevID))
+		devParams = append(devParams, fmt.Sprintf("chardev=%s", vhostuserDev.CharDevID))
+	case VhostUserBlk:
+		devParams = append(devParams, VhostUserBlk)
+		devParams = append(devParams, "logical_block_size=4096")
+		devParams = append(devParams, "size=512M")
+		devParams = append(devParams, fmt.Sprintf("chardev=%s", vhostuserDev.CharDevID))
+	default:
+		return nil
+	}
+
+	qemuParams = append(qemuParams, "-chardev")
+	qemuParams = append(qemuParams, strings.Join(charParams, ","))
+
+	// if network based vhost device:
+	if vhostuserDev.VhostUserType == VhostUserNet {
+		qemuParams = append(qemuParams, "-netdev")
+		qemuParams = append(qemuParams, strings.Join(netParams, ","))
+	}
+	qemuParams = append(qemuParams, "-device")
+	qemuParams = append(qemuParams, strings.Join(devParams, ","))
+
+	return qemuParams
+}
+
 // VFIODevice represents a qemu vfio device meant for direct access by guest OS.
 type VFIODevice struct {
 	// Bus-Device-Function of device

--- a/vendor/github.com/ciao-project/ciao/qemu/qemu_test.go
+++ b/vendor/github.com/ciao-project/ciao/qemu/qemu_test.go
@@ -21,9 +21,10 @@ import (
 	"os"
 	"strings"
 	"testing"
-
-	"github.com/ciao-project/ciao/testutil"
 )
+
+const agentUUID = "4cb19522-1e18-439a-883a-f9b2a3a95f5e"
+const volumeUUID = "67d86208-b46c-4465-9018-e14187d4010"
 
 func testAppend(structure interface{}, expected string, t *testing.T) {
 	var config Config
@@ -141,14 +142,14 @@ func TestAppendDeviceNetwork(t *testing.T) {
 var deviceNetworkStringMq = "-netdev tap,id=tap0,vhost=on,fds=3:4 -device driver=virtio-net-pci,netdev=tap0,mac=01:02:de:ad:be:ef,disable-modern=true,mq=on,vectors=6"
 
 func TestAppendDeviceNetworkMq(t *testing.T) {
-	foo, _ := ioutil.TempFile(os.TempDir(), "qemu-ciao-test")
-	bar, _ := ioutil.TempFile(os.TempDir(), "qemu-ciao-test")
+	foo, _ := ioutil.TempFile(os.TempDir(), "govmm-qemu-test")
+	bar, _ := ioutil.TempFile(os.TempDir(), "govmm-qemu-test")
 
 	defer func() {
-		foo.Close()
-		bar.Close()
-		os.Remove(foo.Name())
-		os.Remove(bar.Name())
+		_ = foo.Close()
+		_ = bar.Close()
+		_ = os.Remove(foo.Name())
+		_ = os.Remove(bar.Name())
 	}()
 
 	netdev := NetDevice{
@@ -191,14 +192,14 @@ func TestAppendDeviceNetworkPCI(t *testing.T) {
 var deviceNetworkPCIStringMq = "-netdev tap,id=tap0,vhost=on,fds=3:4 -device driver=virtio-net-pci,netdev=tap0,mac=01:02:de:ad:be:ef,bus=/pci-bus/pcie.0,addr=ff,disable-modern=true,mq=on,vectors=6"
 
 func TestAppendDeviceNetworkPCIMq(t *testing.T) {
-	foo, _ := ioutil.TempFile(os.TempDir(), "qemu-ciao-test")
-	bar, _ := ioutil.TempFile(os.TempDir(), "qemu-ciao-test")
+	foo, _ := ioutil.TempFile(os.TempDir(), "govmm-qemu-test")
+	bar, _ := ioutil.TempFile(os.TempDir(), "govmm-qemu-test")
 
 	defer func() {
-		foo.Close()
-		bar.Close()
-		os.Remove(foo.Name())
-		os.Remove(bar.Name())
+		_ = foo.Close()
+		_ = bar.Close()
+		_ = os.Remove(foo.Name())
+		_ = os.Remove(bar.Name())
 	}()
 
 	netdev := NetDevice{
@@ -246,13 +247,13 @@ func TestAppendDeviceSerialPort(t *testing.T) {
 	testAppend(chardev, deviceSerialPortString, t)
 }
 
-var deviceBlockString = "-device virtio-blk,disable-modern=true,drive=hd0,scsi=off,config-wce=off -drive id=hd0,file=/var/lib/ciao.img,aio=threads,format=qcow2,if=none"
+var deviceBlockString = "-device virtio-blk,disable-modern=true,drive=hd0,scsi=off,config-wce=off -drive id=hd0,file=/var/lib/vm.img,aio=threads,format=qcow2,if=none"
 
 func TestAppendDeviceBlock(t *testing.T) {
 	blkdev := BlockDevice{
 		Driver:        VirtioBlock,
 		ID:            "hd0",
-		File:          "/var/lib/ciao.img",
+		File:          "/var/lib/vm.img",
 		AIO:           Threads,
 		Format:        QCOW2,
 		Interface:     NoInterface,
@@ -262,6 +263,40 @@ func TestAppendDeviceBlock(t *testing.T) {
 	}
 
 	testAppend(blkdev, deviceBlockString, t)
+}
+
+var deviceVhostUserNetString = "-chardev socket,id=char1,path=/tmp/nonexistentsocket.socket -netdev type=vhost-user,id=net1,chardev=char1,vhostforce -device virtio-net-pci,netdev=net1,mac=00:11:22:33:44:55"
+var deviceVhostUserSCSIString = "-chardev socket,id=char1,path=/tmp/nonexistentsocket.socket -device vhost-user-scsi-pci,id=scsi1,chardev=char1"
+var deviceVhostUserBlkString = "-chardev socket,id=char2,path=/tmp/nonexistentsocket.socket -device vhost-user-blk-pci,logical_block_size=4096,size=512M,chardev=char2"
+
+func TestAppendDeviceVhostUser(t *testing.T) {
+
+	vhostuserBlkDevice := VhostUserDevice{
+		SocketPath:    "/tmp/nonexistentsocket.socket",
+		CharDevID:     "char2",
+		TypeDevID:     "",
+		Address:       "",
+		VhostUserType: VhostUserBlk,
+	}
+	testAppend(vhostuserBlkDevice, deviceVhostUserBlkString, t)
+
+	vhostuserSCSIDevice := VhostUserDevice{
+		SocketPath:    "/tmp/nonexistentsocket.socket",
+		CharDevID:     "char1",
+		TypeDevID:     "scsi1",
+		Address:       "",
+		VhostUserType: VhostUserSCSI,
+	}
+	testAppend(vhostuserSCSIDevice, deviceVhostUserSCSIString, t)
+
+	vhostuserNetDevice := VhostUserDevice{
+		SocketPath:    "/tmp/nonexistentsocket.socket",
+		CharDevID:     "char1",
+		TypeDevID:     "net1",
+		Address:       "00:11:22:33:44:55",
+		VhostUserType: VhostUserNet,
+	}
+	testAppend(vhostuserNetDevice, deviceVhostUserNetString, t)
 }
 
 var deviceVFIOString = "-device vfio-pci,host=02:10.0"
@@ -390,13 +425,13 @@ func TestAppendQMPSocketServer(t *testing.T) {
 	testAppend(qmp, qmpSocketServerString, t)
 }
 
-var qemuString = "-name cc-qemu -cpu host -uuid " + testutil.AgentUUID
+var qemuString = "-name cc-qemu -cpu host -uuid " + agentUUID
 
 func TestAppendStrings(t *testing.T) {
 	config := Config{
 		Path:     "qemu",
 		Name:     "cc-qemu",
-		UUID:     testutil.AgentUUID,
+		UUID:     agentUUID,
 		CPUModel: "host",
 	}
 


### PR DESCRIPTION
Changes for introducing vhost-user enabling to virtcontainers.

Todo: 

- [x] Need to test within context of virtc and a forked vhost-user CNI driver
- [x] Need to introduce update to vhost-user CNM driver
- [ ] Introduce changes for supporting generic vhost-user handling (for SCSI devices).  Currently just have device interface implemented for vhostuser device type.
- [x] Wait for latest vendor pull for Ciao's QEMU (and then drop hacked vendored changes patch)