### PR TITLE
agent: Return the actual error returned by the agent

### DIFF
--- a/pkg/hyperstart/hyperstart.go
+++ b/pkg/hyperstart/hyperstart.go
@@ -438,13 +438,13 @@ func (h *Hyperstart) CodeFromCmd(cmd string) (uint32, error) {
 }
 
 // CheckReturnedCode ensures we did not receive an ERROR code.
-func (h *Hyperstart) CheckReturnedCode(recvCode, expectedCode uint32) error {
-	if recvCode != expectedCode {
-		if recvCode == ErrorCode {
-			return fmt.Errorf("ERROR received from VM agent")
+func (h *Hyperstart) CheckReturnedCode(recvMsg *DecodedMessage, expectedCode uint32) error {
+	if recvMsg.Code != expectedCode {
+		if recvMsg.Code == ErrorCode {
+			return fmt.Errorf("ERROR received from VM agent, control msg received : %s", recvMsg.Message)
 		}
 
-		return fmt.Errorf("CMD ID received %d not matching expected %d", recvCode, expectedCode)
+		return fmt.Errorf("CMD ID received %d not matching expected %d, control msg received : %s", recvMsg.Code, expectedCode, recvMsg.Message)
 	}
 
 	return nil
@@ -463,7 +463,7 @@ func (h *Hyperstart) WaitForReady() error {
 
 	msg := <-channel
 
-	err = h.CheckReturnedCode(msg.Code, ReadyCode)
+	err = h.CheckReturnedCode(msg, ReadyCode)
 	if err != nil {
 		return err
 	}
@@ -536,7 +536,7 @@ func (h *Hyperstart) SendCtlMessage(cmd string, data []byte) (*DecodedMessage, e
 
 	msgRecv := <-channel
 
-	err = h.CheckReturnedCode(msgRecv.Code, AckCode)
+	err = h.CheckReturnedCode(msgRecv, AckCode)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hyperstart/hyperstart_test.go
+++ b/pkg/hyperstart/hyperstart_test.go
@@ -271,7 +271,7 @@ func TestWriteCtlMessage(t *testing.T) {
 			continue
 		}
 
-		err = h.CheckReturnedCode(reply.Code, AckCode)
+		err = h.CheckReturnedCode(reply, AckCode)
 		if err != nil {
 			t.Fatal()
 		}
@@ -471,10 +471,10 @@ func TestCodeFromCmdUnknown(t *testing.T) {
 	}
 }
 
-func testCheckReturnedCode(t *testing.T, code, refCode uint32) {
+func testCheckReturnedCode(t *testing.T, recvMsg *DecodedMessage, refCode uint32) {
 	h := &Hyperstart{}
 
-	err := h.CheckReturnedCode(code, refCode)
+	err := h.CheckReturnedCode(recvMsg, refCode)
 	if err != nil {
 		t.Fatal()
 	}
@@ -482,14 +482,15 @@ func testCheckReturnedCode(t *testing.T, code, refCode uint32) {
 
 func TestCheckReturnedCodeList(t *testing.T) {
 	for _, code := range CodeList {
-		testCheckReturnedCode(t, code, code)
+		recvMsg := DecodedMessage{Code: code}
+		testCheckReturnedCode(t, &recvMsg, code)
 	}
 }
 
-func testCheckReturnedCodeFailure(t *testing.T, code, refCode uint32) {
+func testCheckReturnedCodeFailure(t *testing.T, recvMsg *DecodedMessage, refCode uint32) {
 	h := &Hyperstart{}
 
-	err := h.CheckReturnedCode(code, refCode)
+	err := h.CheckReturnedCode(recvMsg, refCode)
 	if err == nil {
 		t.Fatal()
 	}
@@ -497,10 +498,11 @@ func testCheckReturnedCodeFailure(t *testing.T, code, refCode uint32) {
 
 func TestCheckReturnedCodeListWrong(t *testing.T) {
 	for _, code := range CodeList {
+		msg := DecodedMessage{Code: code}
 		if code != ReadyCode {
-			testCheckReturnedCodeFailure(t, code, ReadyCode)
+			testCheckReturnedCodeFailure(t, &msg, ReadyCode)
 		} else {
-			testCheckReturnedCodeFailure(t, code, PingCode)
+			testCheckReturnedCodeFailure(t, &msg, PingCode)
 		}
 	}
 }


### PR DESCRIPTION
In case the agent returns an error, we simply return a very
generic message "Error received from agent". This is not very
helpful, the error should include the actual control message
received as well to help debug errors.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>