### PR TITLE
Add support for CPU hot add/remove

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -883,6 +883,7 @@ func TestStatusPodSuccessfulStateReady(t *testing.T) {
 		DefaultMemSz:      defaultMemSzMiB,
 		DefaultBridges:    defaultBridges,
 		BlockDeviceDriver: defaultBlockDriver,
+		DefaultMaxVCPUs:   defaultMaxQemuVCPUs,
 	}
 
 	expectedStatus := PodStatus{
@@ -938,6 +939,7 @@ func TestStatusPodSuccessfulStateRunning(t *testing.T) {
 		DefaultMemSz:      defaultMemSzMiB,
 		DefaultBridges:    defaultBridges,
 		BlockDeviceDriver: defaultBlockDriver,
+		DefaultMaxVCPUs:   defaultMaxQemuVCPUs,
 	}
 
 	expectedStatus := PodStatus{

--- a/container_test.go
+++ b/container_test.go
@@ -26,6 +26,7 @@ import (
 	"syscall"
 	"testing"
 
+	vcAnnotations "github.com/containers/virtcontainers/pkg/annotations"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -280,4 +281,54 @@ func TestCheckPodRunningSuccessful(t *testing.T) {
 	}
 	err := c.checkPodRunning("test_cmd")
 	assert.Nil(t, err, "%v", err)
+}
+
+func TestContainerAddResources(t *testing.T) {
+	assert := assert.New(t)
+
+	c := &Container{}
+	err := c.addResources()
+	assert.Nil(err)
+
+	c.config = &ContainerConfig{Annotations: make(map[string]string)}
+	c.config.Annotations[vcAnnotations.ContainerTypeKey] = string(PodSandbox)
+	err = c.addResources()
+	assert.Nil(err)
+
+	c.config.Annotations[vcAnnotations.ContainerTypeKey] = string(PodContainer)
+	err = c.addResources()
+	assert.Nil(err)
+
+	c.config.Resources = ContainerResources{
+		CPUQuota:  5000,
+		CPUPeriod: 1000,
+	}
+	c.pod = &Pod{hypervisor: &mockHypervisor{}}
+	err = c.addResources()
+	assert.Nil(err)
+}
+
+func TestContainerRemoveResources(t *testing.T) {
+	assert := assert.New(t)
+
+	c := &Container{}
+	err := c.addResources()
+	assert.Nil(err)
+
+	c.config = &ContainerConfig{Annotations: make(map[string]string)}
+	c.config.Annotations[vcAnnotations.ContainerTypeKey] = string(PodSandbox)
+	err = c.removeResources()
+	assert.Nil(err)
+
+	c.config.Annotations[vcAnnotations.ContainerTypeKey] = string(PodContainer)
+	err = c.removeResources()
+	assert.Nil(err)
+
+	c.config.Resources = ContainerResources{
+		CPUQuota:  5000,
+		CPUPeriod: 1000,
+	}
+	c.pod = &Pod{hypervisor: &mockHypervisor{}}
+	err = c.removeResources()
+	assert.Nil(err)
 }

--- a/hyperstart_agent.go
+++ b/hyperstart_agent.go
@@ -424,6 +424,13 @@ func (h *hyper) startOneContainer(pod Pod, c *Container) error {
 		Process: process,
 	}
 
+	if c.config.Resources.CPUQuota != 0 && c.config.Resources.CPUPeriod != 0 {
+		container.Constraints = hyperstart.Constraints{
+			CPUQuota:  c.config.Resources.CPUQuota,
+			CPUPeriod: c.config.Resources.CPUPeriod,
+		}
+	}
+
 	container.SystemMountsInfo.BindMountDev = c.systemMountsInfo.BindMountDev
 
 	if c.state.Fstype != "" {

--- a/hypervisor.go
+++ b/hypervisor.go
@@ -51,6 +51,9 @@ const (
 	defaultBlockDriver = VirtioSCSI
 )
 
+// In some architectures the maximum number of vCPUs depends on the number of physical cores.
+var defaultMaxQemuVCPUs = maxQemuVCPUs()
+
 // deviceType describes a virtualized device type.
 type deviceType int
 
@@ -81,6 +84,9 @@ const (
 
 	// vhostuserDev is a Vhost-user device type
 	vhostuserDev
+
+	// CPUDevice is CPU device type
+	cpuDev
 )
 
 // Set sets an hypervisor type based on the input string.
@@ -179,6 +185,9 @@ type HypervisorConfig struct {
 	// Pod configuration VMConfig.VCPUs overwrites this.
 	DefaultVCPUs uint32
 
+	//DefaultMaxVCPUs specifies the maximum number of vCPUs for the VM.
+	DefaultMaxVCPUs uint32
+
 	// DefaultMem specifies default memory size in MiB for the VM.
 	// Pod configuration VMConfig.Memory overwrites this.
 	DefaultMemSz uint32
@@ -235,6 +244,10 @@ func (conf *HypervisorConfig) valid() (bool, error) {
 
 	if conf.BlockDeviceDriver == "" {
 		conf.BlockDeviceDriver = defaultBlockDriver
+	}
+
+	if conf.DefaultMaxVCPUs == 0 {
+		conf.DefaultMaxVCPUs = defaultMaxQemuVCPUs
 	}
 
 	return true, nil

--- a/hypervisor_test.go
+++ b/hypervisor_test.go
@@ -181,6 +181,7 @@ func TestHypervisorConfigDefaults(t *testing.T) {
 		DefaultMemSz:      defaultMemSzMiB,
 		DefaultBridges:    defaultBridges,
 		BlockDeviceDriver: defaultBlockDriver,
+		DefaultMaxVCPUs:   defaultMaxQemuVCPUs,
 	}
 	if reflect.DeepEqual(hypervisorConfig, hypervisorConfigDefaultsExpected) == false {
 		t.Fatal()

--- a/pkg/hyperstart/types.go
+++ b/pkg/hyperstart/types.go
@@ -202,6 +202,16 @@ type SystemMountsInfo struct {
 	DevShmSize int `json:"devShmSize"`
 }
 
+// Constraints describes the constrains for a container
+type Constraints struct {
+	// CPUQuota specifies the total amount of time in microseconds
+	// The number of microseconds per CPUPeriod that the container is guaranteed CPU access
+	CPUQuota int64
+
+	// CPUPeriod specifies the CPU CFS scheduler period of time in microseconds
+	CPUPeriod uint64
+}
+
 // Container describes a container running on a pod.
 type Container struct {
 	ID               string              `json:"id"`
@@ -216,6 +226,7 @@ type Container struct {
 	RestartPolicy    string              `json:"restartPolicy"`
 	Initialize       bool                `json:"initialize"`
 	SystemMountsInfo SystemMountsInfo    `json:"systemMountsInfo"`
+	Constraints      Constraints         `json:"constraints"`
 }
 
 // IPAddress describes an IP address and its network mask.

--- a/qemu.go
+++ b/qemu.go
@@ -35,10 +35,18 @@ type qmpChannel struct {
 	qmp  *govmmQemu.QMP
 }
 
+// CPUDevice represents a CPU device which was hot-added in a running VM
+type CPUDevice struct {
+	// ID is used to identify this CPU in the hypervisor options.
+	ID string
+}
+
 // QemuState keeps Qemu's state
 type QemuState struct {
 	Bridges []Bridge
-	UUID    string
+	// HotpluggedCPUs is the list of CPUs that were hot-added
+	HotpluggedVCPUs []CPUDevice
+	UUID            string
 }
 
 // qemu is an Hypervisor interface implementation for the Linux qemu hypervisor.
@@ -634,8 +642,11 @@ func (q *qemu) hotplugDevice(devInfo interface{}, devType deviceType, op operati
 	case blockDev:
 		drive := devInfo.(Drive)
 		return q.hotplugBlockDevice(drive, op)
+	case cpuDev:
+		vcpus := devInfo.(uint32)
+		return q.hotplugCPUs(vcpus, op)
 	default:
-		return fmt.Errorf("Only hotplug for block devices supported for now, provided device type : %v", devType)
+		return fmt.Errorf("cannot hotplug device: unsupported device type '%v'", devType)
 	}
 }
 
@@ -650,6 +661,104 @@ func (q *qemu) hotplugAddDevice(devInfo interface{}, devType deviceType) error {
 func (q *qemu) hotplugRemoveDevice(devInfo interface{}, devType deviceType) error {
 	if err := q.hotplugDevice(devInfo, devType, removeDevice); err != nil {
 		return err
+	}
+
+	return q.pod.storage.storeHypervisorState(q.pod.id, q.state)
+}
+
+func (q *qemu) hotplugCPUs(vcpus uint32, op operation) error {
+	if vcpus == 0 {
+		q.Logger().Warnf("cannot hotplug 0 vCPUs")
+		return nil
+	}
+
+	defer func(qemu *qemu) {
+		if q.qmpMonitorCh.qmp != nil {
+			q.qmpMonitorCh.qmp.Shutdown()
+		}
+	}(q)
+
+	qmp, err := q.qmpSetup()
+	if err != nil {
+		return err
+	}
+
+	q.qmpMonitorCh.qmp = qmp
+
+	if op == addDevice {
+		return q.hotplugAddCPUs(vcpus)
+	}
+
+	return q.hotplugRemoveCPUs(vcpus)
+}
+
+func (q *qemu) hotplugAddCPUs(amount uint32) error {
+	currentVCPUs := q.qemuConfig.SMP.CPUs + uint32(len(q.state.HotpluggedVCPUs))
+
+	// Don't exceed the maximum amount of vCPUs
+	if currentVCPUs+amount > q.config.DefaultMaxVCPUs {
+		return fmt.Errorf("Unable to hotplug %d CPUs, currently this POD has %d CPUs and the maximum amount of CPUs is %d",
+			amount, currentVCPUs, q.config.DefaultMaxVCPUs)
+	}
+
+	// get the list of hotpluggable CPUs
+	hotpluggableVCPUs, err := q.qmpMonitorCh.qmp.ExecuteQueryHotpluggableCPUs(q.qmpMonitorCh.ctx)
+	if err != nil {
+		return fmt.Errorf("failed to query hotpluggable CPUs: %v", err)
+	}
+
+	var hotpluggedVCPUs uint32
+	for _, hc := range hotpluggableVCPUs {
+		// qom-path is the path to the CPU, non-empty means that this CPU is already in use
+		if hc.QOMPath != "" {
+			continue
+		}
+
+		// CPU type, i.e host-x86_64-cpu
+		driver := hc.Type
+		cpuID := fmt.Sprintf("cpu-%d", len(q.state.HotpluggedVCPUs))
+		socketID := fmt.Sprintf("%d", hc.Properties.Socket)
+		coreID := fmt.Sprintf("%d", hc.Properties.Core)
+		threadID := fmt.Sprintf("%d", hc.Properties.Thread)
+		if err := q.qmpMonitorCh.qmp.ExecuteCPUDeviceAdd(q.qmpMonitorCh.ctx, driver, cpuID, socketID, coreID, threadID); err != nil {
+			// don't fail, let's try with other CPU
+			continue
+		}
+
+		// a new vCPU was added, update list of hotplugged vCPUs and check if all vCPUs were added
+		q.state.HotpluggedVCPUs = append(q.state.HotpluggedVCPUs, CPUDevice{cpuID})
+		hotpluggedVCPUs++
+		if hotpluggedVCPUs == amount {
+			// All vCPUs were hotplugged
+			return q.pod.storage.storeHypervisorState(q.pod.id, q.state)
+		}
+	}
+
+	// All vCPUs were NOT hotplugged
+	if err := q.pod.storage.storeHypervisorState(q.pod.id, q.state); err != nil {
+		q.Logger().Errorf("failed to save hypervisor state after hotplug %d vCPUs: %v", hotpluggedVCPUs, err)
+	}
+
+	return fmt.Errorf("failed to hot add vCPUs: only %d vCPUs of %d were added", hotpluggedVCPUs, amount)
+}
+
+func (q *qemu) hotplugRemoveCPUs(amount uint32) error {
+	hotpluggedVCPUs := uint32(len(q.state.HotpluggedVCPUs))
+
+	// we can only remove hotplugged vCPUs
+	if amount > hotpluggedVCPUs {
+		return fmt.Errorf("Unable to remove %d CPUs, currently there are only %d hotplugged CPUs", amount, hotpluggedVCPUs)
+	}
+
+	for i := uint32(0); i < amount; i++ {
+		// get the last vCPUs and try to remove it
+		cpu := q.state.HotpluggedVCPUs[len(q.state.HotpluggedVCPUs)-1]
+		if err := q.qmpMonitorCh.qmp.ExecuteDeviceDel(q.qmpMonitorCh.ctx, cpu.ID); err != nil {
+			return fmt.Errorf("failed to hotunplug CPUs, only %d CPUs were hotunplugged: %v", i, err)
+		}
+
+		// remove from the list the vCPU hotunplugged
+		q.state.HotpluggedVCPUs = q.state.HotpluggedVCPUs[:len(q.state.HotpluggedVCPUs)-1]
 	}
 
 	return q.pod.storage.storeHypervisorState(q.pod.id, q.state)

--- a/qemu_amd64.go
+++ b/qemu_amd64.go
@@ -78,6 +78,11 @@ var supportedQemuMachines = []govmmQemu.Machine{
 	},
 }
 
+// returns the maximum number of vCPUs supported
+func maxQemuVCPUs() uint32 {
+	return uint32(240)
+}
+
 func newQemuArch(machineType string) qemuArch {
 	if machineType == "" {
 		machineType = defaultQemuMachineType

--- a/qemu_arch_base.go
+++ b/qemu_arch_base.go
@@ -213,6 +213,7 @@ func (q *qemuArchBase) cpuTopology(vcpus uint32) govmmQemu.SMP {
 		Sockets: vcpus,
 		Cores:   defaultCores,
 		Threads: defaultThreads,
+		MaxCPUs: defaultMaxQemuVCPUs,
 	}
 
 	return smp

--- a/qemu_arch_base_test.go
+++ b/qemu_arch_base_test.go
@@ -174,6 +174,7 @@ func TestQemuArchBaseCPUTopology(t *testing.T) {
 		Sockets: vcpus,
 		Cores:   defaultCores,
 		Threads: defaultThreads,
+		MaxCPUs: defaultMaxQemuVCPUs,
 	}
 
 	smp := qemuArchBase.cpuTopology(vcpus)

--- a/qemu_arm64.go
+++ b/qemu_arm64.go
@@ -16,7 +16,11 @@
 
 package virtcontainers
 
-import govmmQemu "github.com/intel/govmm/qemu"
+import (
+	"runtime"
+
+	govmmQemu "github.com/intel/govmm/qemu"
+)
 
 type qemuArm64 struct {
 	// inherit from qemuArchBase, overwrite methods if needed
@@ -44,6 +48,11 @@ var supportedQemuMachines = []govmmQemu.Machine{
 		Type:    QemuVirt,
 		Options: defaultQemuMachineOptions,
 	},
+}
+
+// returns the maximum number of vCPUs supported
+func maxQemuVCPUs() uint32 {
+	return uint32(runtime.NumCPU())
 }
 
 func newQemuArch(machineType string) qemuArch {

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -143,6 +143,7 @@ func TestQemuCPUTopology(t *testing.T) {
 		Sockets: uint32(vcpus),
 		Cores:   defaultCores,
 		Threads: defaultThreads,
+		MaxCPUs: defaultMaxQemuVCPUs,
 	}
 
 	vmConfig := Resources{

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -37,6 +37,7 @@ func newQemuConfig() HypervisorConfig {
 		DefaultMemSz:      defaultMemSzMiB,
 		DefaultBridges:    defaultBridges,
 		BlockDeviceDriver: defaultBlockDriver,
+		DefaultMaxVCPUs:   defaultMaxQemuVCPUs,
 	}
 }
 

--- a/utils.go
+++ b/utils.go
@@ -96,3 +96,18 @@ func writeToFile(path string, data []byte) error {
 
 	return nil
 }
+
+// ConstraintsToVCPUs converts CPU quota and period to vCPUs
+func ConstraintsToVCPUs(quota int64, period uint64) uint {
+	if quota != 0 && period != 0 {
+		// Use some math magic to round up to the nearest whole vCPU
+		// (that is, a partial part of a quota request ends up assigning
+		// a whole vCPU, for instance, a request of 1.5 'cpu quotas'
+		// will give 2 vCPUs).
+		// This also has the side effect that we will always allocate
+		// at least 1 vCPU.
+		return uint((uint64(quota) + (period - 1)) / period)
+	}
+
+	return 0
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -162,3 +162,20 @@ func TestWriteToFile(t *testing.T) {
 
 	assert.True(t, reflect.DeepEqual(testData, data))
 }
+
+func TestConstraintsToVCPUs(t *testing.T) {
+	assert := assert.New(t)
+
+	vcpus := ConstraintsToVCPUs(0, 100)
+	assert.Zero(vcpus)
+
+	vcpus = ConstraintsToVCPUs(100, 0)
+	assert.Zero(vcpus)
+
+	expectedVCPUs := uint(4)
+	vcpus = ConstraintsToVCPUs(4000, 1000)
+	assert.Equal(expectedVCPUs, vcpus)
+
+	vcpus = ConstraintsToVCPUs(4000, 1200)
+	assert.Equal(expectedVCPUs, vcpus)
+}


### PR DESCRIPTION
For hot-add, we have to know what CPUs are available using
`query-hotpluggable-cpus`.
For hot-remove we only need to know the CPUs ids in order to avoid the
use of 1 query 1 cpu, hotplugAddCPUs and hotRemoveCPUs receive the
total amount of CPUs to hot add or hot remove.

depending of the container's state, pod's resources are updated.
for example, if the container has a CPU constraint of 4 vCPU and it is stopped,
then these 4 vCPUs are removed.
another example, if the container is ready to be started and it has a CPU
constraint of 3 vCPUs, 3 vCPUs are added and the constraint is sent to the
agent to limit CPU usage of the container.
With this patch the fractional part of the CPU constraint is also honoured,
for example, if the container has a CPU constraint of 5.5, then 6 vCPUs are
added to the POD and a constraint of 5.5 CPUs is applied to the container

fixes #511

Signed-off-by: Julio Montes <julio.montes@intel.com>