### PR TITLE
Network refactoring/cleanup

### DIFF
--- a/cni.go
+++ b/cni.go
@@ -70,7 +70,7 @@ func convertCNIResult(cniResult cniTypes.Result) (NetworkInfo, error) {
 	}
 }
 
-func (n *cni) invokePlugins(pod Pod, networkNS *NetworkNamespace) (*NetworkInfo, error) {
+func (n *cni) invokePluginsAdd(pod Pod, networkNS *NetworkNamespace) (*NetworkInfo, error) {
 	netPlugin, err := cniPlugin.NewNetworkPlugin()
 	if err != nil {
 		return nil, err
@@ -97,7 +97,7 @@ func (n *cni) invokePlugins(pod Pod, networkNS *NetworkNamespace) (*NetworkInfo,
 	return &netInfo, nil
 }
 
-func (n *cni) deleteInterfaces(pod Pod, networkNS NetworkNamespace) error {
+func (n *cni) invokePluginsDelete(pod Pod, networkNS NetworkNamespace) error {
 	netPlugin, err := cniPlugin.NewNetworkPlugin()
 	if err != nil {
 		return err
@@ -148,7 +148,7 @@ func (n *cni) add(pod Pod, config NetworkConfig, netNsPath string, netNsCreated 
 		NetNsCreated: netNsCreated,
 	}
 
-	netInfo, err := n.invokePlugins(pod, &networkNS)
+	netInfo, err := n.invokePluginsAdd(pod, &networkNS)
 	if err != nil {
 		return NetworkNamespace{}, err
 	}
@@ -171,7 +171,7 @@ func (n *cni) remove(pod Pod, networkNS NetworkNamespace) error {
 		return err
 	}
 
-	if err := n.deleteInterfaces(pod, networkNS); err != nil {
+	if err := n.invokePluginsDelete(pod, networkNS); err != nil {
 		return err
 	}
 

--- a/cni.go
+++ b/cni.go
@@ -26,6 +26,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// CniPrimaryInterface Name chosen for the primary interface
+// If CNI ever support multiple primary interfaces this should be revisited
+const CniPrimaryInterface = "eth0"
+
 // cni is a network implementation for the CNI plugin.
 type cni struct{}
 
@@ -66,84 +70,63 @@ func convertCNIResult(cniResult cniTypes.Result) (NetworkInfo, error) {
 	}
 }
 
-func (n *cni) addVirtInterfaces(pod Pod, networkNS *NetworkNamespace) error {
+func (n *cni) invokePlugins(pod Pod, networkNS *NetworkNamespace) (*NetworkInfo, error) {
+	netPlugin, err := cniPlugin.NewNetworkPlugin()
+	if err != nil {
+		return nil, err
+	}
+
+	// Note: In the case of multus or cni-genie this will return only the results
+	// corresponding to the primary interface. The remaining results need to be
+	// derived
+	result, err := netPlugin.AddNetwork(pod.id, networkNS.NetNsPath, CniPrimaryInterface)
+	if err != nil {
+		return nil, err
+	}
+
+	netInfo, err := convertCNIResult(result)
+	if err != nil {
+		return nil, err
+	}
+
+	// We do not care about this for now but
+	// If present, the CNI DNS result has to be updated in resolv.conf
+	// if the kubelet has not supplied it already
+	n.Logger().Infof("AddNetwork results %s", result.String())
+
+	return &netInfo, nil
+}
+
+func (n *cni) deleteInterfaces(pod Pod, networkNS NetworkNamespace) error {
 	netPlugin, err := cniPlugin.NewNetworkPlugin()
 	if err != nil {
 		return err
 	}
 
-	for idx, endpoint := range networkNS.Endpoints {
-		virtualEndpoint, ok := endpoint.(*VirtualEndpoint)
-		if !ok {
-			continue
-		}
-
-		result, err := netPlugin.AddNetwork(pod.id, networkNS.NetNsPath, virtualEndpoint.Name())
-		if err != nil {
-			return err
-		}
-
-		netInfo, err := convertCNIResult(result)
-		if err != nil {
-			return err
-		}
-
-		networkNS.Endpoints[idx].SetProperties(netInfo)
-
-		n.Logger().Infof("AddNetwork results %s", result.String())
-	}
-
-	return nil
-}
-
-func (n *cni) deleteVirtInterfaces(pod Pod, networkNS NetworkNamespace) error {
-	netPlugin, err := cniPlugin.NewNetworkPlugin()
+	err = netPlugin.RemoveNetwork(pod.id, networkNS.NetNsPath, CniPrimaryInterface)
 	if err != nil {
 		return err
 	}
 
-	for _, endpoint := range networkNS.Endpoints {
-		virtualEndpoint, ok := endpoint.(*VirtualEndpoint)
-		if !ok {
-			continue
-		}
-
-		err := netPlugin.RemoveNetwork(pod.id, networkNS.NetNsPath, virtualEndpoint.NetPair.VirtIface.Name)
-		if err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 
-func (n *cni) updateEndpointsFromScan(networkNS *NetworkNamespace) error {
+func (n *cni) updateEndpointsFromScan(networkNS *NetworkNamespace, netInfo *NetworkInfo) error {
 	endpoints, err := createEndpointsFromScan(networkNS.NetNsPath)
 	if err != nil {
 		return err
 	}
 
 	for _, endpoint := range endpoints {
-		for _, ep := range networkNS.Endpoints {
-			if ep.Name() == endpoint.Name() {
-				// Update endpoint properties with info from
-				// the scan. Do not update DNS since the scan
-				// cannot provide it.
-				prop := endpoint.Properties()
-				prop.DNS = ep.Properties().DNS
-				endpoint.SetProperties(prop)
-
-				switch e := endpoint.(type) {
-				case *VirtualEndpoint:
-					e.NetPair = ep.(*VirtualEndpoint).NetPair
-				}
-				break
-			}
+		if CniPrimaryInterface == endpoint.Name() {
+			prop := endpoint.Properties()
+			prop.DNS = netInfo.DNS
+			endpoint.SetProperties(prop)
+			break
 		}
 	}
 
 	networkNS.Endpoints = endpoints
-
 	return nil
 }
 
@@ -159,22 +142,18 @@ func (n *cni) run(networkNSPath string, cb func() error) error {
 
 // add adds all needed interfaces inside the network namespace for the CNI network.
 func (n *cni) add(pod Pod, config NetworkConfig, netNsPath string, netNsCreated bool) (NetworkNamespace, error) {
-	endpoints, err := createNetworkEndpoints(config.NumInterfaces)
-	if err != nil {
-		return NetworkNamespace{}, err
-	}
 
 	networkNS := NetworkNamespace{
 		NetNsPath:    netNsPath,
 		NetNsCreated: netNsCreated,
-		Endpoints:    endpoints,
 	}
 
-	if err := n.addVirtInterfaces(pod, &networkNS); err != nil {
+	netInfo, err := n.invokePlugins(pod, &networkNS)
+	if err != nil {
 		return NetworkNamespace{}, err
 	}
 
-	if err := n.updateEndpointsFromScan(&networkNS); err != nil {
+	if err := n.updateEndpointsFromScan(&networkNS, netInfo); err != nil {
 		return NetworkNamespace{}, err
 	}
 
@@ -192,7 +171,7 @@ func (n *cni) remove(pod Pod, networkNS NetworkNamespace) error {
 		return err
 	}
 
-	if err := n.deleteVirtInterfaces(pod, networkNS); err != nil {
+	if err := n.deleteInterfaces(pod, networkNS); err != nil {
 		return err
 	}
 

--- a/network.go
+++ b/network.go
@@ -580,6 +580,7 @@ func getLinkByName(netHandle *netlink.Handle, name string, expectedLink netlink.
 	return nil, fmt.Errorf("Incorrect link type %s, expecting %s", link.Type(), expectedLink.Type())
 }
 
+// The endpoint type should dictate how the connection needs to be made
 func xconnectVMNetwork(netPair *NetworkInterfacePair, connect bool) error {
 	switch DefaultNetInterworkingModel {
 	case ModelBridged:
@@ -1021,6 +1022,9 @@ func createVirtualNetworkEndpoint(idx int, uniqueID string, ifName string) (*Vir
 	hardAddr := net.HardwareAddr{0x02, 0x00, 0xCA, 0xFE, byte(idx >> 8), byte(idx)}
 
 	endpoint := &VirtualEndpoint{
+		// TODO This is too specific. We may need to create multiple
+		// end point types here and then decide how to connect them
+		// at the time of hypervisor attach and not here
 		NetPair: NetworkInterfacePair{
 			ID:   fmt.Sprintf("%s-%d", uniqueID, idx),
 			Name: fmt.Sprintf("br%d", idx),
@@ -1141,6 +1145,12 @@ func createEndpointsFromScan(networkNSPath string) ([]Endpoint, error) {
 		}
 
 		if err := doNetNS(networkNSPath, func(_ ns.NetNS) error {
+
+			// TODO: This is the incoming interface
+			// based on the incoming interface we should create
+			// an appropriate EndPoint based on interface type
+			// This should be a switch
+
 			// Check if interface is a physical interface. Do not create
 			// tap interface/bridge if it is.
 			isPhysical, err := isPhysicalIface(netInfo.Iface.Name)

--- a/network_test.go
+++ b/network_test.go
@@ -211,10 +211,13 @@ func TestCreateVirtualNetworkEndpoint(t *testing.T) {
 		EndpointType: VirtualEndpointType,
 	}
 
-	result, err := createVirtualNetworkEndpoint(4, "uniqueTestID", "")
+	result, err := createVirtualNetworkEndpoint(4, "")
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// the resulting ID  will be random - so let's overwrite to test the rest of the flow
+	result.NetPair.ID = "uniqueTestID-4"
 
 	if reflect.DeepEqual(result, expected) == false {
 		t.Fatal()
@@ -239,10 +242,13 @@ func TestCreateVirtualNetworkEndpointChooseIfaceName(t *testing.T) {
 		EndpointType: VirtualEndpointType,
 	}
 
-	result, err := createVirtualNetworkEndpoint(4, "uniqueTestID", "eth1")
+	result, err := createVirtualNetworkEndpoint(4, "eth1")
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// the resulting ID will be random - so let's overwrite to test the rest of the flow
+	result.NetPair.ID = "uniqueTestID-4"
 
 	if reflect.DeepEqual(result, expected) == false {
 		t.Fatal()
@@ -251,25 +257,18 @@ func TestCreateVirtualNetworkEndpointChooseIfaceName(t *testing.T) {
 
 func TestCreateVirtualNetworkEndpointInvalidArgs(t *testing.T) {
 	type endpointValues struct {
-		idx      int
-		uniqueID string
-		ifName   string
+		idx    int
+		ifName string
 	}
 
 	// all elements are expected to result in failure
 	failingValues := []endpointValues{
-		{-1, "foo", "bar"},
-		{-1, "foo", ""},
-		{-3, "foo", "bar"},
-		{-3, "foo", ""},
-		{0, "", "bar"},
-		{0, "", ""},
-		{1, "", "bar"},
-		{1, "", ""},
+		{-1, "bar"},
+		{-1, ""},
 	}
 
 	for _, d := range failingValues {
-		result, err := createVirtualNetworkEndpoint(d.idx, d.uniqueID, d.ifName)
+		result, err := createVirtualNetworkEndpoint(d.idx, d.ifName)
 		if err == nil {
 			t.Fatalf("expected invalid endpoint for %v, got %v", d, result)
 		}

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -268,6 +268,8 @@ func networkConfig(ocispec CompatOCISpec) (vc.NetworkConfig, error) {
 			continue
 		}
 
+		// Bug: This is not the interface count
+		// It is just an indication that you need networking
 		netConf.NumInterfaces = 1
 		if n.Path != "" {
 			netConf.NetNSPath = n.Path


### PR DESCRIPTION
Some of the function naming and process around CNI's add() were overly complicated and/or obfuscated.
    
    Initially, the CNI "add" function would create a virtual device which
    would then be used to store the results obtained from calling the CNI
    plugin.  This patch removes that, and instead keeps the netinfo results
    for application to the endpoint device when we identify it post-scan.
    
    Renamed addVirtInterfaces and deleteVirtInterfaces functions.
    add is now invokePlugins, since this is what is carried out, and
    the "virt" is removed from delete since there is nothing specific
    to virtual in this case (it just invokes delete command to the plugin).
    The function prototype for invokePlugins was also modified to return
    the resulting netinfo from the CNI call, allowing the DNS information
    to be used when updating the endpoints after the network namespace
    is scanned.
    
    The logic has been updated to reflect that a pod will only have a single
    network namespace.  This simplified the code in a couple of locations,
    since we know the initial numInterfaces is always '1' - no need to loop.
    This single interfaces is described as 'CniPrimaryInterface' in the
    sources.

-Also, fixed bug in how uniqueID was used for createVirtualNetworkEndpoint.
-Rewrote network scan portion to avoid looping twice unnecessarily.