### PR TITLE
agent: Check for -v /dev:/dev case

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetAnnotations(t *testing.T) {
@@ -47,6 +49,28 @@ func TestGetAnnotations(t *testing.T) {
 			t.Fatalf("Expecting ['%s']='%s', Got ['%s']='%s'\n", k, annotations[k], k, v)
 		}
 	}
+}
+
+func TestContainerSystemMountsInfo(t *testing.T) {
+	mounts := []Mount{
+		{
+			Source:      "/dev",
+			Destination: "/dev",
+			Type:        "bind",
+		},
+	}
+
+	c := Container{
+		mounts: mounts,
+	}
+
+	assert.False(t, c.systemMountsInfo.BindMountDev)
+	c.getSystemMountInfo()
+	assert.True(t, c.systemMountsInfo.BindMountDev)
+
+	c.mounts[0].Type = "tmpfs"
+	c.getSystemMountInfo()
+	assert.False(t, c.systemMountsInfo.BindMountDev)
 }
 
 func TestContainerPod(t *testing.T) {

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -461,6 +461,8 @@ func (h *hyper) startOneContainer(pod Pod, c Container) error {
 		Process: process,
 	}
 
+	container.SystemMountsInfo.BindMountDev = c.systemMountsInfo.BindMountDev
+
 	if c.state.Fstype != "" {
 		driveName, err := getVirtDriveName(c.state.BlockIndex)
 		if err != nil {

--- a/pkg/hyperstart/types.go
+++ b/pkg/hyperstart/types.go
@@ -173,19 +173,30 @@ type Process struct {
 	Rlimits []Rlimit `json:"rlimits,omitempty"`
 }
 
+// SystemMountsInfo describes additional information for system mounts that the agent
+// needs to handle
+type SystemMountsInfo struct {
+	// Indicates if /dev has been passed as a bind mount for the host /dev
+	BindMountDev bool `json:"bindMountDev"`
+
+	// Size of /dev/shm assigned on the host.
+	DevShmSize int `json:"devShmSize"`
+}
+
 // Container describes a container running on a pod.
 type Container struct {
-	ID            string              `json:"id"`
-	Rootfs        string              `json:"rootfs"`
-	Fstype        string              `json:"fstype,omitempty"`
-	Image         string              `json:"image"`
-	Addr          string              `json:"addr,omitempty"`
-	Volumes       []*VolumeDescriptor `json:"volumes,omitempty"`
-	Fsmap         []*FsmapDescriptor  `json:"fsmap,omitempty"`
-	Sysctl        map[string]string   `json:"sysctl,omitempty"`
-	Process       *Process            `json:"process"`
-	RestartPolicy string              `json:"restartPolicy"`
-	Initialize    bool                `json:"initialize"`
+	ID               string              `json:"id"`
+	Rootfs           string              `json:"rootfs"`
+	Fstype           string              `json:"fstype,omitempty"`
+	Image            string              `json:"image"`
+	Addr             string              `json:"addr,omitempty"`
+	Volumes          []*VolumeDescriptor `json:"volumes,omitempty"`
+	Fsmap            []*FsmapDescriptor  `json:"fsmap,omitempty"`
+	Sysctl           map[string]string   `json:"sysctl,omitempty"`
+	Process          *Process            `json:"process"`
+	RestartPolicy    string              `json:"restartPolicy"`
+	Initialize       bool                `json:"initialize"`
+	SystemMountsInfo SystemMountsInfo    `json:"systemMountsInfo"`
 }
 
 // IPAddress describes an IP address and its network mask.


### PR DESCRIPTION
Introduce a new variable "BindMountDev" to indicate the case where
/dev is passed as a volume on the docker command line.
This case needs to be handled by the agent.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>