### PR TITLE
proxy: Introduce no_proxy and kata_proxy implementations

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -133,6 +133,22 @@ type agent interface {
 	// to handle all other Agent interface methods.
 	init(pod *Pod, config interface{}) error
 
+	// vmURL returns the agent URL exposed by the hypervisor. This URL has
+	// been previously built from the agent implementation and provided to
+	// the hypervisor through a specific hypervisor interface function. It
+	// represents the entry point to connect to the agent through the VM.
+	// This function is particularly useful in case there is no proxy
+	// needed, meaning the proxy implementation will have to provide this
+	// URL instead of a real proxy URL.
+	vmURL() (string, error)
+
+	// setProxyURL sets the URL virtcontainers should connect in order to
+	// communicate with the agent. This URL can be either the proxy URL
+	// if it actually needs to go through a proxy, or it can be the VM
+	// URL in case no proxy is needed. Both ways, this has to be
+	// transparent for the agent implementation.
+	setProxyURL(url string) error
+
 	// capabilities should return a structure that specifies the capabilities
 	// supported by the agent.
 	capabilities() capabilities

--- a/cc_proxy_test.go
+++ b/cc_proxy_test.go
@@ -49,8 +49,7 @@ func TestCCProxyStart(t *testing.T) {
 		{
 			Pod{
 				config: &PodConfig{
-					ProxyType:   "invalid",
-					ProxyConfig: "invalid",
+					ProxyType: "invalid",
 				},
 			}, "", true,
 		},
@@ -58,7 +57,7 @@ func TestCCProxyStart(t *testing.T) {
 			Pod{
 				config: &PodConfig{
 					ProxyType:   CCProxyType,
-					ProxyConfig: CCProxyConfig{
+					ProxyConfig: ProxyConfig{
 					// invalid - no path
 					},
 				},
@@ -68,7 +67,7 @@ func TestCCProxyStart(t *testing.T) {
 			Pod{
 				config: &PodConfig{
 					ProxyType: CCProxyType,
-					ProxyConfig: CCProxyConfig{
+					ProxyConfig: ProxyConfig{
 						Path: invalidPath,
 					},
 				},
@@ -79,7 +78,7 @@ func TestCCProxyStart(t *testing.T) {
 				id: testPodID,
 				config: &PodConfig{
 					ProxyType: CCProxyType,
-					ProxyConfig: CCProxyConfig{
+					ProxyConfig: ProxyConfig{
 						Path: "echo",
 					},
 				},

--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -321,17 +321,16 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 	return podConfig, nil
 }
 
-func getProxyConfig(proxyType vc.ProxyType, path string) interface{} {
-	var proxyConfig interface{}
+func getProxyConfig(proxyType vc.ProxyType, path string) vc.ProxyConfig {
+	var proxyConfig vc.ProxyConfig
 
 	switch proxyType {
+	case vc.KataProxyType:
+		fallthrough
 	case vc.CCProxyType:
-		proxyConfig = vc.CCProxyConfig{
+		proxyConfig = vc.ProxyConfig{
 			Path: path,
 		}
-
-	default:
-		proxyConfig = nil
 	}
 
 	return proxyConfig

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -339,6 +339,16 @@ func (h *hyper) init(pod *Pod, config interface{}) (err error) {
 	return nil
 }
 
+// vmURL returns VM URL from hyperstart agent implementation.
+func (h *hyper) vmURL() (string, error) {
+	return "", nil
+}
+
+// setProxyURL sets proxy URL for hyperstart agent implementation.
+func (h *hyper) setProxyURL(url string) error {
+	return nil
+}
+
 func (h *hyper) createPod(pod *Pod) (err error) {
 	for _, volume := range h.config.Volumes {
 		err := pod.hypervisor.addDevice(volume, fsDev)

--- a/kata_proxy.go
+++ b/kata_proxy.go
@@ -1,0 +1,98 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+)
+
+// This is the Kata Containers implementation of the proxy interface.
+// This is pretty simple since it provides the same interface to both
+// runtime and shim as if they were talking directly to the agent.
+type kataProxy struct {
+	proxyURL string
+}
+
+// start is kataProxy start implementation for proxy interface.
+func (p *kataProxy) start(pod Pod) (int, string, error) {
+	config, err := newProxyConfig(pod.config)
+	if err != nil {
+		return -1, "", err
+	}
+
+	// construct the socket path the proxy instance will use
+	socketPath := filepath.Join(runStoragePath, pod.id, "kata_proxy.sock")
+	proxyURL := fmt.Sprintf("unix://%s", socketPath)
+
+	vmURL, err := pod.agent.vmURL()
+	if err != nil {
+		return -1, "", err
+	}
+
+	if err := pod.agent.setProxyURL(proxyURL); err != nil {
+		return -1, "", err
+	}
+
+	p.proxyURL = proxyURL
+
+	args := []string{config.Path, "-listen-socket", proxyURL, "-mux-socket", vmURL}
+	if config.Debug {
+		args = append(args, "-log", "debug")
+	}
+
+	cmd := exec.Command(args[0], args[1:]...)
+	if err := cmd.Start(); err != nil {
+		return -1, "", err
+	}
+
+	return cmd.Process.Pid, p.proxyURL, nil
+}
+
+// register is kataProxy register implementation for proxy interface.
+func (p *kataProxy) register(pod Pod) ([]ProxyInfo, string, error) {
+	var proxyInfos []ProxyInfo
+
+	for i := 0; i < len(pod.containers); i++ {
+		proxyInfo := ProxyInfo{}
+
+		proxyInfos = append(proxyInfos, proxyInfo)
+	}
+
+	return proxyInfos, p.proxyURL, nil
+}
+
+// unregister is kataProxy unregister implementation for proxy interface.
+func (p *kataProxy) unregister(pod Pod) error {
+	return nil
+}
+
+// connect is kataProxy connect implementation for proxy interface.
+func (p *kataProxy) connect(pod Pod, createToken bool) (ProxyInfo, string, error) {
+	return ProxyInfo{}, p.proxyURL, nil
+}
+
+// disconnect is kataProxy disconnect implementation for proxy interface.
+func (p *kataProxy) disconnect() error {
+	return nil
+}
+
+// sendCmd is kataProxy sendCmd implementation for proxy interface.
+func (p *kataProxy) sendCmd(cmd interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/kata_proxy_test.go
+++ b/kata_proxy_test.go
@@ -1,0 +1,77 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"testing"
+)
+
+var testKataProxyURL = "vmURL"
+
+func TestKataProxyRegister(t *testing.T) {
+	p := &kataProxy{
+		proxyURL: testKataProxyURL,
+	}
+
+	_, proxyURL, err := p.register(Pod{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if proxyURL != testKataProxyURL {
+		t.Fatalf("Got URL %q, expecting %q", proxyURL, testKataProxyURL)
+	}
+}
+
+func TestKataProxyUnregister(t *testing.T) {
+	p := &kataProxy{}
+
+	if err := p.unregister(Pod{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestKataProxyConnect(t *testing.T) {
+	p := &kataProxy{
+		proxyURL: testKataProxyURL,
+	}
+
+	_, proxyURL, err := p.connect(Pod{}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if proxyURL != testKataProxyURL {
+		t.Fatalf("Got URL %q, expecting %q", proxyURL, testKataProxyURL)
+	}
+}
+
+func TestKataProxyDisconnect(t *testing.T) {
+	p := &kataProxy{}
+
+	if err := p.disconnect(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestKataProxySendCmd(t *testing.T) {
+	p := &kataProxy{}
+
+	if _, err := p.sendCmd(nil); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/no_proxy.go
+++ b/no_proxy.go
@@ -1,0 +1,80 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+// This is the no proxy implementation of the proxy interface. This
+// is a generic implementation for any case (basically any agent),
+// where no actual proxy is needed. This happens when the combination
+// of the VM and the agent can handle multiple connections without
+// additional component to handle the multiplexing. Both the runtime
+// and the shim will connect to the agent through the VM, bypassing
+// the proxy model.
+// That's why this implementation is very generic, and all it does
+// is to provide both shim and runtime the correct URL to connect
+// directly to the VM.
+type noProxy struct {
+	vmURL string
+}
+
+// start is noProxy start implementation for proxy interface.
+func (p *noProxy) start(pod Pod) (int, string, error) {
+	url, err := pod.agent.vmURL()
+	if err != nil {
+		return -1, "", err
+	}
+
+	p.vmURL = url
+
+	if err := pod.agent.setProxyURL(url); err != nil {
+		return -1, "", err
+	}
+
+	return 0, p.vmURL, nil
+}
+
+// register is noProxy register implementation for proxy interface.
+func (p *noProxy) register(pod Pod) ([]ProxyInfo, string, error) {
+	var proxyInfos []ProxyInfo
+
+	for i := 0; i < len(pod.containers); i++ {
+		proxyInfo := ProxyInfo{}
+
+		proxyInfos = append(proxyInfos, proxyInfo)
+	}
+
+	return proxyInfos, p.vmURL, nil
+}
+
+// unregister is noProxy unregister implementation for proxy interface.
+func (p *noProxy) unregister(pod Pod) error {
+	return nil
+}
+
+// connect is noProxy connect implementation for proxy interface.
+func (p *noProxy) connect(pod Pod, createToken bool) (ProxyInfo, string, error) {
+	return ProxyInfo{}, p.vmURL, nil
+}
+
+// disconnect is noProxy disconnect implementation for proxy interface.
+func (p *noProxy) disconnect() error {
+	return nil
+}
+
+// sendCmd is noProxy sendCmd implementation for proxy interface.
+func (p *noProxy) sendCmd(cmd interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/no_proxy_test.go
+++ b/no_proxy_test.go
@@ -1,0 +1,98 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"testing"
+)
+
+var testNoProxyVMURL = "vmURL"
+
+func TestNoProxyStart(t *testing.T) {
+	pod := Pod{
+		agent: newAgent(NoopAgentType),
+	}
+
+	p := &noProxy{}
+
+	pid, vmURL, err := p.start(pod)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if vmURL != "" {
+		t.Fatalf("Got URL %q, expecting empty URL", vmURL)
+	}
+
+	if pid != 0 {
+		t.Fatal("Failure since returned PID should be 0")
+	}
+}
+
+func TestNoProxyRegister(t *testing.T) {
+	p := &noProxy{
+		vmURL: testNoProxyVMURL,
+	}
+
+	_, vmURL, err := p.register(Pod{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if vmURL != testNoProxyVMURL {
+		t.Fatalf("Got URL %q, expecting %q", vmURL, testNoProxyVMURL)
+	}
+}
+
+func TestNoProxyUnregister(t *testing.T) {
+	p := &noProxy{}
+
+	if err := p.unregister(Pod{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNoProxyConnect(t *testing.T) {
+	p := &noProxy{
+		vmURL: testNoProxyVMURL,
+	}
+
+	_, vmURL, err := p.connect(Pod{}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if vmURL != testNoProxyVMURL {
+		t.Fatalf("Got URL %q, expecting %q", vmURL, testNoProxyVMURL)
+	}
+}
+
+func TestNoProxyDisconnect(t *testing.T) {
+	p := &noProxy{}
+
+	if err := p.disconnect(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNoProxySendCmd(t *testing.T) {
+	p := &noProxy{}
+
+	if _, err := p.sendCmd(nil); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/noop_agent.go
+++ b/noop_agent.go
@@ -30,6 +30,16 @@ func (n *noopAgent) init(pod *Pod, config interface{}) error {
 	return nil
 }
 
+// vmURL returns the VM URL from the Noop agent. It does nothing.
+func (n *noopAgent) vmURL() (string, error) {
+	return "", nil
+}
+
+// setProxyURL sets the URL of the proxy for the Noop agent. It does nothing.
+func (n *noopAgent) setProxyURL(url string) error {
+	return nil
+}
+
 // createPod is the Noop agent pod creation implementation. It does nothing.
 func (n *noopAgent) createPod(pod *Pod) error {
 	return nil

--- a/noop_agent_test.go
+++ b/noop_agent_test.go
@@ -30,6 +30,27 @@ func TestNoopAgentInit(t *testing.T) {
 	}
 }
 
+func TestNoopAgentVmURL(t *testing.T) {
+	n := &noopAgent{}
+
+	url, err := n.vmURL()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if url != "" {
+		t.Fatalf("URL should be empty: %s", url)
+	}
+}
+
+func TestNoopAgentProxyURL(t *testing.T) {
+	n := &noopAgent{}
+
+	if err := n.setProxyURL(""); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestNoopAgentExec(t *testing.T) {
 	n := &noopAgent{}
 	pod := &Pod{}

--- a/noop_proxy.go
+++ b/noop_proxy.go
@@ -16,6 +16,8 @@
 
 package virtcontainers
 
+// This is a dummy proxy implementation of the proxy interface, only
+// used for testing purpose.
 type noopProxy struct{}
 
 var noopProxyURL = "noopProxyURL"

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -95,7 +95,7 @@ type RuntimeConfig struct {
 	AgentConfig interface{}
 
 	ProxyType   vc.ProxyType
-	ProxyConfig interface{}
+	ProxyConfig vc.ProxyConfig
 
 	ShimType   vc.ShimType
 	ShimConfig interface{}

--- a/pod.go
+++ b/pod.go
@@ -316,7 +316,7 @@ type PodConfig struct {
 	AgentConfig interface{}
 
 	ProxyType   ProxyType
-	ProxyConfig interface{}
+	ProxyConfig ProxyConfig
 
 	ShimType   ShimType
 	ShimConfig interface{}

--- a/proxy.go
+++ b/proxy.go
@@ -18,23 +18,42 @@ package virtcontainers
 
 import (
 	"fmt"
+	"net"
+	"net/url"
+	"time"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/sirupsen/logrus"
 )
 
+// ProxyConfig is a structure storing information needed from any
+// proxy in order to be properly initialized.
+type ProxyConfig struct {
+	Path  string
+	Debug bool
+}
+
 // ProxyType describes a proxy type.
 type ProxyType string
 
 const (
+	// NoopProxyType is the noopProxy.
+	NoopProxyType ProxyType = "noopProxy"
+
 	// NoProxyType is the noProxy.
 	NoProxyType ProxyType = "noProxy"
 
 	// CCProxyType is the ccProxy.
 	CCProxyType ProxyType = "ccProxy"
 
-	// NoopProxyType is the noopProxy.
-	NoopProxyType ProxyType = "noopProxy"
+	// KataProxyType is the kataProxy.
+	KataProxyType ProxyType = "kataProxy"
+)
+
+const (
+	// Number of seconds to wait for the proxy to respond to a connection
+	// request.
+	waitForProxyTimeoutSecs = 5.0
 )
 
 func proxyLogger() *logrus.Entry {
@@ -53,6 +72,9 @@ func (pType *ProxyType) Set(value string) error {
 	case "ccProxy":
 		*pType = CCProxyType
 		return nil
+	case "kataProxy":
+		*pType = KataProxyType
+		return nil
 	default:
 		return fmt.Errorf("Unknown proxy type %s", value)
 	}
@@ -67,6 +89,8 @@ func (pType *ProxyType) String() string {
 		return string(NoProxyType)
 	case CCProxyType:
 		return string(CCProxyType)
+	case KataProxyType:
+		return string(KataProxyType)
 	default:
 		return ""
 	}
@@ -81,34 +105,119 @@ func newProxy(pType ProxyType) (proxy, error) {
 		return &noProxy{}, nil
 	case CCProxyType:
 		return &ccProxy{}, nil
+	case KataProxyType:
+		return &kataProxy{}, nil
 	default:
 		return &noopProxy{}, nil
 	}
 }
 
-// newProxyConfig returns a proxy config from a generic PodConfig interface.
-func newProxyConfig(config PodConfig) interface{} {
-	switch config.ProxyType {
-	case NoopProxyType:
-		return nil
-	case NoProxyType:
-		return nil
-	case CCProxyType:
-		var ccConfig CCProxyConfig
-		err := mapstructure.Decode(config.ProxyConfig, &ccConfig)
-		if err != nil {
-			return err
-		}
-		return ccConfig
-	default:
-		return nil
+// newProxyConfig returns a proxy config from a generic PodConfig handler,
+// after it properly checked the configuration was valid.
+func newProxyConfig(podConfig *PodConfig) (ProxyConfig, error) {
+	if podConfig == nil {
+		return ProxyConfig{}, fmt.Errorf("Pod config cannot be nil")
 	}
+
+	var config ProxyConfig
+	switch podConfig.ProxyType {
+	case KataProxyType:
+		fallthrough
+	case CCProxyType:
+		if err := mapstructure.Decode(podConfig.ProxyConfig, &config); err != nil {
+			return ProxyConfig{}, err
+		}
+	}
+
+	if config.Path == "" {
+		return ProxyConfig{}, fmt.Errorf("Proxy path cannot be empty")
+	}
+
+	return config, nil
 }
 
 // ProxyInfo holds the token returned by the proxy.
 // Each ProxyInfo relates to a process running inside a container.
 type ProxyInfo struct {
 	Token string
+}
+
+// connectProxyRetry repeatedly tries to connect to the proxy on the specified
+// address until a timeout state is reached, when it will fail.
+func connectProxyRetry(scheme, address string) (conn net.Conn, err error) {
+	attempt := 1
+
+	timeoutSecs := time.Duration(waitForProxyTimeoutSecs * time.Second)
+
+	startTime := time.Now()
+	lastLogTime := startTime
+
+	for {
+		conn, err = net.Dial(scheme, address)
+		if err == nil {
+			// If the initial connection was unsuccessful,
+			// ensure a log message is generated when successfully
+			// connected.
+			if attempt > 1 {
+				proxyLogger().WithField("attempt", fmt.Sprintf("%d", attempt)).Info("Connected to proxy")
+			}
+
+			return conn, nil
+		}
+
+		attempt++
+
+		now := time.Now()
+
+		delta := now.Sub(startTime)
+		remaining := timeoutSecs - delta
+
+		if remaining <= 0 {
+			return nil, fmt.Errorf("failed to connect to proxy after %v: %v", timeoutSecs, err)
+		}
+
+		logDelta := now.Sub(lastLogTime)
+		logDeltaSecs := logDelta / time.Second
+
+		if logDeltaSecs >= 1 {
+			proxyLogger().WithError(err).WithFields(logrus.Fields{
+				"attempt":             fmt.Sprintf("%d", attempt),
+				"proxy-network":       scheme,
+				"proxy-address":       address,
+				"remaining-time-secs": fmt.Sprintf("%2.2f", remaining.Seconds()),
+			}).Warning("Retrying proxy connection")
+
+			lastLogTime = now
+		}
+
+		time.Sleep(time.Duration(100) * time.Millisecond)
+	}
+}
+
+func connectProxy(uri string) (net.Conn, error) {
+	if uri == "" {
+		return nil, fmt.Errorf("no proxy URI")
+	}
+
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	if u.Scheme == "" {
+		return nil, fmt.Errorf("URL scheme cannot be empty")
+	}
+
+	address := u.Host
+	if address == "" {
+		if u.Path == "" {
+			return nil, fmt.Errorf("URL host and path cannot be empty")
+		}
+
+		address = u.Path
+	}
+
+	return connectProxyRetry(u.Scheme, address)
 }
 
 // proxy is the virtcontainers proxy interface.

--- a/proxy.go
+++ b/proxy.go
@@ -27,6 +27,9 @@ import (
 type ProxyType string
 
 const (
+	// NoProxyType is the noProxy.
+	NoProxyType ProxyType = "noProxy"
+
 	// CCProxyType is the ccProxy.
 	CCProxyType ProxyType = "ccProxy"
 
@@ -44,6 +47,9 @@ func (pType *ProxyType) Set(value string) error {
 	case "noopProxy":
 		*pType = NoopProxyType
 		return nil
+	case "noProxy":
+		*pType = NoProxyType
+		return nil
 	case "ccProxy":
 		*pType = CCProxyType
 		return nil
@@ -57,6 +63,8 @@ func (pType *ProxyType) String() string {
 	switch *pType {
 	case NoopProxyType:
 		return string(NoopProxyType)
+	case NoProxyType:
+		return string(NoProxyType)
 	case CCProxyType:
 		return string(CCProxyType)
 	default:
@@ -69,6 +77,8 @@ func newProxy(pType ProxyType) (proxy, error) {
 	switch pType {
 	case NoopProxyType:
 		return &noopProxy{}, nil
+	case NoProxyType:
+		return &noProxy{}, nil
 	case CCProxyType:
 		return &ccProxy{}, nil
 	default:
@@ -80,6 +90,8 @@ func newProxy(pType ProxyType) (proxy, error) {
 func newProxyConfig(config PodConfig) interface{} {
 	switch config.ProxyType {
 	case NoopProxyType:
+		return nil
+	case NoProxyType:
 		return nil
 	case CCProxyType:
 		var ccConfig CCProxyConfig

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -42,6 +42,10 @@ func TestSetNoopProxyType(t *testing.T) {
 	testSetProxyType(t, "noopProxy", NoopProxyType)
 }
 
+func TestSetNoProxyType(t *testing.T) {
+	testSetProxyType(t, "noProxy", NoProxyType)
+}
+
 func TestSetUnknownProxyType(t *testing.T) {
 	var proxyType ProxyType
 
@@ -52,7 +56,9 @@ func TestSetUnknownProxyType(t *testing.T) {
 		t.Fatalf("Should fail because %s type used", unknownType)
 	}
 
-	if proxyType == CCProxyType || proxyType == NoopProxyType {
+	if proxyType == CCProxyType ||
+		proxyType == NoopProxyType ||
+		proxyType == NoProxyType {
 		t.Fatalf("%s proxy type was not expected", proxyType)
 	}
 }
@@ -67,6 +73,11 @@ func testStringFromProxyType(t *testing.T, proxyType ProxyType, expected string)
 func TestStringFromCCProxyType(t *testing.T) {
 	proxyType := CCProxyType
 	testStringFromProxyType(t, proxyType, "ccProxy")
+}
+
+func TestStringFromNoProxyType(t *testing.T) {
+	proxyType := NoProxyType
+	testStringFromProxyType(t, proxyType, "noProxy")
 }
 
 func TestStringFromNoopProxyType(t *testing.T) {
@@ -93,6 +104,12 @@ func testNewProxyFromProxyType(t *testing.T, proxyType ProxyType, expected proxy
 func TestNewProxyFromCCProxyType(t *testing.T) {
 	proxyType := CCProxyType
 	expectedProxy := &ccProxy{}
+	testNewProxyFromProxyType(t, proxyType, expectedProxy)
+}
+
+func TestNewProxyFromNoProxyType(t *testing.T) {
+	proxyType := NoProxyType
+	expectedProxy := &noProxy{}
 	testNewProxyFromProxyType(t, proxyType, expectedProxy)
 }
 
@@ -128,6 +145,14 @@ func TestNewProxyConfigFromCCProxyPodConfig(t *testing.T) {
 	}
 
 	testNewProxyConfigFromPodConfig(t, podConfig, proxyConfig)
+}
+
+func TestNewProxyConfigFromNoProxyPodConfig(t *testing.T) {
+	podConfig := PodConfig{
+		ProxyType: NoProxyType,
+	}
+
+	testNewProxyConfigFromPodConfig(t, podConfig, nil)
 }
 
 func TestNewProxyConfigFromNoopProxyPodConfig(t *testing.T) {

--- a/sshd.go
+++ b/sshd.go
@@ -105,6 +105,16 @@ func (s *sshd) init(pod *Pod, config interface{}) error {
 	return nil
 }
 
+// vmURL returns VM URL from the sshd agent implementation.
+func (s *sshd) vmURL() (string, error) {
+	return "", nil
+}
+
+// setProxyURL sets proxy URL for the sshd agent implementation.
+func (s *sshd) setProxyURL(url string) error {
+	return nil
+}
+
 // createPod is the agent pod creation implementation for sshd.
 func (s *sshd) createPod(pod *Pod) error {
 	return nil


### PR DESCRIPTION
This PR implements proxies for Kata Containers cases with and without proxy.
In order to achieve this, it slightly modifies the agent interface by adding two new functions.

Fixes #515 #516 #524 