### PR TITLE
network: pod: Get default internetwork model from pod configuration

### DIFF
--- a/cni.go
+++ b/cni.go
@@ -111,8 +111,8 @@ func (n *cni) invokePluginsDelete(pod Pod, networkNS NetworkNamespace) error {
 	return nil
 }
 
-func (n *cni) updateEndpointsFromScan(networkNS *NetworkNamespace, netInfo *NetworkInfo) error {
-	endpoints, err := createEndpointsFromScan(networkNS.NetNsPath)
+func (n *cni) updateEndpointsFromScan(networkNS *NetworkNamespace, netInfo *NetworkInfo, config NetworkConfig) error {
+	endpoints, err := createEndpointsFromScan(networkNS.NetNsPath, config)
 	if err != nil {
 		return err
 	}
@@ -153,7 +153,7 @@ func (n *cni) add(pod Pod, config NetworkConfig, netNsPath string, netNsCreated 
 		return NetworkNamespace{}, err
 	}
 
-	if err := n.updateEndpointsFromScan(&networkNS, netInfo); err != nil {
+	if err := n.updateEndpointsFromScan(&networkNS, netInfo, config); err != nil {
 		return NetworkNamespace{}, err
 	}
 

--- a/cnm.go
+++ b/cnm.go
@@ -41,7 +41,7 @@ func (n *cnm) run(networkNSPath string, cb func() error) error {
 
 // add adds all needed interfaces inside the network namespace for the CNM network.
 func (n *cnm) add(pod Pod, config NetworkConfig, netNsPath string, netNsCreated bool) (NetworkNamespace, error) {
-	endpoints, err := createEndpointsFromScan(netNsPath)
+	endpoints, err := createEndpointsFromScan(netNsPath, config)
 	if err != nil {
 		return NetworkNamespace{}, err
 	}

--- a/network.go
+++ b/network.go
@@ -1137,22 +1137,6 @@ func createVirtualNetworkEndpoint(idx int, ifName string) (*VirtualEndpoint, err
 	return endpoint, nil
 }
 
-func createNetworkEndpoints(numOfEndpoints int) (endpoints []Endpoint, err error) {
-	if numOfEndpoints < 1 {
-		return endpoints, fmt.Errorf("Invalid number of network endpoints")
-	}
-
-	for i := 0; i < numOfEndpoints; i++ {
-		endpoint, err := createVirtualNetworkEndpoint(i, "")
-		if err != nil {
-			return nil, err
-		}
-		endpoints = append(endpoints, endpoint)
-	}
-
-	return endpoints, nil
-}
-
 func networkInfoFromLink(handle *netlink.Handle, link netlink.Link) (NetworkInfo, error) {
 	addrs, err := handle.AddrList(link, netlink.FAMILY_ALL)
 	if err != nil {

--- a/network.go
+++ b/network.go
@@ -675,7 +675,7 @@ func getLinkByName(netHandle *netlink.Handle, name string, expectedLink netlink.
 
 // The endpoint type should dictate how the connection needs to be made
 func xconnectVMNetwork(netPair *NetworkInterfacePair, connect bool) error {
-	switch DefaultNetInterworkingModel {
+	switch netPair.NetInterworkingModel {
 	case ModelBridged:
 		netPair.NetInterworkingModel = ModelBridged
 		if connect {
@@ -691,7 +691,7 @@ func xconnectVMNetwork(netPair *NetworkInterfacePair, connect bool) error {
 	case ModelEnlightened:
 		return fmt.Errorf("Unsupported networking model")
 	default:
-		return fmt.Errorf("Invalid networking model")
+		return fmt.Errorf("Invalid internetworking model: '%s'", netPair.NetInterworkingModel)
 	}
 }
 

--- a/network.go
+++ b/network.go
@@ -71,30 +71,21 @@ func (n NetInterworkingModel) IsValid() bool {
 	return 0 <= int(n) && int(n) < int(NetXConnectInvalidModel)
 }
 
-var interworkingModelStringMap = map[NetInterworkingModel]string{
-	NetXConnectDefaultModel:     "default",
-	NetXConnectBridgedModel:     "bridged",
-	NetXConnectMacVtapModel:     "macvtap",
-	NetXConnectEnlightenedModel: "enlightened",
-}
-
-func (n NetInterworkingModel) String() string {
-	if val, ok := interworkingModelStringMap[n]; ok {
-		return val
-	}
-	return fmt.Sprintf("Unknown type %d", int(n))
-}
-
 //SetModel change the model string value
 func (n *NetInterworkingModel) SetModel(modelName string) error {
-	if modelName == NetXConnectDefaultModel.String() {
-		modelName = DefaultNetInterworkingModel.String()
-	}
-	for model, name := range interworkingModelStringMap {
-		if name == modelName {
-			*n = model
-			return nil
-		}
+	switch modelName {
+	case "default":
+		*n = DefaultNetInterworkingModel
+		return nil
+	case "bridged":
+		*n = NetXConnectBridgedModel
+		return nil
+	case "macvtap":
+		*n = NetXConnectMacVtapModel
+		return nil
+	case "enlightened":
+		*n = NetXConnectEnlightenedModel
+		return nil
 	}
 	return fmt.Errorf("Unknown type %s", modelName)
 }
@@ -737,7 +728,7 @@ func xconnectVMNetwork(netPair *NetworkInterfacePair, connect bool) error {
 	case NetXConnectEnlightenedModel:
 		return fmt.Errorf("Unsupported networking model")
 	default:
-		return fmt.Errorf("Invalid internetworking model: '%s'", netPair.NetInterworkingModel)
+		return fmt.Errorf("Invalid internetworking model")
 	}
 }
 

--- a/network.go
+++ b/network.go
@@ -43,39 +43,39 @@ import (
 type NetInterworkingModel int
 
 const (
-	// ModelDefault Ask to use DefaultNetInterworkingModel
-	ModelDefault NetInterworkingModel = iota
+	// NetXConnectDefaultModel Ask to use DefaultNetInterworkingModel
+	NetXConnectDefaultModel NetInterworkingModel = iota
 
-	// ModelBridged uses a linux bridge to interconnect
+	// NetXConnectBridgedModel uses a linux bridge to interconnect
 	// the container interface to the VM. This is the
 	// safe default that works for most cases except
 	// macvlan and ipvlan
-	ModelBridged
+	NetXConnectBridgedModel
 
-	// ModelMacVtap can be used when the Container network
+	// NetXConnectMacVtapModel can be used when the Container network
 	// interface can be bridged using macvtap
-	ModelMacVtap
+	NetXConnectMacVtapModel
 
-	// ModelEnlightened can be used when the Network plugins
+	// NetXConnectEnlightenedModel can be used when the Network plugins
 	// are enlightened to create VM native interfaces
 	// when requested by the runtime
 	// This will be used for vethtap, macvtap, ipvtap
-	ModelEnlightened
+	NetXConnectEnlightenedModel
 
-	// InvalidNetInterworkingModel is the last item to check valid values by IsValid()
-	InvalidNetInterworkingModel
+	// NetXConnectInvalidModel is the last item to check valid values by IsValid()
+	NetXConnectInvalidModel
 )
 
 //IsValid checks if a model is valid
 func (n NetInterworkingModel) IsValid() bool {
-	return 0 <= int(n) && int(n) < int(InvalidNetInterworkingModel)
+	return 0 <= int(n) && int(n) < int(NetXConnectInvalidModel)
 }
 
 var interworkingModelStringMap = map[NetInterworkingModel]string{
-	ModelDefault:     "default",
-	ModelBridged:     "bridged",
-	ModelMacVtap:     "macvtap",
-	ModelEnlightened: "enlightened",
+	NetXConnectDefaultModel:     "default",
+	NetXConnectBridgedModel:     "bridged",
+	NetXConnectMacVtapModel:     "macvtap",
+	NetXConnectEnlightenedModel: "enlightened",
 }
 
 func (n NetInterworkingModel) String() string {
@@ -87,7 +87,7 @@ func (n NetInterworkingModel) String() string {
 
 //SetModel change the model string value
 func (n *NetInterworkingModel) SetModel(modelName string) error {
-	if modelName == ModelDefault.String() {
+	if modelName == NetXConnectDefaultModel.String() {
 		modelName = DefaultNetInterworkingModel.String()
 	}
 	for model, name := range interworkingModelStringMap {
@@ -102,7 +102,7 @@ func (n *NetInterworkingModel) SetModel(modelName string) error {
 // DefaultNetInterworkingModel is a package level default
 // that determines how the VM should be connected to the
 // the container network interface
-var DefaultNetInterworkingModel = ModelMacVtap
+var DefaultNetInterworkingModel = NetXConnectMacVtapModel
 
 // Introduces constants related to networking
 const (
@@ -584,7 +584,7 @@ func newNetwork(networkType NetworkModel) network {
 }
 
 func initNetworkCommon(config NetworkConfig) (string, bool, error) {
-	if !config.InterworkingModel.IsValid() || config.InterworkingModel == ModelDefault {
+	if !config.InterworkingModel.IsValid() || config.InterworkingModel == NetXConnectDefaultModel {
 		config.InterworkingModel = DefaultNetInterworkingModel
 	}
 
@@ -718,23 +718,23 @@ func getLinkByName(netHandle *netlink.Handle, name string, expectedLink netlink.
 
 // The endpoint type should dictate how the connection needs to be made
 func xconnectVMNetwork(netPair *NetworkInterfacePair, connect bool) error {
-	if netPair.NetInterworkingModel == ModelDefault {
+	if netPair.NetInterworkingModel == NetXConnectDefaultModel {
 		netPair.NetInterworkingModel = DefaultNetInterworkingModel
 	}
 	switch netPair.NetInterworkingModel {
-	case ModelBridged:
-		netPair.NetInterworkingModel = ModelBridged
+	case NetXConnectBridgedModel:
+		netPair.NetInterworkingModel = NetXConnectBridgedModel
 		if connect {
 			return bridgeNetworkPair(netPair)
 		}
 		return unBridgeNetworkPair(*netPair)
-	case ModelMacVtap:
-		netPair.NetInterworkingModel = ModelMacVtap
+	case NetXConnectMacVtapModel:
+		netPair.NetInterworkingModel = NetXConnectMacVtapModel
 		if connect {
 			return tapNetworkPair(netPair)
 		}
 		return untapNetworkPair(*netPair)
-	case ModelEnlightened:
+	case NetXConnectEnlightenedModel:
 		return fmt.Errorf("Unsupported networking model")
 	default:
 		return fmt.Errorf("Invalid internetworking model: '%s'", netPair.NetInterworkingModel)

--- a/network_test.go
+++ b/network_test.go
@@ -238,11 +238,12 @@ func TestCreateVirtualNetworkEndpoint(t *testing.T) {
 			TAPIface: NetworkInterface{
 				Name: "tap4",
 			},
+			NetInterworkingModel: DefaultNetInterworkingModel,
 		},
 		EndpointType: VirtualEndpointType,
 	}
 
-	result, err := createVirtualNetworkEndpoint(4, "")
+	result, err := createVirtualNetworkEndpoint(4, "", DefaultNetInterworkingModel)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -269,11 +270,12 @@ func TestCreateVirtualNetworkEndpointChooseIfaceName(t *testing.T) {
 			TAPIface: NetworkInterface{
 				Name: "tap4",
 			},
+			NetInterworkingModel: DefaultNetInterworkingModel,
 		},
 		EndpointType: VirtualEndpointType,
 	}
 
-	result, err := createVirtualNetworkEndpoint(4, "eth1")
+	result, err := createVirtualNetworkEndpoint(4, "eth1", DefaultNetInterworkingModel)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -299,7 +301,7 @@ func TestCreateVirtualNetworkEndpointInvalidArgs(t *testing.T) {
 	}
 
 	for _, d := range failingValues {
-		result, err := createVirtualNetworkEndpoint(d.idx, d.ifName)
+		result, err := createVirtualNetworkEndpoint(d.idx, d.ifName, DefaultNetInterworkingModel)
 		if err == nil {
 			t.Fatalf("expected invalid endpoint for %v, got %v", d, result)
 		}

--- a/network_test.go
+++ b/network_test.go
@@ -306,29 +306,6 @@ func TestCreateVirtualNetworkEndpointInvalidArgs(t *testing.T) {
 	}
 }
 
-func TestCreateNetworkEndpoints(t *testing.T) {
-	numOfEndpoints := 3
-
-	endpoints, err := createNetworkEndpoints(numOfEndpoints)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(endpoints) != numOfEndpoints {
-		t.Fatal()
-	}
-}
-
-func TestCreateNetworkEndpointsFailure(t *testing.T) {
-	numOfEndpoints := 0
-
-	_, err := createNetworkEndpoints(numOfEndpoints)
-	if err == nil {
-		t.Fatalf("Should fail because %d endpoints is invalid",
-			numOfEndpoints)
-	}
-}
-
 func TestIsPhysicalIface(t *testing.T) {
 	testNetIface := "testIface0"
 	testMTU := 1500

--- a/network_test.go
+++ b/network_test.go
@@ -364,3 +364,47 @@ func TestIsPhysicalIface(t *testing.T) {
 		t.Fatalf("Got %+v\nExpecting %+v", isPhysical, false)
 	}
 }
+
+func TestNetInterworkingModelIsValid(t *testing.T) {
+	tests := []struct {
+		name string
+		n    NetInterworkingModel
+		want bool
+	}{
+		{"Invalid Model", NetXConnectInvalidModel, false},
+		{"Default Model", NetXConnectDefaultModel, true},
+		{"Bridged Model", NetXConnectBridgedModel, true},
+		{"Macvtap Model", NetXConnectMacVtapModel, true},
+		{"Enlightened Model", NetXConnectEnlightenedModel, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.n.IsValid(); got != tt.want {
+				t.Errorf("NetInterworkingModel.IsValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNetInterworkingModelSetModel(t *testing.T) {
+	var n NetInterworkingModel
+	tests := []struct {
+		name      string
+		modelName string
+		wantErr   bool
+	}{
+		{"Invalid Model", "Invalid", true},
+		{"default Model", "default", false},
+		{"bridged Model", "bridged", false},
+		{"macvtap Model", "macvtap", false},
+		{"enlightened Model", "enlightened", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := n.SetModel(tt.modelName); (err != nil) != tt.wantErr {
+				t.Errorf("NetInterworkingModel.SetModel() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -110,6 +110,10 @@ type RuntimeConfig struct {
 	ShimConfig interface{}
 
 	Console string
+
+	//Determines how the VM should be connected to the
+	//the container network interface
+	InterNetworkModel vc.NetInterworkingModel
 }
 
 // AddKernelParam allows the addition of new kernel parameters to an existing
@@ -322,7 +326,7 @@ func containerCapabilities(s CompatOCISpec) (vc.LinuxCapabilities, error) {
 	return c, nil
 }
 
-func networkConfig(ocispec CompatOCISpec) (vc.NetworkConfig, error) {
+func networkConfig(ocispec CompatOCISpec, config RuntimeConfig) (vc.NetworkConfig, error) {
 	linux := ocispec.Linux
 	if linux == nil {
 		return vc.NetworkConfig{}, ErrNoLinux
@@ -342,6 +346,7 @@ func networkConfig(ocispec CompatOCISpec) (vc.NetworkConfig, error) {
 			netConf.NetNSPath = n.Path
 		}
 	}
+	netConf.InterworkingModel = config.InterNetworkModel
 
 	return netConf, nil
 }
@@ -488,7 +493,7 @@ func PodConfig(ocispec CompatOCISpec, runtime RuntimeConfig, bundlePath, cid, co
 		return vc.PodConfig{}, err
 	}
 
-	networkConfig, err := networkConfig(ocispec)
+	networkConfig, err := networkConfig(ocispec, runtime)
 	if err != nil {
 		return vc.PodConfig{}, err
 	}

--- a/qemu.go
+++ b/qemu.go
@@ -354,9 +354,9 @@ func (q *qemu) appendSocket(devices []govmmQemu.Device, socket Socket) []govmmQe
 
 func networkModelToQemuType(model NetInterworkingModel) govmmQemu.NetDeviceType {
 	switch model {
-	case ModelBridged:
+	case NetXConnectBridgedModel:
 		return govmmQemu.MACVTAP //TODO: We should rename MACVTAP to .NET_FD
-	case ModelMacVtap:
+	case NetXConnectMacVtapModel:
 		return govmmQemu.MACVTAP
 	//case ModelEnlightened:
 	// Here the Network plugin will create a VM native interface


### PR DESCRIPTION
This patch change the default internetwork model based in the pod
configuration.

Fixes: #527

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>