### PR TITLE
vendor: Revendor govmm for VSOCK support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -30,7 +30,7 @@
 [[projects]]
   name = "github.com/intel/govmm"
   packages = ["qemu"]
-  revision = "064ffdb2b27a49feea45eea8db1a6738f5dc4e09"
+  revision = "9250e77eda726cbc468985582ce6de932c868bec"
 
 [[projects]]
   name = "github.com/kubernetes-incubator/cri-o"
@@ -96,6 +96,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "08587dd11560c8b455a1a84351761327aeb6195999805d76057a4a816d0f6536"
+  inputs-digest = "004e4ccd38201404ca6a06b2379762df4d3b0cfc9311e402e0588b80b2b1a727"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -134,4 +134,4 @@
 
 [[constraint]]
   name = "github.com/intel/govmm"
-  revision = "064ffdb2b27a49feea45eea8db1a6738f5dc4e09"
+  revision = "9250e77eda726cbc468985582ce6de932c868bec"

--- a/vendor/github.com/intel/govmm/qemu/qemu.go
+++ b/vendor/github.com/intel/govmm/qemu/qemu.go
@@ -892,6 +892,45 @@ func (bridgeDev BridgeDevice) QemuParams(config *Config) []string {
 	return qemuParams
 }
 
+// VSOCKDevice represents a AF_VSOCK socket.
+type VSOCKDevice struct {
+	ID string
+
+	ContextID uint32
+}
+
+const (
+	// MinimalGuestCID is the smallest valid context ID for a guest.
+	MinimalGuestCID uint32 = 3
+
+	// VhostVSOCKPCI is the VSOCK vhost device type.
+	VhostVSOCKPCI = "vhost-vsock-pci"
+
+	// VSOCKGuestCID is the VSOCK guest CID parameter.
+	VSOCKGuestCID = "guest-cid"
+)
+
+// Valid returns true if the VSOCKDevice structure is valid and complete.
+func (vsock VSOCKDevice) Valid() bool {
+	if vsock.ID == "" || vsock.ContextID < MinimalGuestCID {
+		return false
+	}
+
+	return true
+}
+
+// QemuParams returns the qemu parameters built out of the VSOCK device.
+func (vsock VSOCKDevice) QemuParams(config *Config) []string {
+	var qemuParams []string
+
+	deviceParam := fmt.Sprintf("%s,id=%s,%s=%d", VhostVSOCKPCI, vsock.ID, VSOCKGuestCID, vsock.ContextID)
+
+	qemuParams = append(qemuParams, "-device")
+	qemuParams = append(qemuParams, deviceParam)
+
+	return qemuParams
+}
+
 // RTCBaseType is the qemu RTC base time type.
 type RTCBaseType string
 

--- a/vendor/github.com/intel/govmm/qemu/qemu_test.go
+++ b/vendor/github.com/intel/govmm/qemu/qemu_test.go
@@ -311,6 +311,34 @@ func TestAppendDeviceVFIO(t *testing.T) {
 	testAppend(vfioDevice, deviceVFIOString, t)
 }
 
+var deviceVSOCKString = "-device vhost-vsock-pci,id=vhost-vsock-pci0,guest-cid=4"
+
+func TestAppendVSOCK(t *testing.T) {
+	vsockDevice := VSOCKDevice{
+		ID:        "vhost-vsock-pci0",
+		ContextID: 4,
+	}
+
+	testAppend(vsockDevice, deviceVSOCKString, t)
+}
+
+func TestVSOCKValid(t *testing.T) {
+	vsockDevice := VSOCKDevice{
+		ID:        "vhost-vsock-pci0",
+		ContextID: MinimalGuestCID - 1,
+	}
+
+	if vsockDevice.Valid() {
+		t.Fatalf("VSOCK Context ID is not valid")
+	}
+
+	vsockDevice.ID = ""
+
+	if vsockDevice.Valid() {
+		t.Fatalf("VSOCK ID is not valid")
+	}
+}
+
 func TestAppendEmptyDevice(t *testing.T) {
 	device := SerialDevice{}
 


### PR DESCRIPTION
We want VSOCK for the kata_agent implementation

Short log:

 5316779 qemu: Add VSOCK support

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>