### PR TITLE
ci: Handle complex revendoring cases

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -37,6 +37,9 @@ cd "${GOPATH}/src/${vc_repo}"
 if [ "${ghprbPullId}" ] && [ "${ghprbTargetBranch}" ]
 then
 	git fetch origin "pull/${ghprbPullId}/head" && git checkout master && git reset --hard FETCH_HEAD && git rebase "origin/${ghprbTargetBranch}"
+
+	export AUTHOR_REPO_GIT_URL="${ghprbAuthorRepoGitUrl}"
+	export COMMIT_REVISION="${ghprbActualCommit}"
 else
 	git fetch origin && git checkout master && git reset --hard origin/master
 fi


### PR DESCRIPTION
    ci: Handle complex revendoring cases
    
    This commit relies fully on dep tool so as to vendor the latest code
    coming from a pull request on virtcontainers repository.
    
    The information about the github repo URL and the commit revision are
    both passed from Jenkins (as environment variables), and the script
    relies on those values in order to override Gopkg.toml for both proxy
    and runtime repositories.
    
    The last step is to run dep tool, leaving the revendoring complexity
    (including nested vendoring sometimes) being handled by dep.
    
    Fixes #513
    
    Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>