### PR TITLE
mounts: Fix bug while checking if /dev was bind-mounted

### DIFF
--- a/container.go
+++ b/container.go
@@ -496,11 +496,11 @@ func (c *Container) fetchState(cmd string) (State, error) {
 
 func (c *Container) getSystemMountInfo() {
 	// check if /dev needs to be bind mounted from host /dev
+	c.systemMountsInfo.BindMountDev = false
+
 	for _, m := range c.mounts {
 		if m.Source == "/dev" && m.Destination == "/dev" && m.Type == "bind" {
 			c.systemMountsInfo.BindMountDev = true
-		} else {
-			c.systemMountsInfo.BindMountDev = false
 		}
 	}
 

--- a/container_test.go
+++ b/container_test.go
@@ -58,6 +58,11 @@ func TestContainerSystemMountsInfo(t *testing.T) {
 			Destination: "/dev",
 			Type:        "bind",
 		},
+		{
+			Source:      "procfs",
+			Destination: "/proc",
+			Type:        "procfs",
+		},
 	}
 
 	c := Container{


### PR DESCRIPTION
There was a bug in the way we were checking if /dev was
bindmounted from the host.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>