### PR TITLE
vendor: Force kata containers agent vendoring

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -44,10 +44,9 @@
   revision = "9250e77eda726cbc468985582ce6de932c868bec"
 
 [[projects]]
-  branch = "master"
   name = "github.com/kata-containers/agent"
   packages = ["protocols/client","protocols/grpc"]
-  revision = "0fdf11ee45a8c79938e60655b22ab91950b28bb7"
+  revision = "306ee20ff47628fe370012d7e3f9316480e43c2e"
 
 [[projects]]
   name = "github.com/kubernetes-incubator/cri-o"
@@ -109,7 +108,7 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "d585fd2cc9195196078f516b69daff6744ef5e84"
+  revision = "0fcca4842a8d74bfddc2c96a073bd2a4d2a7a2e8"
 
 [[projects]]
   name = "golang.org/x/net"
@@ -125,7 +124,7 @@
   branch = "master"
   name = "golang.org/x/text"
   packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
-  revision = "eb22672bea55af56d225d4e35405f4d2e9f062a0"
+  revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
 
 [[projects]]
   branch = "master"
@@ -141,6 +140,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2a1b6f0d532137a1fd1c412bbedb44519fc503533dc928475179246c08ee1e9c"
+  inputs-digest = "0d9b34864a43e820b4e23f22f92aa15ab2cc6e3345cf215335805f77c348f2df"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -73,3 +73,7 @@
 [[constraint]]
   name = "github.com/mdlayher/vsock"
   revision = "7b5c6741e074564cf63927c1a82beda0138e1ed4"
+
+[[constraint]]
+  name = "github.com/kata-containers/agent"
+  revision = "306ee20ff47628fe370012d7e3f9316480e43c2e"

--- a/kata_agent.go
+++ b/kata_agent.go
@@ -452,7 +452,7 @@ func (k *kataAgent) stopContainer(pod Pod, c Container) error {
 func (k *kataAgent) killContainer(pod Pod, c Container, signal syscall.Signal, all bool) error {
 	req := &grpc.SignalProcessRequest{
 		ContainerId: c.id,
-		PID:         uint32(c.process.Pid),
+		ExecId:      c.process.Token,
 		Signal:      uint32(signal),
 	}
 

--- a/vendor/github.com/kata-containers/agent/agent.go
+++ b/vendor/github.com/kata-containers/agent/agent.go
@@ -27,13 +27,14 @@ import (
 )
 
 type process struct {
-	id          int
+	id          string
 	process     libcontainer.Process
 	stdin       *os.File
 	stdout      *os.File
 	stderr      *os.File
 	consoleSock *os.File
 	termMaster  *os.File
+	exitCodeCh  chan int
 }
 
 type container struct {
@@ -43,7 +44,7 @@ type container struct {
 	initProcess *process
 	container   libcontainer.Container
 	config      configs.Config
-	processes   map[int]*process
+	processes   map[string]*process
 	mounts      []string
 }
 
@@ -63,8 +64,9 @@ type sandbox struct {
 }
 
 type namespace struct {
-	path string
-	init *os.Process
+	path       string
+	init       *os.Process
+	exitCodeCh <-chan int
 }
 
 var agentLog = logrus.WithFields(logrus.Fields{
@@ -93,11 +95,11 @@ func (p *process) closePostStartFDs() {
 	}
 
 	if p.process.ConsoleSocket != nil {
-		p.process.Stderr.(*os.File).Close()
+		p.process.ConsoleSocket.Close()
 	}
 
 	if p.consoleSock != nil {
-		p.process.Stderr.(*os.File).Close()
+		p.consoleSock.Close()
 	}
 }
 
@@ -122,15 +124,15 @@ func (p *process) closePostExitFDs() {
 	}
 }
 
-func (c *container) setProcess(pid int, process *process) {
+func (c *container) setProcess(execID string, process *process) {
 	c.Lock()
-	c.processes[pid] = process
+	c.processes[execID] = process
 	c.Unlock()
 }
 
-func (c *container) deleteProcess(pid int) {
+func (c *container) deleteProcess(execID string) {
 	c.Lock()
-	delete(c.processes, pid)
+	delete(c.processes, execID)
 	c.Unlock()
 }
 
@@ -145,13 +147,13 @@ func (c *container) removeContainer() error {
 	return removeMounts(c.mounts)
 }
 
-func (c *container) getProcess(pid int) (*process, error) {
+func (c *container) getProcess(execID string) (*process, error) {
 	c.RLock()
 	defer c.RUnlock()
 
-	proc, exist := c.processes[pid]
+	proc, exist := c.processes[execID]
 	if !exist {
-		return nil, fmt.Errorf("Process %d not found (container %s)", pid, c.id)
+		return nil, fmt.Errorf("Process %s not found (container %s)", execID, c.id)
 	}
 
 	return proc, nil
@@ -181,7 +183,7 @@ func (s *sandbox) deleteContainer(id string) {
 	s.Unlock()
 }
 
-func (s *sandbox) getRunningProcess(cid string, pid int) (*process, *container, error) {
+func (s *sandbox) getRunningProcess(cid, execID string) (*process, *container, error) {
 	if s.running == false {
 		return nil, nil, fmt.Errorf("Sandbox not started")
 	}
@@ -200,7 +202,7 @@ func (s *sandbox) getRunningProcess(cid string, pid int) (*process, *container, 
 		return nil, nil, fmt.Errorf("Container %s %s, should be %s", cid, status.String(), libcontainer.Running.String())
 	}
 
-	proc, err := ctr.getProcess(pid)
+	proc, err := ctr.getProcess(execID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -208,8 +210,8 @@ func (s *sandbox) getRunningProcess(cid string, pid int) (*process, *container, 
 	return proc, ctr, nil
 }
 
-func (s *sandbox) readStdio(cid string, pid int, length int, stdout bool) ([]byte, error) {
-	proc, _, err := s.getRunningProcess(cid, pid)
+func (s *sandbox) readStdio(cid, execID string, length int, stdout bool) ([]byte, error) {
+	proc, _, err := s.getRunningProcess(cid, execID)
 	if err != nil {
 		return nil, err
 	}
@@ -250,14 +252,16 @@ func (s *sandbox) setupSharedPidNs() error {
 		Cloneflags: syscall.CLONE_NEWPID,
 	}
 
-	if err := s.subreaper.start(cmd); err != nil {
+	exitCodeCh, err := s.subreaper.start(cmd)
+	if err != nil {
 		return err
 	}
 
 	// Save info about this namespace inside sandbox structure.
 	s.sharedPidNs = namespace{
-		path: fmt.Sprintf("/proc/%d/ns/pid", cmd.Process.Pid),
-		init: cmd.Process,
+		path:       fmt.Sprintf("/proc/%d/ns/pid", cmd.Process.Pid),
+		init:       cmd.Process,
+		exitCodeCh: exitCodeCh,
 	}
 
 	return nil
@@ -277,7 +281,7 @@ func (s *sandbox) teardownSharedPidNs() error {
 
 	// Using helper function wait() to deal with the subreaper.
 	osProcess := (*reaperOSProcess)(s.sharedPidNs.init)
-	if _, err := s.subreaper.wait(osProcess.Pid, osProcess); err != nil {
+	if _, err := s.subreaper.wait(s.sharedPidNs.exitCodeCh, osProcess); err != nil {
 		return err
 	}
 
@@ -414,7 +418,7 @@ func main() {
 		containers: make(map[string]*container),
 		running:    false,
 		subreaper: &reaper{
-			exitCodeChans: make(map[int]chan int),
+			exitCodeChans: make(map[int]chan<- int),
 		},
 	}
 

--- a/vendor/github.com/kata-containers/agent/codecov.yml
+++ b/vendor/github.com/kata-containers/agent/codecov.yml
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+ignore:
+  - "protocols/grpc/*.json"
+  - "protocols/grpc/*.pb.go"
+  - "protocols/grpc/*.proto"

--- a/vendor/github.com/kata-containers/agent/protocols/grpc/agent.proto
+++ b/vendor/github.com/kata-containers/agent/protocols/grpc/agent.proto
@@ -16,7 +16,7 @@ import "google/protobuf/empty.proto";
 service AgentService {
 	// execution
 	rpc CreateContainer(CreateContainerRequest) returns (google.protobuf.Empty);
-	rpc StartContainer(StartContainerRequest) returns (NewProcessResponse);
+	rpc StartContainer(StartContainerRequest) returns (google.protobuf.Empty);
 
 	// RemoveContainer will tear down an existing container by forcibly terminating
 	// all processes running inside that container and releasing all internal
@@ -25,7 +25,7 @@ service AgentService {
 	// If any process can not be killed or if it can not be killed after
 	// the RemoveContainerRequest timeout, RemoveContainer will return an error.
 	rpc RemoveContainer(RemoveContainerRequest) returns (google.protobuf.Empty);
-	rpc ExecProcess(ExecProcessRequest) returns (NewProcessResponse);
+	rpc ExecProcess(ExecProcessRequest) returns (google.protobuf.Empty);
 	rpc SignalProcess(SignalProcessRequest) returns (google.protobuf.Empty);
 	rpc WaitProcess(WaitProcessRequest) returns (WaitProcessResponse); // wait & reap like waitpid(2)
 
@@ -51,9 +51,10 @@ service AgentService {
 
 message CreateContainerRequest {
 	string container_id = 1;
-	StringUser string_user = 2;
-	repeated Storage storages = 3;
-	Spec OCI = 4;
+	string exec_id = 2;
+	StringUser string_user = 3;
+	repeated Storage storages = 4;
+	Spec OCI = 5;
 }
 
 message StartContainerRequest {
@@ -71,32 +72,26 @@ message RemoveContainerRequest {
 	uint32 timeout = 2;
 }
 
-// NewProcessResponse contains a Linux PID for a process
-// that the agent created and manages.
-// Any gRPC request from the host for a PID that is not managed
-// by the agent will result in an error. For example, calling
-// WaitProcess() with a WaitProcessRequest pid field set to a
-// PID that was not created by the agent will return an error
-// back to the caller.
-message NewProcessResponse {
-	uint32 PID = 1;
-}
-
 message ExecProcessRequest {
 	string container_id = 1;
+	string exec_id = 2;
 	StringUser string_user = 3;
 	Process process = 4;
 }
 
 message SignalProcessRequest {
 	string container_id = 1;
-	uint32 PID = 2;
+
+	// Special case for SignalProcess(): exec_id can be empty(""),
+	// which means to send the signal to all the processes including their descendants.
+	// Other APIs with exec_id should treat empty exec_id as an invalid request.
+	string exec_id = 2;
 	uint32 signal = 3;
 }
 
 message WaitProcessRequest {
 	string container_id = 1;
-	uint32 PID = 2;
+	string exec_id = 2;
 }
 
 message WaitProcessResponse {
@@ -105,7 +100,7 @@ message WaitProcessResponse {
 
 message WriteStreamRequest {
 	string container_id = 1;
-	uint32 PID = 2;
+	string exec_id = 2;
 	bytes data = 3;
 }
 
@@ -115,7 +110,7 @@ message WriteStreamResponse {
 
 message ReadStreamRequest {
 	string container_id = 1;
-	uint32 PID = 2;
+	string exec_id = 2;
 	uint32 len = 3;
 }
 
@@ -125,12 +120,12 @@ message ReadStreamResponse {
 
 message CloseStdinRequest {
 	string container_id = 1;
-	uint32 PID = 2;
+	string exec_id = 2;
 }
 
 message TtyWinResizeRequest {
 	string container_id = 1;
-	uint32 PID = 2;
+	string exec_id = 2;
 	uint32 row = 3;
 	uint32 column = 4;
 }

--- a/vendor/github.com/kata-containers/agent/protocols/grpc/health.pb.go
+++ b/vendor/github.com/kata-containers/agent/protocols/grpc/health.pb.go
@@ -108,7 +108,10 @@ func init() {
 }
 func (this *CheckRequest) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*CheckRequest)
@@ -121,7 +124,10 @@ func (this *CheckRequest) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -132,7 +138,10 @@ func (this *CheckRequest) Equal(that interface{}) bool {
 }
 func (this *HealthCheckResponse) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*HealthCheckResponse)
@@ -145,7 +154,10 @@ func (this *HealthCheckResponse) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -156,7 +168,10 @@ func (this *HealthCheckResponse) Equal(that interface{}) bool {
 }
 func (this *VersionCheckResponse) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*VersionCheckResponse)
@@ -169,7 +184,10 @@ func (this *VersionCheckResponse) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}

--- a/vendor/github.com/kata-containers/agent/protocols/grpc/oci.pb.go
+++ b/vendor/github.com/kata-containers/agent/protocols/grpc/oci.pb.go
@@ -1499,7 +1499,10 @@ func init() {
 }
 func (this *Spec) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Spec)
@@ -1512,7 +1515,10 @@ func (this *Spec) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1560,7 +1566,10 @@ func (this *Spec) Equal(that interface{}) bool {
 }
 func (this *Process) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Process)
@@ -1573,7 +1582,10 @@ func (this *Process) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1632,7 +1644,10 @@ func (this *Process) Equal(that interface{}) bool {
 }
 func (this *Box) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Box)
@@ -1645,7 +1660,10 @@ func (this *Box) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1659,7 +1677,10 @@ func (this *Box) Equal(that interface{}) bool {
 }
 func (this *User) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*User)
@@ -1672,7 +1693,10 @@ func (this *User) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1697,7 +1721,10 @@ func (this *User) Equal(that interface{}) bool {
 }
 func (this *LinuxCapabilities) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxCapabilities)
@@ -1710,7 +1737,10 @@ func (this *LinuxCapabilities) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1758,7 +1788,10 @@ func (this *LinuxCapabilities) Equal(that interface{}) bool {
 }
 func (this *POSIXRlimit) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*POSIXRlimit)
@@ -1771,7 +1804,10 @@ func (this *POSIXRlimit) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1788,7 +1824,10 @@ func (this *POSIXRlimit) Equal(that interface{}) bool {
 }
 func (this *Mount) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Mount)
@@ -1801,7 +1840,10 @@ func (this *Mount) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1826,7 +1868,10 @@ func (this *Mount) Equal(that interface{}) bool {
 }
 func (this *Root) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Root)
@@ -1839,7 +1884,10 @@ func (this *Root) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1853,7 +1901,10 @@ func (this *Root) Equal(that interface{}) bool {
 }
 func (this *Hooks) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Hooks)
@@ -1866,7 +1917,10 @@ func (this *Hooks) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1898,7 +1952,10 @@ func (this *Hooks) Equal(that interface{}) bool {
 }
 func (this *Hook) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Hook)
@@ -1911,7 +1968,10 @@ func (this *Hook) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -1941,7 +2001,10 @@ func (this *Hook) Equal(that interface{}) bool {
 }
 func (this *Linux) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Linux)
@@ -1954,7 +2017,10 @@ func (this *Linux) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2036,7 +2102,10 @@ func (this *Linux) Equal(that interface{}) bool {
 }
 func (this *Windows) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Windows)
@@ -2049,7 +2118,10 @@ func (this *Windows) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2060,7 +2132,10 @@ func (this *Windows) Equal(that interface{}) bool {
 }
 func (this *Solaris) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*Solaris)
@@ -2073,7 +2148,10 @@ func (this *Solaris) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2084,7 +2162,10 @@ func (this *Solaris) Equal(that interface{}) bool {
 }
 func (this *LinuxIDMapping) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxIDMapping)
@@ -2097,7 +2178,10 @@ func (this *LinuxIDMapping) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2114,7 +2198,10 @@ func (this *LinuxIDMapping) Equal(that interface{}) bool {
 }
 func (this *LinuxNamespace) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxNamespace)
@@ -2127,7 +2214,10 @@ func (this *LinuxNamespace) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2141,7 +2231,10 @@ func (this *LinuxNamespace) Equal(that interface{}) bool {
 }
 func (this *LinuxDevice) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxDevice)
@@ -2154,7 +2247,10 @@ func (this *LinuxDevice) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2183,7 +2279,10 @@ func (this *LinuxDevice) Equal(that interface{}) bool {
 }
 func (this *LinuxResources) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxResources)
@@ -2196,7 +2295,10 @@ func (this *LinuxResources) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2235,7 +2337,10 @@ func (this *LinuxResources) Equal(that interface{}) bool {
 }
 func (this *LinuxMemory) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxMemory)
@@ -2248,7 +2353,10 @@ func (this *LinuxMemory) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2277,7 +2385,10 @@ func (this *LinuxMemory) Equal(that interface{}) bool {
 }
 func (this *LinuxCPU) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxCPU)
@@ -2290,7 +2401,10 @@ func (this *LinuxCPU) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2319,7 +2433,10 @@ func (this *LinuxCPU) Equal(that interface{}) bool {
 }
 func (this *LinuxWeightDevice) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxWeightDevice)
@@ -2332,7 +2449,10 @@ func (this *LinuxWeightDevice) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2352,7 +2472,10 @@ func (this *LinuxWeightDevice) Equal(that interface{}) bool {
 }
 func (this *LinuxThrottleDevice) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxThrottleDevice)
@@ -2365,7 +2488,10 @@ func (this *LinuxThrottleDevice) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2382,7 +2508,10 @@ func (this *LinuxThrottleDevice) Equal(that interface{}) bool {
 }
 func (this *LinuxBlockIO) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxBlockIO)
@@ -2395,7 +2524,10 @@ func (this *LinuxBlockIO) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2449,7 +2581,10 @@ func (this *LinuxBlockIO) Equal(that interface{}) bool {
 }
 func (this *LinuxPids) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxPids)
@@ -2462,7 +2597,10 @@ func (this *LinuxPids) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2473,7 +2611,10 @@ func (this *LinuxPids) Equal(that interface{}) bool {
 }
 func (this *LinuxDeviceCgroup) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxDeviceCgroup)
@@ -2486,7 +2627,10 @@ func (this *LinuxDeviceCgroup) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2509,7 +2653,10 @@ func (this *LinuxDeviceCgroup) Equal(that interface{}) bool {
 }
 func (this *LinuxNetwork) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxNetwork)
@@ -2522,7 +2669,10 @@ func (this *LinuxNetwork) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2541,7 +2691,10 @@ func (this *LinuxNetwork) Equal(that interface{}) bool {
 }
 func (this *LinuxHugepageLimit) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxHugepageLimit)
@@ -2554,7 +2707,10 @@ func (this *LinuxHugepageLimit) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2568,7 +2724,10 @@ func (this *LinuxHugepageLimit) Equal(that interface{}) bool {
 }
 func (this *LinuxInterfacePriority) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxInterfacePriority)
@@ -2581,7 +2740,10 @@ func (this *LinuxInterfacePriority) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2595,7 +2757,10 @@ func (this *LinuxInterfacePriority) Equal(that interface{}) bool {
 }
 func (this *LinuxSeccomp) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxSeccomp)
@@ -2608,7 +2773,10 @@ func (this *LinuxSeccomp) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2635,7 +2803,10 @@ func (this *LinuxSeccomp) Equal(that interface{}) bool {
 }
 func (this *LinuxSeccompArg) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxSeccompArg)
@@ -2648,7 +2819,10 @@ func (this *LinuxSeccompArg) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2668,7 +2842,10 @@ func (this *LinuxSeccompArg) Equal(that interface{}) bool {
 }
 func (this *LinuxSyscall) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxSyscall)
@@ -2681,7 +2858,10 @@ func (this *LinuxSyscall) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}
@@ -2708,7 +2888,10 @@ func (this *LinuxSyscall) Equal(that interface{}) bool {
 }
 func (this *LinuxIntelRdt) Equal(that interface{}) bool {
 	if that == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	}
 
 	that1, ok := that.(*LinuxIntelRdt)
@@ -2721,7 +2904,10 @@ func (this *LinuxIntelRdt) Equal(that interface{}) bool {
 		}
 	}
 	if that1 == nil {
-		return this == nil
+		if this == nil {
+			return true
+		}
+		return false
 	} else if this == nil {
 		return false
 	}

--- a/vendor/golang.org/x/crypto/ssh/certs.go
+++ b/vendor/golang.org/x/crypto/ssh/certs.go
@@ -340,7 +340,7 @@ func (c *CertChecker) Authenticate(conn ConnMetadata, pubKey PublicKey) (*Permis
 // the signature of the certificate.
 func (c *CertChecker) CheckCert(principal string, cert *Certificate) error {
 	if c.IsRevoked != nil && c.IsRevoked(cert) {
-		return fmt.Errorf("ssh: certicate serial %d revoked", cert.Serial)
+		return fmt.Errorf("ssh: certificate serial %d revoked", cert.Serial)
 	}
 
 	for opt := range cert.CriticalOptions {


### PR DESCRIPTION
So that all runtimes based on virtcontainers will pull the same
kata agent commit and thus the same gRPC API.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>