### PR TITLE
gitignore: Add new shim binary to gitignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@
 /hack/virtc/virtc
 /hook/mock/hook
 /shim/mock/shim
+/shim/mock/cc-shim/cc-shim
+/shim/mock/kata-shim/kata-shim
 profile.cov


### PR DESCRIPTION
After new shim mocks have been added to the repository, we forgot to
add their binary names to the gitignore list.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>