### PR TITLE
Kata agent and proxy fixes

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -18,6 +18,7 @@ package virtcontainers
 
 import (
 	"fmt"
+	"path/filepath"
 	"syscall"
 
 	"github.com/mitchellh/mapstructure"
@@ -51,6 +52,13 @@ const (
 
 	// KataContainersAgent is the Kata Containers agent.
 	KataContainersAgent AgentType = "kata"
+
+	// SocketTypeVSOCK is a VSOCK socket type for talking to an agent.
+	SocketTypeVSOCK = "vsock"
+
+	// SocketTypeUNIX is a UNIX socket type for talking to an agent.
+	// It typically means the agent is living behind a host proxy.
+	SocketTypeUNIX = "unix"
 )
 
 // Set sets an agent type based on the input string.
@@ -119,6 +127,19 @@ func newAgentConfig(config PodConfig) interface{} {
 		return kataAgentConfig
 	default:
 		return nil
+	}
+}
+
+func defaultAgentURL(pod *Pod, socketType string) (string, error) {
+	switch socketType {
+	case SocketTypeUNIX:
+		socketPath := filepath.Join(runStoragePath, pod.id, "proxy.sock")
+		return fmt.Sprintf("unix://%s", socketPath), nil
+	case SocketTypeVSOCK:
+		// TODO Build the VSOCK default URL
+		return "", nil
+	default:
+		return "", fmt.Errorf("Unknown socket type: %s", socketType)
 	}
 }
 

--- a/container.go
+++ b/container.go
@@ -544,6 +544,10 @@ func (c *Container) start() error {
 	// inside the VM
 	c.getSystemMountInfo()
 
+	if err := c.pod.agent.createContainer(c.pod, c); err != nil {
+		return err
+	}
+
 	if err := c.pod.agent.startContainer(*(c.pod), *c); err != nil {
 		c.Logger().WithError(err).Error("Failed to start container")
 

--- a/hyperstart_agent.go
+++ b/hyperstart_agent.go
@@ -409,7 +409,7 @@ func (h *hyper) startOneContainer(pod Pod, c Container) error {
 	//TODO : Enter mount namespace
 
 	// Handle container mounts
-	newMounts, err := bindMountContainerMounts(defaultSharedDir, pod.id, c.id, c.mounts)
+	newMounts, err := bindMountContainerMounts(defaultSharedDir, "", pod.id, c.id, c.mounts)
 	if err != nil {
 		bindUnmountAllRootfs(defaultSharedDir, pod)
 		return err

--- a/kata_agent.go
+++ b/kata_agent.go
@@ -315,7 +315,7 @@ func (k *kataAgent) startPod(pod Pod) error {
 	req := &grpc.CreateSandboxRequest{
 		Hostname:     hostname,
 		Storages:     []*grpc.Storage{sharedVolume},
-		SandboxPidns: true,
+		SandboxPidns: false,
 	}
 
 	_, err := k.proxy.sendCmd(req)

--- a/kata_agent.go
+++ b/kata_agent.go
@@ -27,10 +27,9 @@ import (
 	"syscall"
 
 	vcAnnotations "github.com/containers/virtcontainers/pkg/annotations"
-
 	"github.com/kata-containers/agent/protocols/grpc"
-
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -74,6 +73,10 @@ type kataAgent struct {
 	vmSocket interface{}
 }
 
+func (k *kataAgent) Logger() *logrus.Entry {
+	return virtLog.WithField("subsystem", "kata_agent")
+}
+
 func parseVSOCKAddr(sock string) (uint32, uint32, error) {
 	sp := strings.Split(sock, ":")
 	if len(sp) != 3 {
@@ -108,6 +111,8 @@ func (k *kataAgent) generateVMSocket(pod *Pod, c *KataAgentConfig) error {
 		}
 
 		c.GRPCSocket = proxyURL
+
+		k.Logger().Info("Agent gRPC socket path %s", c.GRPCSocket)
 	}
 
 	cid, port, err := parseVSOCKAddr(c.GRPCSocket)

--- a/kata_agent.go
+++ b/kata_agent.go
@@ -413,7 +413,7 @@ func (k *kataAgent) createContainer(pod *Pod, c *Container) error {
 	}
 
 	// Handle container mounts
-	newMounts, err := bindMountContainerMounts(kataHostSharedDir, pod.id, c.id, c.mounts)
+	newMounts, err := bindMountContainerMounts(kataHostSharedDir, kataGuestSharedDir, pod.id, c.id, c.mounts)
 	if err != nil {
 		bindUnmountAllRootfs(kataHostSharedDir, *pod)
 		return err

--- a/kata_agent.go
+++ b/kata_agent.go
@@ -470,7 +470,15 @@ func (k *kataAgent) stopContainer(pod Pod, c Container) error {
 	}
 
 	_, err := k.proxy.sendCmd(req)
-	return err
+	if err != nil {
+		return err
+	}
+
+	if err := bindUnmountContainerRootfs(kataHostSharedDir, pod.id, c.id); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (k *kataAgent) killContainer(pod Pod, c Container, signal syscall.Signal, all bool) error {

--- a/kata_agent.go
+++ b/kata_agent.go
@@ -282,6 +282,7 @@ func (k *kataAgent) exec(pod *Pod, c Container, process Process, cmd Cmd) (err e
 
 	req := &grpc.ExecProcessRequest{
 		ContainerId: c.id,
+		ExecId:      c.process.Token,
 		Process:     kataProcess,
 	}
 
@@ -435,6 +436,7 @@ func (k *kataAgent) createContainer(pod *Pod, c *Container) error {
 
 	req := &grpc.CreateContainerRequest{
 		ContainerId: c.id,
+		ExecId:      c.process.Token,
 		Storages:    containerStorage,
 		OCI:         grpcSpec,
 	}

--- a/kata_agent.go
+++ b/kata_agent.go
@@ -35,7 +35,7 @@ import (
 
 var (
 	defaultKataSockPathTemplate = "%s/%s/kata.sock"
-	defaultKataChannel          = "io.katacontainers.channel"
+	defaultKataChannel          = "agent.channel.0"
 	defaultKataDeviceID         = "channel0"
 	defaultKataID               = "charch0"
 	errorMissingProxy           = errors.New("Missing proxy pointer")

--- a/kata_agent.go
+++ b/kata_agent.go
@@ -337,6 +337,8 @@ func appendStorageFromMounts(storage []*grpc.Storage, mounts []*Mount) []*grpc.S
 		s := &grpc.Storage{
 			Source:     m.Source,
 			MountPoint: m.Destination,
+			Fstype:     m.Type,
+			Options:    m.Options,
 		}
 
 		storage = append(storage, s)

--- a/kata_agent.go
+++ b/kata_agent.go
@@ -374,7 +374,7 @@ func (k *kataAgent) createContainer(pod *Pod, c *Container) error {
 	rootfs := &grpc.Storage{}
 
 	// First we need to give the OCI spec our absolute path in the guest.
-	grpcSpec.Root.Path = filepath.Join(kataGuestSharedDir, pod.id, c.id, rootfsDir)
+	grpcSpec.Root.Path = filepath.Join(kataGuestSharedDir, pod.id, rootfsDir)
 
 	if c.state.Fstype != "" {
 		// This is a block based device rootfs.

--- a/kata_proxy.go
+++ b/kata_proxy.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"syscall"
 
 	kataclient "github.com/kata-containers/agent/protocols/client"
 	"github.com/kata-containers/agent/protocols/grpc"
@@ -91,7 +92,8 @@ func (p *kataProxy) register(pod Pod) ([]ProxyInfo, string, error) {
 
 // unregister is kataProxy unregister implementation for proxy interface.
 func (p *kataProxy) unregister(pod Pod) error {
-	return nil
+	// Kill the proxy. This should ideally be dealt with from a stop method.
+	return syscall.Kill(pod.state.ProxyPid, syscall.SIGKILL)
 }
 
 // connect is kataProxy connect implementation for proxy interface.

--- a/kata_proxy.go
+++ b/kata_proxy.go
@@ -17,7 +17,12 @@
 package virtcontainers
 
 import (
+	"context"
+	"fmt"
 	"os/exec"
+
+	kataclient "github.com/kata-containers/agent/protocols/client"
+	"github.com/kata-containers/agent/protocols/grpc"
 )
 
 // This is the Kata Containers implementation of the proxy interface.
@@ -25,6 +30,7 @@ import (
 // runtime and shim as if they were talking directly to the agent.
 type kataProxy struct {
 	proxyURL string
+	client   *kataclient.AgentClient
 }
 
 // start is kataProxy start implementation for proxy interface.
@@ -66,6 +72,12 @@ func (p *kataProxy) start(pod Pod) (int, string, error) {
 
 // register is kataProxy register implementation for proxy interface.
 func (p *kataProxy) register(pod Pod) ([]ProxyInfo, string, error) {
+	client, err := kataclient.NewAgentClient(p.proxyURL)
+	if err != nil {
+		return []ProxyInfo{}, "", err
+	}
+	p.client = client
+
 	var proxyInfos []ProxyInfo
 
 	for i := 0; i < len(pod.containers); i++ {
@@ -84,15 +96,56 @@ func (p *kataProxy) unregister(pod Pod) error {
 
 // connect is kataProxy connect implementation for proxy interface.
 func (p *kataProxy) connect(pod Pod, createToken bool) (ProxyInfo, string, error) {
+	client, err := kataclient.NewAgentClient(pod.state.URL)
+	if err != nil {
+		return ProxyInfo{}, "", err
+	}
+
+	p.client = client
+
 	return ProxyInfo{}, p.proxyURL, nil
 }
 
 // disconnect is kataProxy disconnect implementation for proxy interface.
 func (p *kataProxy) disconnect() error {
+	if p.client == nil {
+		return fmt.Errorf("Client is nil, we can't interact with kata-proxy")
+	}
+
+	p.client.Close()
+
 	return nil
 }
 
 // sendCmd is kataProxy sendCmd implementation for proxy interface.
 func (p *kataProxy) sendCmd(cmd interface{}) (interface{}, error) {
-	return nil, nil
+	if p.client == nil {
+		return nil, fmt.Errorf("Client is nil, we can't interact with kata-proxy")
+	}
+
+	switch c := cmd.(type) {
+	case *grpc.ExecProcessRequest:
+		_, err := p.client.ExecProcess(context.Background(), c)
+		return nil, err
+	case *grpc.CreateSandboxRequest:
+		_, err := p.client.CreateSandbox(context.Background(), c)
+		return nil, err
+	case *grpc.DestroySandboxRequest:
+		_, err := p.client.DestroySandbox(context.Background(), c)
+		return nil, err
+	case *grpc.CreateContainerRequest:
+		_, err := p.client.CreateContainer(context.Background(), c)
+		return nil, err
+	case *grpc.StartContainerRequest:
+		_, err := p.client.StartContainer(context.Background(), c)
+		return nil, err
+	case *grpc.RemoveContainerRequest:
+		_, err := p.client.RemoveContainer(context.Background(), c)
+		return nil, err
+	case *grpc.SignalProcessRequest:
+		_, err := p.client.SignalProcess(context.Background(), c)
+		return nil, err
+	default:
+		return nil, fmt.Errorf("Unknown gRPC type %T", c)
+	}
 }

--- a/kata_proxy.go
+++ b/kata_proxy.go
@@ -65,6 +65,7 @@ func (p *kataProxy) start(pod Pod) (int, string, error) {
 	args := []string{config.Path, "-listen-socket", proxyURL, "-mux-socket", vmURL}
 	if config.Debug {
 		args = append(args, "-log", "debug")
+		args = append(args, "-agent-logs-socket", pod.hypervisor.getPodConsole(pod.id))
 	}
 
 	cmd := exec.Command(args[0], args[1:]...)

--- a/kata_proxy.go
+++ b/kata_proxy.go
@@ -36,6 +36,10 @@ type kataProxy struct {
 
 // start is kataProxy start implementation for proxy interface.
 func (p *kataProxy) start(pod Pod) (int, string, error) {
+	if pod.agent == nil {
+		return -1, "", fmt.Errorf("No agent")
+	}
+
 	config, err := newProxyConfig(pod.config)
 	if err != nil {
 		return -1, "", err

--- a/kata_proxy.go
+++ b/kata_proxy.go
@@ -17,9 +17,7 @@
 package virtcontainers
 
 import (
-	"fmt"
 	"os/exec"
-	"path/filepath"
 )
 
 // This is the Kata Containers implementation of the proxy interface.
@@ -37,8 +35,10 @@ func (p *kataProxy) start(pod Pod) (int, string, error) {
 	}
 
 	// construct the socket path the proxy instance will use
-	socketPath := filepath.Join(runStoragePath, pod.id, "kata_proxy.sock")
-	proxyURL := fmt.Sprintf("unix://%s", socketPath)
+	proxyURL, err := defaultAgentURL(&pod, SocketTypeUNIX)
+	if err != nil {
+		return -1, "", err
+	}
 
 	vmURL, err := pod.agent.vmURL()
 	if err != nil {

--- a/kata_proxy_test.go
+++ b/kata_proxy_test.go
@@ -17,12 +17,34 @@
 package virtcontainers
 
 import (
+	"context"
+	"net"
 	"testing"
+
+	"github.com/containers/virtcontainers/pkg/mock"
+	gpb "github.com/gogo/protobuf/types"
+	pb "github.com/kata-containers/agent/protocols/grpc"
+	"google.golang.org/grpc"
 )
 
-var testKataProxyURL = "vmURL"
+var testKataProxyURL = "unix:///tmp/kata-proxy-test.sock"
+
+func proxyHandlerDiscard(c net.Conn) {
+	buf := make([]byte, 1024)
+	c.Read(buf)
+}
 
 func TestKataProxyRegister(t *testing.T) {
+	proxy := mock.ProxyUnixMock{
+		ClientHandler: proxyHandlerDiscard,
+	}
+
+	if err := proxy.Start(testKataProxyURL); err != nil {
+		t.Fatal(err)
+	}
+
+	defer proxy.Stop()
+
 	p := &kataProxy{
 		proxyURL: testKataProxyURL,
 	}
@@ -37,20 +59,28 @@ func TestKataProxyRegister(t *testing.T) {
 	}
 }
 
-func TestKataProxyUnregister(t *testing.T) {
-	p := &kataProxy{}
+func TestKataProxyConnect(t *testing.T) {
+	proxy := mock.ProxyUnixMock{
+		ClientHandler: proxyHandlerDiscard,
+	}
 
-	if err := p.unregister(Pod{}); err != nil {
+	if err := proxy.Start(testKataProxyURL); err != nil {
 		t.Fatal(err)
 	}
-}
 
-func TestKataProxyConnect(t *testing.T) {
+	defer proxy.Stop()
+
 	p := &kataProxy{
 		proxyURL: testKataProxyURL,
 	}
 
-	_, proxyURL, err := p.connect(Pod{}, false)
+	_, proxyURL, err := p.connect(
+		Pod{
+			state: State{
+				URL: testKataProxyURL,
+			},
+		},
+		false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,17 +91,162 @@ func TestKataProxyConnect(t *testing.T) {
 }
 
 func TestKataProxyDisconnect(t *testing.T) {
-	p := &kataProxy{}
+	proxy := mock.ProxyUnixMock{
+		ClientHandler: proxyHandlerDiscard,
+	}
+
+	if err := proxy.Start(testKataProxyURL); err != nil {
+		t.Fatal(err)
+	}
+
+	defer proxy.Stop()
+
+	p := &kataProxy{
+		proxyURL: testKataProxyURL,
+	}
+
+	_, proxyURL, err := p.connect(
+		Pod{
+			state: State{
+				URL: testKataProxyURL,
+			},
+		},
+		false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if proxyURL != testKataProxyURL {
+		t.Fatalf("Got URL %q, expecting %q", proxyURL, testKataProxyURL)
+	}
 
 	if err := p.disconnect(); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestKataProxySendCmd(t *testing.T) {
-	p := &kataProxy{}
+type gRPCProxy struct{}
 
-	if _, err := p.sendCmd(nil); err != nil {
+var emptyResp = &gpb.Empty{}
+
+func (p *gRPCProxy) CreateContainer(ctx context.Context, req *pb.CreateContainerRequest) (*gpb.Empty, error) {
+	return emptyResp, nil
+}
+
+func (p *gRPCProxy) StartContainer(ctx context.Context, req *pb.StartContainerRequest) (*gpb.Empty, error) {
+	return emptyResp, nil
+}
+
+func (p *gRPCProxy) ExecProcess(ctx context.Context, req *pb.ExecProcessRequest) (*gpb.Empty, error) {
+	return emptyResp, nil
+}
+
+func (p *gRPCProxy) SignalProcess(ctx context.Context, req *pb.SignalProcessRequest) (*gpb.Empty, error) {
+	return emptyResp, nil
+}
+
+func (p *gRPCProxy) WaitProcess(ctx context.Context, req *pb.WaitProcessRequest) (*pb.WaitProcessResponse, error) {
+	return &pb.WaitProcessResponse{}, nil
+}
+
+func (p *gRPCProxy) RemoveContainer(ctx context.Context, req *pb.RemoveContainerRequest) (*gpb.Empty, error) {
+	return emptyResp, nil
+}
+
+func (p *gRPCProxy) WriteStdin(ctx context.Context, req *pb.WriteStreamRequest) (*pb.WriteStreamResponse, error) {
+	return &pb.WriteStreamResponse{}, nil
+}
+
+func (p *gRPCProxy) ReadStdout(ctx context.Context, req *pb.ReadStreamRequest) (*pb.ReadStreamResponse, error) {
+	return &pb.ReadStreamResponse{}, nil
+}
+
+func (p *gRPCProxy) ReadStderr(ctx context.Context, req *pb.ReadStreamRequest) (*pb.ReadStreamResponse, error) {
+	return &pb.ReadStreamResponse{}, nil
+}
+
+func (p *gRPCProxy) CloseStdin(ctx context.Context, req *pb.CloseStdinRequest) (*gpb.Empty, error) {
+	return emptyResp, nil
+}
+
+func (p *gRPCProxy) TtyWinResize(ctx context.Context, req *pb.TtyWinResizeRequest) (*gpb.Empty, error) {
+	return emptyResp, nil
+}
+
+func (p *gRPCProxy) CreateSandbox(ctx context.Context, req *pb.CreateSandboxRequest) (*gpb.Empty, error) {
+	return emptyResp, nil
+}
+
+func (p *gRPCProxy) DestroySandbox(ctx context.Context, req *pb.DestroySandboxRequest) (*gpb.Empty, error) {
+	return emptyResp, nil
+}
+
+func (p *gRPCProxy) AddInterface(ctx context.Context, req *pb.AddInterfaceRequest) (*gpb.Empty, error) {
+	return emptyResp, nil
+}
+
+func (p *gRPCProxy) RemoveInterface(ctx context.Context, req *pb.RemoveInterfaceRequest) (*gpb.Empty, error) {
+	return emptyResp, nil
+}
+
+func (p *gRPCProxy) UpdateInterface(ctx context.Context, req *pb.UpdateInterfaceRequest) (*gpb.Empty, error) {
+	return emptyResp, nil
+}
+
+func (p *gRPCProxy) AddRoute(ctx context.Context, req *pb.RouteRequest) (*gpb.Empty, error) {
+	return emptyResp, nil
+}
+
+func (p *gRPCProxy) RemoveRoute(ctx context.Context, req *pb.RouteRequest) (*gpb.Empty, error) {
+	return emptyResp, nil
+}
+
+func (p *gRPCProxy) OnlineCPUMem(ctx context.Context, req *pb.OnlineCPUMemRequest) (*gpb.Empty, error) {
+	return emptyResp, nil
+}
+
+func gRPCRegister(s *grpc.Server, srv interface{}) {
+	switch g := srv.(type) {
+	case *gRPCProxy:
+		pb.RegisterAgentServiceServer(s, g)
+	}
+}
+
+func TestKataProxySendCmd(t *testing.T) {
+	impl := &gRPCProxy{}
+
+	proxy := mock.ProxyGRPCMock{
+		GRPCImplementer: impl,
+		GRPCRegister:    gRPCRegister,
+	}
+
+	if err := proxy.Start(testKataProxyURL); err != nil {
+		t.Fatal(err)
+	}
+
+	defer proxy.Stop()
+
+	p := &kataProxy{
+		proxyURL: testKataProxyURL,
+	}
+
+	_, proxyURL, err := p.connect(
+		Pod{
+			state: State{
+				URL: testKataProxyURL,
+			},
+		},
+		false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if proxyURL != testKataProxyURL {
+		t.Fatalf("Got URL %q, expecting %q", proxyURL, testKataProxyURL)
+	}
+
+	req := &pb.DestroySandboxRequest{}
+	if _, err := p.sendCmd(req); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/mount.go
+++ b/mount.go
@@ -309,7 +309,7 @@ type Mount struct {
 // which is mounted through 9pfs in the VM.
 // Hyperstart uses "fsmap" struct to bind mount these mounts in the hypertstart shared directory
 // to the correct mountpoint within the container rootfs.
-func bindMountContainerMounts(sharedDir, podID string, cID string, mounts []Mount) ([]*Mount, error) {
+func bindMountContainerMounts(hostSharedDir, guestSharedDir, podID string, cID string, mounts []Mount) ([]*Mount, error) {
 	if mounts == nil {
 		return nil, nil
 	}
@@ -337,7 +337,7 @@ func bindMountContainerMounts(sharedDir, podID string, cID string, mounts []Moun
 
 		// These mounts are created in the shared dir
 		filename := fmt.Sprintf("%s-%s-%s", cID, hex.EncodeToString(randBytes), filepath.Base(m.Destination))
-		mountDest := filepath.Join(sharedDir, podID, filename)
+		mountDest := filepath.Join(hostSharedDir, podID, filename)
 
 		err = bindMount(m.Source, mountDest, false)
 		if err != nil {
@@ -355,7 +355,7 @@ func bindMountContainerMounts(sharedDir, podID string, cID string, mounts []Moun
 		}
 
 		newMount := &Mount{
-			Source:      filename,
+			Source:      filepath.Join(guestSharedDir, filename),
 			Destination: m.Destination,
 			Type:        m.Type,
 			Options:     m.Options,

--- a/mount.go
+++ b/mount.go
@@ -357,6 +357,8 @@ func bindMountContainerMounts(sharedDir, podID string, cID string, mounts []Moun
 		newMount := &Mount{
 			Source:      filename,
 			Destination: m.Destination,
+			Type:        m.Type,
+			Options:     m.Options,
 			ReadOnly:    readonly,
 		}
 		newMounts = append(newMounts, newMount)

--- a/qemu.go
+++ b/qemu.go
@@ -554,10 +554,9 @@ func (q *qemu) init(pod *Pod) error {
 		return err
 	}
 
-	q.Logger().WithField("inside-vm", fmt.Sprintf("%t", nested)).Debug("Checking nesting environment")
-
 	if q.config.DisableNestingChecks {
 		//Intentionally ignore the nesting check
+		q.Logger().WithField("inside-vm", fmt.Sprintf("%t", nested)).Debug("Disable nesting environment checksx")
 		q.nestedRun = false
 	} else {
 		q.nestedRun = nested


### PR DESCRIPTION
Now that we can test all kata containers components with virtcontainers, here is my first round of fixes:

- Build and store a default gRPC socket.
- Move the gRPC client handling from kata_agent to kata_proxy.
- Misc fixes from Sebastien.
