### PR TITLE
shim: Correct kata debug flag

### DIFF
--- a/kata_shim.go
+++ b/kata_shim.go
@@ -60,7 +60,7 @@ func (s *kataShim) start(pod Pod, params ShimParams) (int, error) {
 
 	args := []string{config.Path, "-agent", params.URL, "-container", params.Container, "-exec-id", params.Token}
 	if config.Debug {
-		args = append(args, "-d")
+		args = append(args, "-log", "debug")
 	}
 
 	return startShim(args, params)


### PR DESCRIPTION
Fixed the CLI flag that is passed to `kata-shim` to run it in debug
mode.

Fixes #550.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>