### PR TITLE
qemu: adjust QMP naming to avoid non-unique truncation

### DIFF
--- a/pod.go
+++ b/pod.go
@@ -30,13 +30,13 @@ import (
 // controlSocket is the pod control socket.
 // It is an hypervisor resource, and for example qemu's control
 // socket is the QMP one.
-const controlSocket = "ctrl.sock"
+const controlSocket = "ctl"
 
 // monitorSocket is the pod monitoring socket.
 // It is an hypervisor resource, and is a qmp socket in the qemu case.
 // This is a socket that any monitoring entity will listen to in order
 // to understand if the VM is still alive or not.
-const monitorSocket = "monitor.sock"
+const monitorSocket = "mon"
 
 // vmStartTimeout represents the time in seconds a pod can wait before
 // to consider the VM starting operation failed.

--- a/qemu.go
+++ b/qemu.go
@@ -615,7 +615,7 @@ func (q *qemu) qmpSocketPath(socketName string) (string, error) {
 			parentDirPath, len(parentDirPath))
 	}
 
-	path := fmt.Sprintf("%s/%s-%s", parentDirPath, q.state.UUID, socketName)
+	path := fmt.Sprintf("%s/%s-%s", parentDirPath, socketName, q.state.UUID)
 
 	if len(path) > qmpSockPathSizeLimit {
 		return path[:qmpSockPathSizeLimit], nil


### PR DESCRIPTION
The full name of the QMP monitor and control sockets was well
beyond the 107 character limit, resulting in the full name to
be truncated during creation.  As a result, only a single socket
was created.

Instead of creating a socket at
<parentDirPath>/<q.state.UUID>-<socketName>, create it at
<parentDirPath>/<socketName>-<q.state.UUID>, keeping as much of the
unique socket name as feasible.

Also, to reduce truncation the ".sock" from the socket names were removed.

Fixes #552

Signed-off-by: Eric Ernst <eric.ernst@intel.com>