### PR TITLE
mount: Fix unmount of dangling bind-mounts

### DIFF
--- a/mount.go
+++ b/mount.go
@@ -373,11 +373,13 @@ func bindUnmountContainerMounts(mounts []Mount) error {
 	for _, m := range mounts {
 		if !isSystemMount(m.Destination) && m.Type == "bind" {
 			err := syscall.Unmount(m.HostPath, 0)
-			mountLogger().WithFields(logrus.Fields{
-				"host-path": m.HostPath,
-				"error":     err,
-			}).Warn("Could not umount")
-			return err
+			if err != nil {
+				mountLogger().WithFields(logrus.Fields{
+					"host-path": m.HostPath,
+					"error":     err,
+				}).Warn("Could not umount")
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Fix bug whereby the first bind mount that was unmounted would always
exit the unmount loop, leaving the other bind-mounts in place after the
container had been deleted.

Fixes #566.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>