### PR TITLE
logging: Set source field for oci and hyperstart packages

### DIFF
--- a/pkg/hyperstart/hyperstart.go
+++ b/pkg/hyperstart/hyperstart.go
@@ -135,7 +135,7 @@ var hyperLog = logrus.FieldLogger(logrus.New())
 
 // SetLogger sets the logger for hyperstart package.
 func SetLogger(logger logrus.FieldLogger) {
-	hyperLog = logger
+	hyperLog = logger.WithField("source", "virtcontainers/hyperstart")
 }
 
 // NewHyperstart returns a new hyperstart structure.

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -104,7 +104,7 @@ var ociLog = logrus.FieldLogger(logrus.New())
 
 // SetLogger sets the logger for oci package.
 func SetLogger(logger logrus.FieldLogger) {
-	ociLog = logger
+	ociLog = logger.WithField("source", "virtcontainers/oci")
 }
 
 func cmdEnvs(spec CompatOCISpec, envs []vc.EnvVar) []vc.EnvVar {


### PR DESCRIPTION
Change the `SetLogger()` API calls in the `oci` and `hyperstart`
packages so that they set the `source` logger field. This allows
callers making use of these packages to see the true source of the log
messages (previously, it would appear that log calls made by these two
packages would be coming *from* the caller itself).

Fixes #571.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>