### PR TITLE
build: Only clean files if they exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,11 +82,11 @@ install:
 #
 
 define UNINSTALL_EXEC
-	rm -f $(VC_BIN_DIR)/$1 || exit 1;
+	rm -f $(call FILE_SAFE_TO_REMOVE,$(VC_BIN_DIR)/$1) || exit 1;
 endef
 
 define UNINSTALL_TEST_EXEC
-	rm -f $(TEST_BIN_DIR)/$1 || exit 1;
+	rm -f $(call FILE_SAFE_TO_REMOVE,$(TEST_BIN_DIR)/$1) || exit 1;
 endef
 
 uninstall:
@@ -99,11 +99,19 @@ uninstall:
 # Clean
 #
 
+# Input: filename to check.
+# Output: filename, assuming the file exists and is safe to delete.
+define FILE_SAFE_TO_REMOVE =
+$(shell test -e "$(1)" && test "$(1)" != "/" && echo "$(1)")
+endef
+
+CLEAN_FILES += $(VIRTC_DIR)/$(VIRTC_BIN)
+CLEAN_FILES += $(HOOK_DIR)/$(HOOK_BIN)
+CLEAN_FILES += $(SHIM_DIR)/$(CC_SHIM_BIN)
+CLEAN_FILES += $(SHIM_DIR)/$(KATA_SHIM_BIN)
+
 clean:
-	rm -f $(VIRTC_DIR)/$(VIRTC_BIN)
-	rm -f $(HOOK_DIR)/$(HOOK_BIN)
-	rm -f $(CC_SHIM_DIR)/$(CC_SHIM_BIN)
-	rm -f $(KATA_SHIM_DIR)/$(KATA_SHIM_BIN)
+	rm -f $(foreach f,$(CLEAN_FILES),$(call FILE_SAFE_TO_REMOVE,$(f)))
 
 .PHONY: \
 	all \

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,8 @@ endef
 uninstall:
 	$(call UNINSTALL_EXEC,$(VIRTC_BIN))
 	$(call UNINSTALL_TEST_EXEC,$(HOOK_BIN))
-	$(call UNINSTALL_TEST_EXEC,$(SHIM_BIN))
+	$(call UNINSTALL_TEST_EXEC,$(CC_SHIM_BIN))
+	$(call UNINSTALL_TEST_EXEC,$(KATA_SHIM_BIN))
 
 #
 # Clean
@@ -101,7 +102,8 @@ uninstall:
 clean:
 	rm -f $(VIRTC_DIR)/$(VIRTC_BIN)
 	rm -f $(HOOK_DIR)/$(HOOK_BIN)
-	rm -f $(SHIM_DIR)/$(SHIM_BIN)
+	rm -f $(CC_SHIM_DIR)/$(CC_SHIM_BIN)
+	rm -f $(KATA_SHIM_DIR)/$(KATA_SHIM_BIN)
 
 .PHONY: \
 	all \


### PR DESCRIPTION
Check before attempting to delete a file that it exists
(and is not "/").
    
Fixes #555.
    
Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>