### PR TITLE
[WIP] ci: Switch to codecov for code coverage reports

### DIFF
--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -24,7 +24,7 @@ test_ldflags="-X github.com/containers/virtcontainers/pkg/mock.DefaultMockCCShim
 echo "Run go test and generate coverage:"
 for pkg in $test_packages; do
 	if [ "$pkg" = "github.com/containers/virtcontainers" ]; then
-		sudo env GOPATH=$GOPATH GOROOT=$GOROOT PATH=$PATH go test -ldflags "$test_ldflags" -cover -coverprofile=profile.cov $pkg
+		sudo env GOPATH=$GOPATH GOROOT=$GOROOT PATH=$PATH go test -ldflags "$test_ldflags" -cover -coverprofile=coverage.txt $pkg
 	else
 		sudo env GOPATH=$GOPATH GOROOT=$GOROOT PATH=$PATH go test -ldflags "$test_ldflags" -cover $pkg
 	fi

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -24,13 +24,6 @@ export GOPATH=${HOME}/go
 export PATH=${GOPATH}/bin:/usr/local/go/bin:/usr/sbin:${PATH}
 export CI=true
 
-# Download and build goveralls binary in case we need to submit the code
-# coverage.
-if [ ${COVERALLS_REPO_TOKEN} ]
-then
-	go get github.com/mattn/goveralls
-fi
-
 # Get the repository and move HEAD to the appropriate commit.
 go get ${vc_repo} || true
 cd "${GOPATH}/src/${vc_repo}"
@@ -48,8 +41,4 @@ fi
 sudo -E PATH=$PATH bash .ci/setup.sh
 sudo -E PATH=$PATH bash .ci/run.sh
 
-# Publish the code coverage if needed.
-if [ ${COVERALLS_REPO_TOKEN} ]
-then
-	sudo -E PATH=${PATH} bash -c "${GOPATH}/bin/goveralls -repotoken=${COVERALLS_REPO_TOKEN} -coverprofile=profile.cov"
-fi
+bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
coveralls is erratic and not reliable.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>