### PR TITLE
Start shims after creating containers

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -178,7 +178,7 @@ type agent interface {
 	createPod(pod *Pod) error
 
 	// exec will tell the agent to run a command in an already running container.
-	exec(pod *Pod, c Container, process Process, cmd Cmd) error
+	exec(pod *Pod, c Container, cmd Cmd) (*Process, error)
 
 	// startPod will tell the agent to start all containers related to the Pod.
 	startPod(pod Pod) error

--- a/api.go
+++ b/api.go
@@ -86,12 +86,6 @@ func createPodFromConfig(podConfig PodConfig) (*Pod, error) {
 		return nil, err
 	}
 
-	// Start the proxy
-	err = p.startProxy()
-	if err != nil {
-		return nil, err
-	}
-
 	// Start shims
 	if err := p.startShims(); err != nil {
 		return nil, err

--- a/api.go
+++ b/api.go
@@ -48,12 +48,6 @@ func createPodFromConfig(podConfig PodConfig) (*Pod, error) {
 		return nil, err
 	}
 
-	// Store it.
-	err = p.storePod()
-	if err != nil {
-		return nil, err
-	}
-
 	// Initialize the network.
 	netNsPath, netNsCreated, err := p.network.init(p.config.NetworkConfig)
 	if err != nil {
@@ -88,6 +82,11 @@ func createPodFromConfig(podConfig PodConfig) (*Pod, error) {
 
 	// Create Containers
 	if err := p.createContainers(); err != nil {
+		return nil, err
+	}
+
+	// The pod is completely created now, we can store it.
+	if err := p.storePod(); err != nil {
 		return nil, err
 	}
 

--- a/api.go
+++ b/api.go
@@ -86,8 +86,8 @@ func createPodFromConfig(podConfig PodConfig) (*Pod, error) {
 		return nil, err
 	}
 
-	// Start shims
-	if err := p.startShims(); err != nil {
+	// Create Containers
+	if err := p.createContainers(); err != nil {
 		return nil, err
 	}
 

--- a/container.go
+++ b/container.go
@@ -230,7 +230,7 @@ func (c *Container) startShim(token string, initProcess bool) (*Process, error) 
 		processToken = proxyInfo.Token
 	}
 
-	process, err := c.createShimProcess(processToken, url, c.config.Cmd)
+	process, err := c.startShimProcess(processToken, url, c.config.Cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -749,7 +749,7 @@ func (c *Container) processList(options ProcessListOptions) (ProcessList, error)
 	return c.pod.agent.processListContainer(*(c.pod), *c, options)
 }
 
-func (c *Container) createShimProcess(token, url string, cmd Cmd) (*Process, error) {
+func (c *Container) startShimProcess(token, url string, cmd Cmd) (*Process, error) {
 	if c.pod.state.URL != url {
 		return &Process{}, fmt.Errorf("Pod URL %q and URL from proxy %q MUST be identical", c.pod.state.URL, url)
 	}

--- a/container.go
+++ b/container.go
@@ -396,26 +396,6 @@ func newContainer(pod *Pod, contConfig ContainerConfig) (*Container, error) {
 	return c, nil
 }
 
-// newContainers uses newContainer to create a Container slice.
-func newContainers(pod *Pod, contConfigs []ContainerConfig) ([]*Container, error) {
-	if pod == nil {
-		return nil, errNeedPod
-	}
-
-	var containers []*Container
-
-	for _, contConfig := range contConfigs {
-		c, err := newContainer(pod, contConfig)
-		if err != nil {
-			return containers, err
-		}
-
-		containers = append(containers, c)
-	}
-
-	return containers, nil
-}
-
 // createContainer creates and start a container inside a Pod.
 func createContainer(pod *Pod, contConfig ContainerConfig) (*Container, error) {
 	if pod == nil {
@@ -776,21 +756,6 @@ func (c *Container) startShimProcess(token, url string, cmd Cmd) (*Process, erro
 	process.Pid = pid
 
 	return &process, nil
-}
-
-func newInitProcess(token, containerID string) Process {
-	if token == "" {
-		// Some proxy implementations will not generate
-		// a process token. In that case virtcontainers
-		// generates one and it re-uses the container ID
-		// for init processes.
-		token = containerID
-	}
-
-	return Process{
-		Token:     token,
-		StartTime: time.Now().UTC(),
-	}
 }
 
 func (c *Container) hotplugDrive() error {

--- a/container.go
+++ b/container.go
@@ -215,7 +215,7 @@ func (c *Container) GetAnnotations() map[string]string {
 	return c.config.Annotations
 }
 
-func (c *Container) startShim(token string, initProcess bool) (*Process, error) {
+func (c *Container) startShim(token string, cmd Cmd, initProcess bool) (*Process, error) {
 	proxyInfo, url, err := c.pod.proxy.connect(*(c.pod), true)
 	if err != nil {
 		return nil, err
@@ -230,7 +230,7 @@ func (c *Container) startShim(token string, initProcess bool) (*Process, error) 
 		processToken = proxyInfo.Token
 	}
 
-	process, err := c.startShimProcess(processToken, url, c.config.Cmd)
+	process, err := c.startShimProcess(processToken, url, cmd)
 	if err != nil {
 		return nil, err
 	}

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -34,17 +34,19 @@ func TestFilesystemCreateAllResourcesSuccessful(t *testing.T) {
 		{ID: "100"},
 	}
 
+	podConfig := &PodConfig{
+		Containers: contConfigs,
+	}
+
 	pod := Pod{
 		id:      testPodID,
 		storage: fs,
+		config:  podConfig,
 	}
 
-	containers, err := newContainers(&pod, contConfigs)
-	if err != nil {
+	if err := pod.newContainers(); err != nil {
 		t.Fatal(err)
 	}
-
-	pod.containers = containers
 
 	podConfigPath := filepath.Join(configStoragePath, testPodID)
 	podRunPath := filepath.Join(runStoragePath, testPodID)
@@ -60,7 +62,7 @@ func TestFilesystemCreateAllResourcesSuccessful(t *testing.T) {
 		os.RemoveAll(runPath)
 	}
 
-	err = fs.createAllResources(pod)
+	err := fs.createAllResources(pod)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/hyperstart_agent.go
+++ b/hyperstart_agent.go
@@ -305,15 +305,20 @@ func (h *hyper) capabilities() capabilities {
 }
 
 // exec is the agent command execution implementation for hyperstart.
-func (h *hyper) exec(pod *Pod, c Container, process Process, cmd Cmd) error {
+func (h *hyper) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
 	hyperProcess, err := h.buildHyperContainerProcess(cmd)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	execCommand := hyperstart.ExecCommand{
 		Container: c.id,
 		Process:   *hyperProcess,
+	}
+
+	process, err := c.startShim("", false)
+	if err != nil {
+		return nil, err
 	}
 
 	proxyCmd := hyperstartProxyCmd{
@@ -322,11 +327,20 @@ func (h *hyper) exec(pod *Pod, c Container, process Process, cmd Cmd) error {
 		token:   process.Token,
 	}
 
+	// HACK startShim just closed the connection on us,
+	// we need to reconnect...
+	// This will be fixed by handling all proxy ops from
+	// the agent implementations.
+	if _, _, err := h.proxy.connect(*(pod), false); err != nil {
+		return nil, err
+	}
+	defer h.proxy.disconnect()
+
 	if _, err := h.proxy.sendCmd(proxyCmd); err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return process, nil
 }
 
 // startPod is the agent Pod starting implementation for hyperstart.
@@ -450,7 +464,8 @@ func (h *hyper) startOneContainer(pod Pod, c Container) error {
 
 // createContainer is the agent Container creation implementation for hyperstart.
 func (h *hyper) createContainer(pod *Pod, c *Container) error {
-	return nil
+	_, err := c.startShim("", true)
+	return err
 }
 
 // startContainer is the agent Container starting implementation for hyperstart.

--- a/hyperstart_agent.go
+++ b/hyperstart_agent.go
@@ -316,7 +316,7 @@ func (h *hyper) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
 		Process:   *hyperProcess,
 	}
 
-	process, err := c.startShim("", false)
+	process, err := c.startShim("", cmd, false)
 	if err != nil {
 		return nil, err
 	}
@@ -464,7 +464,7 @@ func (h *hyper) startOneContainer(pod Pod, c Container) error {
 
 // createContainer is the agent Container creation implementation for hyperstart.
 func (h *hyper) createContainer(pod *Pod, c *Container) error {
-	_, err := c.startShim("", true)
+	_, err := c.startShim("", c.config.Cmd, true)
 	return err
 }
 

--- a/kata_agent.go
+++ b/kata_agent.go
@@ -292,7 +292,7 @@ func (k *kataAgent) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
 		return nil, err
 	}
 
-	return c.startShim(req.ExecId, false)
+	return c.startShim(req.ExecId, cmd, false)
 }
 
 func (k *kataAgent) startPod(pod Pod) error {
@@ -514,7 +514,7 @@ func (k *kataAgent) createContainer(pod *Pod, c *Container) error {
 		return err
 	}
 
-	_, err = c.startShim(req.ExecId, true)
+	_, err = c.startShim(req.ExecId, c.config.Cmd, true)
 	return err
 }
 

--- a/kata_proxy.go
+++ b/kata_proxy.go
@@ -92,6 +92,16 @@ func (p *kataProxy) register(pod Pod) ([]ProxyInfo, string, error) {
 		proxyInfos = append(proxyInfos, proxyInfo)
 	}
 
+	if p.proxyURL == "" {
+		// construct the socket path the proxy instance will use
+		proxyURL, err := defaultAgentURL(&pod, SocketTypeUNIX)
+		if err != nil {
+			return []ProxyInfo{}, "", err
+		}
+
+		p.proxyURL = proxyURL
+	}
+
 	return proxyInfos, p.proxyURL, nil
 }
 
@@ -109,6 +119,16 @@ func (p *kataProxy) connect(pod Pod, createToken bool) (ProxyInfo, string, error
 	}
 
 	p.client = client
+
+	if p.proxyURL == "" {
+		// construct the socket path the proxy instance will use
+		proxyURL, err := defaultAgentURL(&pod, SocketTypeUNIX)
+		if err != nil {
+			return ProxyInfo{}, "", err
+		}
+
+		p.proxyURL = proxyURL
+	}
 
 	return ProxyInfo{}, p.proxyURL, nil
 }

--- a/noop_agent.go
+++ b/noop_agent.go
@@ -51,8 +51,8 @@ func (n *noopAgent) capabilities() capabilities {
 }
 
 // exec is the Noop agent command execution implementation. It does nothing.
-func (n *noopAgent) exec(pod *Pod, c Container, process Process, cmd Cmd) error {
-	return nil
+func (n *noopAgent) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
+	return c.startShim("", false)
 }
 
 // startPod is the Noop agent Pod starting implementation. It does nothing.
@@ -67,7 +67,8 @@ func (n *noopAgent) stopPod(pod Pod) error {
 
 // createContainer is the Noop agent Container creation implementation. It does nothing.
 func (n *noopAgent) createContainer(pod *Pod, c *Container) error {
-	return nil
+	_, err := c.startShim("", true)
+	return err
 }
 
 // startContainer is the Noop agent Container starting implementation. It does nothing.

--- a/noop_agent.go
+++ b/noop_agent.go
@@ -52,7 +52,7 @@ func (n *noopAgent) capabilities() capabilities {
 
 // exec is the Noop agent command execution implementation. It does nothing.
 func (n *noopAgent) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
-	return c.startShim("", false)
+	return c.startShim("", cmd, false)
 }
 
 // startPod is the Noop agent Pod starting implementation. It does nothing.
@@ -67,7 +67,7 @@ func (n *noopAgent) stopPod(pod Pod) error {
 
 // createContainer is the Noop agent Container creation implementation. It does nothing.
 func (n *noopAgent) createContainer(pod *Pod, c *Container) error {
-	_, err := c.startShim("", true)
+	_, err := c.startShim("", c.config.Cmd, true)
 	return err
 }
 

--- a/noop_agent_test.go
+++ b/noop_agent_test.go
@@ -20,6 +20,25 @@ import (
 	"testing"
 )
 
+func testCreateNoopContainer() (*Pod, *Container, error) {
+	contID := "100"
+	config := newTestPodConfigNoop()
+
+	p, err := CreatePod(config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	contConfig := newTestContainerConfigNoop(contID)
+
+	p, c, err := CreateContainer(p.ID(), contConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return p.(*Pod), c.(*Container), nil
+}
+
 func TestNoopAgentInit(t *testing.T) {
 	n := &noopAgent{}
 	pod := &Pod{}
@@ -53,12 +72,13 @@ func TestNoopAgentProxyURL(t *testing.T) {
 
 func TestNoopAgentExec(t *testing.T) {
 	n := &noopAgent{}
-	pod := &Pod{}
-	container := Container{}
-	process := Process{}
 	cmd := Cmd{}
+	pod, container, err := testCreateNoopContainer()
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	if err := n.exec(pod, container, process, cmd); err != nil {
+	if _, err = n.exec(pod, *container, cmd); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -85,10 +105,17 @@ func TestNoopAgentStopPod(t *testing.T) {
 
 func TestNoopAgentCreateContainer(t *testing.T) {
 	n := &noopAgent{}
-	pod := &Pod{}
-	container := &Container{}
+	pod, container, err := testCreateNoopContainer()
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	err := n.createContainer(pod, container)
+	err = n.startPod(*pod)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = n.createContainer(pod, container)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,10 +123,12 @@ func TestNoopAgentCreateContainer(t *testing.T) {
 
 func TestNoopAgentStartContainer(t *testing.T) {
 	n := &noopAgent{}
-	pod := Pod{}
-	container := Container{}
+	pod, container, err := testCreateNoopContainer()
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	err := n.startContainer(pod, container)
+	err = n.startContainer(*pod, *container)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,10 +136,12 @@ func TestNoopAgentStartContainer(t *testing.T) {
 
 func TestNoopAgentStopContainer(t *testing.T) {
 	n := &noopAgent{}
-	pod := Pod{}
-	container := Container{}
+	pod, container, err := testCreateNoopContainer()
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	err := n.stopContainer(pod, container)
+	err = n.stopContainer(*pod, *container)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pod.go
+++ b/pod.go
@@ -597,7 +597,7 @@ func createPod(podConfig PodConfig) (*Pod, error) {
 		return nil, err
 	}
 
-	p, err := doFetchPod(podConfig)
+	p, err := newPod(podConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -626,7 +626,7 @@ func createPod(podConfig PodConfig) (*Pod, error) {
 	return p, nil
 }
 
-func doFetchPod(podConfig PodConfig) (*Pod, error) {
+func newPod(podConfig PodConfig) (*Pod, error) {
 	if podConfig.valid() == false {
 		return nil, fmt.Errorf("Invalid pod configuration")
 	}

--- a/pod.go
+++ b/pod.go
@@ -838,6 +838,14 @@ func (p *Pod) startProxy() error {
 		return err
 	}
 
+	if _, _, err := p.proxy.register(*p); err != nil {
+		return err
+	}
+
+	if err := p.proxy.disconnect(); err != nil {
+		return err
+	}
+
 	p.Logger().WithField("proxy-pid", pid).Info("proxy started")
 
 	return nil


### PR DESCRIPTION
Right now the virtcontainers core code explictly starts shims as soon as possible, regardless of the shim implementation being able to handle non existing containers or not.

This PR reorders that sequence and guarantees that shims will not be started before their corresponding container process is not started.

Now we have:

- container.go `createContainer` basically only allocate a new container structure and asks the agent to create it on the guest.
- It is up to each agent implementation to decide if there's a need to associate a shim to a container's process or not. i.e. the agent is now responsible for launching the shims.
- pod.go `startShims` is now `createContainers()` and calls into `createContainer()` for each configured container.