### PR TITLE
vendor: Update kata agent vendoring

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -52,7 +52,7 @@
 [[projects]]
   name = "github.com/kata-containers/agent"
   packages = ["protocols/client","protocols/grpc"]
-  revision = "306ee20ff47628fe370012d7e3f9316480e43c2e"
+  revision = "3f6f6da6d469c31364aac417f336ec0d16772095"
 
 [[projects]]
   name = "github.com/kubernetes-incubator/cri-o"
@@ -146,6 +146,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "64f06e6d14dde1b65c8dfd0b81e27c773b12660dfae7dc8a8ff66267f36ff7e4"
+  inputs-digest = "cb375a87b8b44a6178fb02b9e63bae86df6d6cac12e87f444f20cc004aed1c93"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -76,4 +76,4 @@
 
 [[constraint]]
   name = "github.com/kata-containers/agent"
-  revision = "306ee20ff47628fe370012d7e3f9316480e43c2e"
+  revision = "3f6f6da6d469c31364aac417f336ec0d16772095"

--- a/vendor/github.com/kata-containers/agent/Gopkg.lock
+++ b/vendor/github.com/kata-containers/agent/Gopkg.lock
@@ -2,8 +2,17 @@
 
 
 [[projects]]
+  branch = "master"
+  name = "github.com/containerd/console"
+  packages = ["."]
+  revision = "84eeaae905fa414d03e07bcd6c8d3f19e7cf180e"
+
+[[projects]]
   name = "github.com/coreos/go-systemd"
-  packages = ["dbus","util"]
+  packages = [
+    "dbus",
+    "util"
+  ]
   revision = "d2196463941895ee908e13531a23a39feb9e1243"
   version = "v15"
 
@@ -14,16 +23,16 @@
   version = "v3"
 
 [[projects]]
+  name = "github.com/cyphar/filepath-securejoin"
+  packages = ["."]
+  revision = "06bda8370f45268db985f7af15732444d94ed51c"
+  version = "v0.2.1"
+
+[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
-
-[[projects]]
-  name = "github.com/docker/docker"
-  packages = ["pkg/longpath","pkg/mount","pkg/symlink","pkg/system"]
-  revision = "b9f10c951893f9a00865890a5232e85d770c1087"
-  version = "v1.11.2"
 
 [[projects]]
   name = "github.com/docker/go-units"
@@ -39,12 +48,25 @@
 
 [[projects]]
   name = "github.com/gogo/protobuf"
-  packages = ["gogoproto","jsonpb","proto","protoc-gen-gogo/descriptor","sortkeys","types"]
+  packages = [
+    "gogoproto",
+    "jsonpb",
+    "proto",
+    "protoc-gen-gogo/descriptor",
+    "sortkeys",
+    "types"
+  ]
   revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
 
 [[projects]]
   name = "github.com/golang/protobuf"
-  packages = ["proto","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
+  packages = [
+    "proto",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp"
+  ]
   revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
 
 [[projects]]
@@ -65,8 +87,27 @@
 
 [[projects]]
   name = "github.com/opencontainers/runc"
-  packages = ["libcontainer","libcontainer/apparmor","libcontainer/cgroups","libcontainer/cgroups/fs","libcontainer/cgroups/rootless","libcontainer/cgroups/systemd","libcontainer/configs","libcontainer/configs/validate","libcontainer/criurpc","libcontainer/keys","libcontainer/seccomp","libcontainer/specconv","libcontainer/stacktrace","libcontainer/system","libcontainer/user","libcontainer/utils"]
-  revision = "2e7cfe036e2c6dc51ccca6eb7fa3ee6b63976dcd"
+  packages = [
+    "libcontainer",
+    "libcontainer/apparmor",
+    "libcontainer/cgroups",
+    "libcontainer/cgroups/fs",
+    "libcontainer/cgroups/systemd",
+    "libcontainer/configs",
+    "libcontainer/configs/validate",
+    "libcontainer/criurpc",
+    "libcontainer/intelrdt",
+    "libcontainer/keys",
+    "libcontainer/mount",
+    "libcontainer/nsenter",
+    "libcontainer/seccomp",
+    "libcontainer/specconv",
+    "libcontainer/stacktrace",
+    "libcontainer/system",
+    "libcontainer/user",
+    "libcontainer/utils"
+  ]
+  revision = "e6516b3d5dc780cb57a976013c242a9a93052543"
 
 [[projects]]
   name = "github.com/opencontainers/runtime-spec"
@@ -75,9 +116,18 @@
 
 [[projects]]
   name = "github.com/opencontainers/selinux"
-  packages = ["go-selinux","go-selinux/label"]
+  packages = [
+    "go-selinux",
+    "go-selinux/label"
+  ]
   revision = "ba1aefe8057f1d0cfb8e88d0ec1dc85925ef987d"
   version = "v1.0.0-rc1"
+
+[[projects]]
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"
@@ -109,7 +159,10 @@
 
 [[projects]]
   name = "github.com/vishvananda/netlink"
-  packages = [".","nl"]
+  packages = [
+    ".",
+    "nl"
+  ]
   revision = "f67b75edbf5e3bb7dfe70bb788610693a71be3d1"
 
 [[projects]]
@@ -126,18 +179,44 @@
 
 [[projects]]
   name = "golang.org/x/net"
-  packages = ["context","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
+  packages = [
+    "context",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "internal/timeseries",
+    "lex/httplex",
+    "trace"
+  ]
   revision = "a8b9294777976932365dabb6640cf1468d95c70f"
 
 [[projects]]
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "8b4580aae2a0dd0c231a45d3ccb8434ff533b840"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable"
+  ]
   revision = "57961680700a5336d15015c8c50686ca5ba362a4"
 
 [[projects]]
@@ -148,12 +227,34 @@
 
 [[projects]]
   name = "google.golang.org/grpc"
-  packages = [".","balancer","balancer/roundrobin","codes","connectivity","credentials","encoding","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","resolver/dns","resolver/passthrough","stats","status","tap","transport"]
+  packages = [
+    ".",
+    "balancer",
+    "balancer/roundrobin",
+    "codes",
+    "connectivity",
+    "credentials",
+    "encoding",
+    "grpclb/grpc_lb_v1/messages",
+    "grpclog",
+    "internal",
+    "keepalive",
+    "metadata",
+    "naming",
+    "peer",
+    "resolver",
+    "resolver/dns",
+    "resolver/passthrough",
+    "stats",
+    "status",
+    "tap",
+    "transport"
+  ]
   revision = "5a9f7b402fe85096d2e1d0383435ee1876e863d0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4f58481ed90edce8331933de5df28b3386c6374da473796ff0c48e846c209c36"
+  inputs-digest = "c38d31b9fcac7acea4857468060fdf0ea2d68c14a70f59d24752bba917f271d8"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/kata-containers/agent/Gopkg.toml
+++ b/vendor/github.com/kata-containers/agent/Gopkg.toml
@@ -16,7 +16,7 @@
 
 [[constraint]]
   name = "github.com/opencontainers/runc"
-  revision = "2e7cfe036e2c6dc51ccca6eb7fa3ee6b63976dcd"
+  revision = "e6516b3d5dc780cb57a976013c242a9a93052543"
 
 [[constraint]]
   name = "github.com/opencontainers/runtime-spec"

--- a/vendor/github.com/kata-containers/agent/agent_test.go
+++ b/vendor/github.com/kata-containers/agent/agent_test.go
@@ -1,0 +1,222 @@
+//
+// Copyright (c) 2018 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/opencontainers/runc/libcontainer"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testExecID      = "testExecID"
+	testContainerID = "testContainerID"
+)
+
+func TestClosePostStartFDsAllNil(t *testing.T) {
+	p := &process{}
+
+	p.closePostStartFDs()
+}
+
+func TestClosePostStartFDsAllInitialized(t *testing.T) {
+	rStdin, wStdin, err := os.Pipe()
+	assert.Nil(t, err, "%v", err)
+	defer wStdin.Close()
+
+	rStdout, wStdout, err := os.Pipe()
+	assert.Nil(t, err, "%v", err)
+	defer rStdout.Close()
+
+	rStderr, wStderr, err := os.Pipe()
+	assert.Nil(t, err, "%v", err)
+	defer rStderr.Close()
+
+	rConsoleSocket, wConsoleSocket, err := os.Pipe()
+	assert.Nil(t, err, "%v", err)
+	defer wConsoleSocket.Close()
+
+	rConsoleSock, wConsoleSock, err := os.Pipe()
+	assert.Nil(t, err, "%v", err)
+	defer wConsoleSock.Close()
+
+	p := &process{
+		process: libcontainer.Process{
+			Stdin:         rStdin,
+			Stdout:        wStdout,
+			Stderr:        wStderr,
+			ConsoleSocket: rConsoleSocket,
+		},
+		consoleSock: rConsoleSock,
+	}
+
+	p.closePostStartFDs()
+}
+
+func TestClosePostExitFDsAllNil(t *testing.T) {
+	p := &process{}
+
+	p.closePostExitFDs()
+}
+
+func TestClosePostExitFDsAllInitialized(t *testing.T) {
+	rTermMaster, wTermMaster, err := os.Pipe()
+	assert.Nil(t, err, "%v", err)
+	defer wTermMaster.Close()
+
+	rStdin, wStdin, err := os.Pipe()
+	assert.Nil(t, err, "%v", err)
+	defer rStdin.Close()
+
+	rStdout, wStdout, err := os.Pipe()
+	assert.Nil(t, err, "%v", err)
+	defer wStdout.Close()
+
+	rStderr, wStderr, err := os.Pipe()
+	assert.Nil(t, err, "%v", err)
+	defer wStderr.Close()
+
+	p := &process{
+		termMaster: rTermMaster,
+		stdin:      wStdin,
+		stdout:     rStdout,
+		stderr:     rStderr,
+	}
+
+	p.closePostExitFDs()
+}
+
+func TestSetProcess(t *testing.T) {
+	c := &container{
+		processes: make(map[string]*process),
+	}
+
+	p := &process{
+		id: testExecID,
+	}
+
+	c.setProcess(p)
+
+	proc, exist := c.processes[testExecID]
+	assert.True(t, exist, "Process entry should exist")
+
+	assert.True(t, reflect.DeepEqual(p, proc),
+		"Process structures should be identical: got %+v, expecting %+v",
+		proc, p)
+}
+
+func TestDeleteProcess(t *testing.T) {
+	c := &container{
+		processes: make(map[string]*process),
+	}
+
+	p := &process{
+		id: testExecID,
+	}
+
+	c.processes[testExecID] = p
+
+	c.deleteProcess(testExecID)
+
+	_, exist := c.processes[testExecID]
+	assert.False(t, exist, "Process entry should not exist")
+}
+
+func TestGetProcessEntryExist(t *testing.T) {
+	c := &container{
+		processes: make(map[string]*process),
+	}
+
+	p := &process{
+		id: testExecID,
+	}
+
+	c.processes[testExecID] = p
+
+	proc, err := c.getProcess(testExecID)
+	assert.Nil(t, err, "%v", err)
+
+	assert.True(t, reflect.DeepEqual(p, proc),
+		"Process structures should be identical: got %+v, expecting %+v",
+		proc, p)
+}
+
+func TestGetProcessNoEntry(t *testing.T) {
+	c := &container{
+		processes: make(map[string]*process),
+	}
+
+	_, err := c.getProcess(testExecID)
+	assert.Error(t, err, "Should fail because no entry has been created")
+}
+
+func TestGetContainerEntryExist(t *testing.T) {
+	s := &sandbox{
+		containers: make(map[string]*container),
+	}
+
+	c := &container{
+		id: testContainerID,
+	}
+
+	s.containers[testContainerID] = c
+
+	cont, err := s.getContainer(testContainerID)
+	assert.Nil(t, err, "%v", err)
+
+	assert.True(t, reflect.DeepEqual(c, cont),
+		"Container structures should be identical: got %+v, expecting %+v",
+		cont, c)
+}
+
+func TestGetContainerNoEntry(t *testing.T) {
+	s := &sandbox{
+		containers: make(map[string]*container),
+	}
+
+	_, err := s.getContainer(testContainerID)
+	assert.Error(t, err, "Should fail because no entry has been created")
+}
+
+func TestSetContainer(t *testing.T) {
+	s := &sandbox{
+		containers: make(map[string]*container),
+	}
+
+	c := &container{
+		id: testContainerID,
+	}
+
+	s.setContainer(testContainerID, c)
+
+	cont, exist := s.containers[testContainerID]
+	assert.True(t, exist, "Container entry should exist")
+
+	assert.True(t, reflect.DeepEqual(c, cont),
+		"Container structures should be identical: got %+v, expecting %+v",
+		cont, c)
+}
+
+func TestDeleteContainer(t *testing.T) {
+	s := &sandbox{
+		containers: make(map[string]*container),
+	}
+
+	c := &container{
+		id: testContainerID,
+	}
+
+	s.containers[testContainerID] = c
+
+	s.deleteContainer(testContainerID)
+
+	_, exist := s.containers[testContainerID]
+	assert.False(t, exist, "Process entry should not exist")
+}

--- a/vendor/github.com/kata-containers/agent/api.go
+++ b/vendor/github.com/kata-containers/agent/api.go
@@ -19,9 +19,10 @@ const (
 
 // VSock
 const (
-	vSockDevPath = "/dev/vsock"
-	vSockPort    = 1024
+	vSockPort = 1024
 )
+
+var vSockDevPath = "/dev/vsock"
 
 // Signals
 const (

--- a/vendor/github.com/kata-containers/agent/channel_test.go
+++ b/vendor/github.com/kata-containers/agent/channel_test.go
@@ -1,0 +1,61 @@
+//
+// Copyright (c) 2018 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVSockPathExistTrue(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "test")
+	assert.Nil(t, err, "%v", err)
+	fileName := tmpFile.Name()
+	defer tmpFile.Close()
+	defer os.Remove(fileName)
+
+	vSockDevPath = fileName
+
+	result, err := vSockPathExist()
+	assert.Nil(t, err, "%v", err)
+
+	assert.True(t, result, "VSOCK should be found")
+}
+
+func TestVSockPathExistFalse(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "test")
+	assert.Nil(t, err, "%v", err)
+
+	fileName := tmpFile.Name()
+	tmpFile.Close()
+	err = os.Remove(fileName)
+	assert.Nil(t, err, "%v", err)
+
+	vSockDevPath = fileName
+
+	result, err := vSockPathExist()
+	assert.Nil(t, err, "%v", err)
+
+	assert.False(t, result, "VSOCK should not be found")
+}
+
+func TestSetupVSockChannel(t *testing.T) {
+	c := &vSockChannel{}
+
+	err := c.setup()
+	assert.Nil(t, err, "%v", err)
+}
+
+func TestTeardownVSockChannel(t *testing.T) {
+	c := &vSockChannel{}
+
+	err := c.teardown()
+	assert.Nil(t, err, "%v", err)
+}

--- a/vendor/github.com/kata-containers/agent/config_test.go
+++ b/vendor/github.com/kata-containers/agent/config_test.go
@@ -1,0 +1,124 @@
+//
+// Copyright (c) 2018 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewConfig(t *testing.T) {
+	testLogLevel := logrus.DebugLevel
+
+	expectedConfig := agentConfig{
+		logLevel: testLogLevel,
+	}
+
+	config := newConfig(testLogLevel)
+
+	assert.True(t, reflect.DeepEqual(config, expectedConfig),
+		"Config structures should be identical: got %+v, expecting %+v",
+		config, expectedConfig)
+}
+
+func TestParseCmdlineOptionEmptyOption(t *testing.T) {
+	a := &agentConfig{}
+
+	err := a.parseCmdlineOption("")
+	assert.Nil(t, err, "%v", err)
+}
+
+func TestParseCmdlineOptionWrongOptionValue(t *testing.T) {
+	a := &agentConfig{}
+
+	wrongOption := logLevelFlag + "=debgu"
+
+	err := a.parseCmdlineOption(wrongOption)
+	assert.Error(t, err, "Parsing should fail because wrong option %q", wrongOption)
+}
+
+func TestParseCmdlineOptionWrongOptionParam(t *testing.T) {
+	a := &agentConfig{}
+
+	wrongOption := "agent.lgo=debug"
+
+	err := a.parseCmdlineOption(wrongOption)
+	assert.Error(t, err, "Parsing should fail because wrong option %q", wrongOption)
+}
+
+func TestParseCmdlineOptionCorrectOptions(t *testing.T) {
+	a := &agentConfig{}
+
+	logFlagList := []string{"debug", "info", "warn", "error", "fatal", "panic"}
+
+	for _, logFlag := range logFlagList {
+		option := logLevelFlag + "=" + logFlag
+
+		err := a.parseCmdlineOption(option)
+		assert.Nil(t, err, "%v", err)
+	}
+}
+
+func TestParseCmdlineOptionIncorrectOptions(t *testing.T) {
+	a := &agentConfig{}
+
+	logFlagList := []string{"debg", "ifo", "wan", "eror", "ftal", "pnic"}
+
+	for _, logFlag := range logFlagList {
+		option := logLevelFlag + "=" + logFlag
+
+		err := a.parseCmdlineOption(option)
+		assert.Error(t, err, "Should fail because of incorrect option %q", logFlag)
+	}
+}
+
+func TestGetConfigEmptyFileName(t *testing.T) {
+	a := &agentConfig{}
+
+	err := a.getConfig("")
+	assert.Error(t, err, "Should fail because command line path is empty")
+}
+
+func TestGetConfigFilePathNotExist(t *testing.T) {
+	a := &agentConfig{}
+
+	tmpFile, err := ioutil.TempFile("", "test")
+	assert.Nil(t, err, "%v", err)
+
+	fileName := tmpFile.Name()
+	tmpFile.Close()
+	err = os.Remove(fileName)
+	assert.Nil(t, err, "%v", err)
+
+	err = a.getConfig(fileName)
+	assert.Error(t, err, "Should fail because command line path does not exist")
+}
+
+func TestGetConfig(t *testing.T) {
+	a := &agentConfig{}
+
+	tmpFile, err := ioutil.TempFile("", "test")
+	assert.Nil(t, err, "%v", err)
+	fileName := tmpFile.Name()
+
+	tmpFile.Write([]byte(logLevelFlag + "=info"))
+	tmpFile.Close()
+
+	defer os.Remove(fileName)
+
+	err = a.getConfig(fileName)
+	assert.Nil(t, err, "%v", err)
+
+	assert.True(t, a.logLevel == logrus.InfoLevel,
+		"Log levels should be identical: got %+v, expecting %+v",
+		a.logLevel, logrus.InfoLevel)
+}

--- a/vendor/github.com/kata-containers/agent/mount.go
+++ b/vendor/github.com/kata-containers/agent/mount.go
@@ -57,6 +57,12 @@ var flagList = map[string]int{
 	"runbindable": unix.MS_UNBINDABLE | unix.MS_REC,
 }
 
+func createDestinationDir(dest string) error {
+	targetPath, _ := filepath.Split(dest)
+
+	return os.MkdirAll(targetPath, mountPerm)
+}
+
 // mount mounts a source in to a destination. This will do some bookkeeping:
 // * evaluate all symlinks
 // * ensure the source exists
@@ -64,7 +70,9 @@ func mount(source, destination, fsType string, flags int, options string) error 
 	var absSource string
 
 	if fsType != type9pFs {
-		absSource, err := filepath.EvalSymlinks(source)
+		var err error
+
+		absSource, err = filepath.EvalSymlinks(source)
 		if err != nil {
 			return fmt.Errorf("Could not resolve symlink for source %v", source)
 		}
@@ -74,6 +82,9 @@ func mount(source, destination, fsType string, flags int, options string) error 
 				destination, err)
 		}
 	} else {
+		if err := createDestinationDir(destination); err != nil {
+			return err
+		}
 		absSource = source
 	}
 
@@ -95,10 +106,9 @@ func ensureDestinationExists(source, destination string, fsType string) error {
 			source)
 	}
 
-	targetPathParent, _ := filepath.Split(destination)
-	if err := os.MkdirAll(targetPathParent, mountPerm); err != nil {
+	if err := createDestinationDir(destination); err != nil {
 		return fmt.Errorf("could not create parent directory: %v",
-			targetPathParent)
+			destination)
 	}
 
 	if fsType != "bind" || fileInfo.IsDir() {

--- a/vendor/github.com/kata-containers/agent/protocols/grpc/utils.go
+++ b/vendor/github.com/kata-containers/agent/protocols/grpc/utils.go
@@ -22,7 +22,14 @@ func copyValue(to, from reflect.Value) error {
 	}
 
 	if toKind == reflect.Ptr {
-		// If the destination is a pointer, we need to allocate a new one.
+		// Handle the case of nil pointers.
+		if fromKind == reflect.Ptr && from.IsNil() {
+			return nil
+		}
+
+		// If the destination and the origin are both pointers, and
+		// if the origin is not nil, we need to allocate a new one
+		// for the destination.
 		to.Set(reflect.New(to.Type().Elem()))
 		if fromKind == reflect.Ptr {
 			return copyValue(to.Elem(), from.Elem())


### PR DESCRIPTION
We need this revendoring to fix the spec converter. We are relying
on the OCI to GRPC spec converter provided by kata agent, and this
has been recently fixed. We need this fix to go in for virtcontainers.

Shortlog:
    
    045c2cf grpc: Split execProcess in more readable functions
    71dd0b8 protocols: grpc: Fix the spec converter regarding nil pointers
    532325c grpc: Move sequencing from StartContainer to CreateContainer
    3dd881f grpc: Reference appropriate process when starting a container
    b2f30e1 grpc: Lock the container creation
    92a2a6a grpc: Remove unused code parts
    d3a27ca agent: Add missing nsenter import
    4f73ac9 mount: Create destination directory for 9pfs as well
    1327404 mount: Do not shadow absSource
    0759700 grpc: Return nil from SignalProcess() if container already stopped
    9d6298b vendor: Re-vendor libcontainer for SIGKILL fix
    3d44912 agent: allow exec before start
    35e36c6 test: Increase unit test coverage

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>