### PR TITLE
shim: Carry the info about terminal

### DIFF
--- a/container.go
+++ b/container.go
@@ -758,6 +758,7 @@ func (c *Container) createShimProcess(token, url string, cmd Cmd, initProcess bo
 		Token:     token,
 		URL:       url,
 		Console:   cmd.Console,
+		Terminal:  cmd.Interactive,
 		Detach:    cmd.Detach,
 	}
 

--- a/kata_shim.go
+++ b/kata_shim.go
@@ -59,6 +59,11 @@ func (s *kataShim) start(pod Pod, params ShimParams) (int, error) {
 	}
 
 	args := []string{config.Path, "-agent", params.URL, "-container", params.Container, "-exec-id", params.Token}
+
+	if params.Terminal {
+		args = append(args, "-terminal")
+	}
+
 	if config.Debug {
 		args = append(args, "-log", "debug")
 	}

--- a/pod.go
+++ b/pod.go
@@ -847,6 +847,7 @@ func (p *Pod) startShims() error {
 			Token:     p.containers[idx].process.Token,
 			URL:       url,
 			Console:   p.containers[idx].config.Cmd.Console,
+			Terminal:  p.containers[idx].config.Cmd.Interactive,
 			Detach:    p.containers[idx].config.Cmd.Detach,
 		}
 

--- a/shim.go
+++ b/shim.go
@@ -51,6 +51,7 @@ type ShimParams struct {
 	Token     string
 	URL       string
 	Console   string
+	Terminal  bool
 	Detach    bool
 	PID       int
 }


### PR DESCRIPTION
Some shim implementation (like Kata) might need to know if a
terminal has been setup or not. This patch relies on Interactive
field from the Cmd structure that was never really used but
already holding this information.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>