### PR TITLE
virtcontainers: Global re-organisation of the proxy/shim code

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -157,7 +157,7 @@ type agent interface {
 	stopPod(pod Pod) error
 
 	// createContainer will tell the agent to create a container related to a Pod.
-	createContainer(pod *Pod, c *Container) error
+	createContainer(pod *Pod, c *Container) (*Process, error)
 
 	// startContainer will tell the agent to start a container related to a Pod.
 	startContainer(pod Pod, c Container) error

--- a/agent.go
+++ b/agent.go
@@ -18,7 +18,6 @@ package virtcontainers
 
 import (
 	"fmt"
-	"path/filepath"
 	"syscall"
 
 	"github.com/mitchellh/mapstructure"
@@ -130,19 +129,6 @@ func newAgentConfig(config PodConfig) interface{} {
 	}
 }
 
-func defaultAgentURL(pod *Pod, socketType string) (string, error) {
-	switch socketType {
-	case SocketTypeUNIX:
-		socketPath := filepath.Join(runStoragePath, pod.id, "proxy.sock")
-		return fmt.Sprintf("unix://%s", socketPath), nil
-	case SocketTypeVSOCK:
-		// TODO Build the VSOCK default URL
-		return "", nil
-	default:
-		return "", fmt.Errorf("Unknown socket type: %s", socketType)
-	}
-}
-
 // agent is the virtcontainers agent interface.
 // Agents are running in the guest VM and handling
 // communications between the host and guest.
@@ -153,15 +139,6 @@ type agent interface {
 	// After init() is called, agent implementations should be initialized and ready
 	// to handle all other Agent interface methods.
 	init(pod *Pod, config interface{}) error
-
-	// vmURL returns the agent URL exposed by the hypervisor. This URL has
-	// been previously built from the agent implementation and provided to
-	// the hypervisor through a specific hypervisor interface function. It
-	// represents the entry point to connect to the agent through the VM.
-	// This function is particularly useful in case there is no proxy
-	// needed, meaning the proxy implementation will have to provide this
-	// URL instead of a real proxy URL.
-	vmURL() (string, error)
 
 	// capabilities should return a structure that specifies the capabilities
 	// supported by the agent.

--- a/agent.go
+++ b/agent.go
@@ -163,13 +163,6 @@ type agent interface {
 	// URL instead of a real proxy URL.
 	vmURL() (string, error)
 
-	// setProxyURL sets the URL virtcontainers should connect in order to
-	// communicate with the agent. This URL can be either the proxy URL
-	// if it actually needs to go through a proxy, or it can be the VM
-	// URL in case no proxy is needed. Both ways, this has to be
-	// transparent for the agent implementation.
-	setProxyURL(url string) error
-
 	// capabilities should return a structure that specifies the capabilities
 	// supported by the agent.
 	capabilities() capabilities

--- a/agent_test.go
+++ b/agent_test.go
@@ -17,8 +17,6 @@
 package virtcontainers
 
 import (
-	"fmt"
-	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -155,47 +153,4 @@ func TestNewAgentConfigFromUnknownAgentType(t *testing.T) {
 	var agentConfig interface{}
 
 	testNewAgentConfig(t, PodConfig{}, agentConfig)
-}
-
-const podID = "123456789"
-
-func testDefaultAgentURL(expectedURL string, socketType string, podID string) error {
-	pod := &Pod{
-		id: podID,
-	}
-
-	url, err := defaultAgentURL(pod, socketType)
-	if err != nil {
-		return err
-	}
-
-	if url != expectedURL {
-		return fmt.Errorf("Mismatched URL: %s vs %s", url, expectedURL)
-	}
-
-	return nil
-}
-
-func TestDefaultAgentURLUnix(t *testing.T) {
-	path := filepath.Join(runStoragePath, podID, "proxy.sock")
-	socketPath := fmt.Sprintf("unix://%s", path)
-
-	if err := testDefaultAgentURL(socketPath, SocketTypeUNIX, podID); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestDefaultAgentURLVSock(t *testing.T) {
-	if err := testDefaultAgentURL("", SocketTypeVSOCK, podID); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestDefaultAgentURLUnknown(t *testing.T) {
-	path := filepath.Join(runStoragePath, podID, "proxy.sock")
-	socketPath := fmt.Sprintf("unix://%s", path)
-
-	if err := testDefaultAgentURL(socketPath, "foobar", podID); err == nil {
-		t.Fatal()
-	}
 }

--- a/api_test.go
+++ b/api_test.go
@@ -108,12 +108,9 @@ func newTestPodConfigHyperstartAgent() PodConfig {
 		HypervisorPath: filepath.Join(testDir, testHypervisor),
 	}
 
-	sockets := []Socket{{}, {}}
-
 	agentConfig := HyperConfig{
 		SockCtlName: testHyperstartCtlSocket,
 		SockTtyName: testHyperstartTtySocket,
-		Sockets:     sockets,
 	}
 
 	podConfig := PodConfig{
@@ -147,12 +144,9 @@ func newTestPodConfigHyperstartAgentCNINetwork() PodConfig {
 		HypervisorPath: filepath.Join(testDir, testHypervisor),
 	}
 
-	sockets := []Socket{{}, {}}
-
 	agentConfig := HyperConfig{
 		SockCtlName: testHyperstartCtlSocket,
 		SockTtyName: testHyperstartTtySocket,
-		Sockets:     sockets,
 	}
 
 	netConfig := NetworkConfig{
@@ -193,12 +187,9 @@ func newTestPodConfigHyperstartAgentCNMNetwork() PodConfig {
 		HypervisorPath: filepath.Join(testDir, testHypervisor),
 	}
 
-	sockets := []Socket{{}, {}}
-
 	agentConfig := HyperConfig{
 		SockCtlName: testHyperstartCtlSocket,
 		SockTtyName: testHyperstartTtySocket,
-		Sockets:     sockets,
 	}
 
 	hooks := Hooks{

--- a/api_test.go
+++ b/api_test.go
@@ -668,9 +668,7 @@ func TestStatusPodSuccessfulStateReady(t *testing.T) {
 	expectedStatus := PodStatus{
 		ID: testPodID,
 		State: State{
-			State:    StateReady,
-			URL:      "",
-			ProxyPid: 0,
+			State: StateReady,
 		},
 		Hypervisor:       MockHypervisor,
 		HypervisorConfig: hypervisorConfig,
@@ -681,7 +679,6 @@ func TestStatusPodSuccessfulStateReady(t *testing.T) {
 				ID: containerID,
 				State: State{
 					State: StateReady,
-					URL:   "",
 				},
 				PID:         0,
 				RootFs:      filepath.Join(testDir, testBundle),
@@ -726,7 +723,6 @@ func TestStatusPodSuccessfulStateRunning(t *testing.T) {
 		ID: testPodID,
 		State: State{
 			State: StateRunning,
-			URL:   "",
 		},
 		Hypervisor:       MockHypervisor,
 		HypervisorConfig: hypervisorConfig,
@@ -737,7 +733,6 @@ func TestStatusPodSuccessfulStateRunning(t *testing.T) {
 				ID: containerID,
 				State: State{
 					State: StateRunning,
-					URL:   "",
 				},
 				PID:         0,
 				RootFs:      filepath.Join(testDir, testBundle),
@@ -1575,7 +1570,6 @@ func TestStatusContainerStateReady(t *testing.T) {
 		ID: contID,
 		State: State{
 			State: StateReady,
-			URL:   "",
 		},
 		PID:         0,
 		RootFs:      filepath.Join(testDir, testBundle),
@@ -1649,7 +1643,6 @@ func TestStatusContainerStateRunning(t *testing.T) {
 		ID: contID,
 		State: State{
 			State: StateRunning,
-			URL:   "",
 		},
 		PID:         0,
 		RootFs:      filepath.Join(testDir, testBundle),

--- a/cc_proxy.go
+++ b/cc_proxy.go
@@ -49,6 +49,6 @@ func (p *ccProxy) start(pod Pod, params proxyParams) (int, string, error) {
 	return cmd.Process.Pid, proxyURL, nil
 }
 
-func (p *ccProxy) stop(pod Pod) error {
+func (p *ccProxy) stop(pod Pod, pid int) error {
 	return nil
 }

--- a/cc_proxy.go
+++ b/cc_proxy.go
@@ -20,14 +20,9 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
-
-	"github.com/clearcontainers/proxy/client"
 )
 
-var defaultCCProxyURL = "unix:///var/run/clear-containers/proxy.sock"
-
 type ccProxy struct {
-	client *client.Client
 }
 
 // start is the proxy start implementation for ccProxy.
@@ -54,136 +49,6 @@ func (p *ccProxy) start(pod Pod) (int, string, error) {
 	return cmd.Process.Pid, uri, nil
 }
 
-// register is the proxy register implementation for ccProxy.
-func (p *ccProxy) register(pod Pod) ([]ProxyInfo, string, error) {
-	var proxyInfos []ProxyInfo
-
-	conn, err := connectProxy(pod.state.URL)
-	if err != nil {
-		return []ProxyInfo{}, "", err
-	}
-
-	p.client = client.NewClient(conn)
-
-	hyperConfig, ok := newAgentConfig(*(pod.config)).(HyperConfig)
-	if !ok {
-		return []ProxyInfo{}, "", fmt.Errorf("Wrong agent config type, should be HyperConfig type")
-	}
-
-	registerVMOptions := &client.RegisterVMOptions{
-		Console:      pod.hypervisor.getPodConsole(pod.id),
-		NumIOStreams: len(pod.containers),
-	}
-
-	registerVMReturn, err := p.client.RegisterVM(pod.id, hyperConfig.SockCtlName,
-		hyperConfig.SockTtyName, registerVMOptions)
-	if err != nil {
-		return []ProxyInfo{}, "", err
-	}
-
-	url := registerVMReturn.IO.URL
-	if url == "" {
-		url = defaultCCProxyURL
-	}
-
-	if len(registerVMReturn.IO.Tokens) != len(pod.containers) {
-		return []ProxyInfo{}, "", fmt.Errorf("%d tokens retrieved out of %d expected",
-			len(registerVMReturn.IO.Tokens),
-			len(pod.containers))
-	}
-
-	for _, token := range registerVMReturn.IO.Tokens {
-		proxyInfo := ProxyInfo{
-			Token: token,
-		}
-
-		proxyInfos = append(proxyInfos, proxyInfo)
-	}
-
-	return proxyInfos, url, nil
-}
-
-// unregister is the proxy unregister implementation for ccProxy.
-func (p *ccProxy) unregister(pod Pod) error {
-	if p.client == nil {
-		return fmt.Errorf("unregister: Client is nil, we can't interact with cc-proxy")
-	}
-
-	return p.client.UnregisterVM(pod.id)
-}
-
-// connect is the proxy connect implementation for ccProxy.
-func (p *ccProxy) connect(pod Pod, createToken bool) (ProxyInfo, string, error) {
-	conn, err := connectProxy(pod.state.URL)
-	if err != nil {
-		return ProxyInfo{}, "", err
-	}
-
-	p.client = client.NewClient(conn)
-
-	// In case we are asked to create a token, this means the caller
-	// expects only one token to be generated.
-	numTokens := 0
-	if createToken {
-		numTokens = 1
-	}
-
-	attachVMOptions := &client.AttachVMOptions{
-		NumIOStreams: numTokens,
-	}
-
-	attachVMReturn, err := p.client.AttachVM(pod.id, attachVMOptions)
-	if err != nil {
-		return ProxyInfo{}, "", err
-	}
-
-	url := attachVMReturn.IO.URL
-	if url == "" {
-		url = defaultCCProxyURL
-	}
-
-	if len(attachVMReturn.IO.Tokens) != numTokens {
-		return ProxyInfo{}, "", fmt.Errorf("%d tokens retrieved out of %d expected",
-			len(attachVMReturn.IO.Tokens), numTokens)
-	}
-
-	if !createToken {
-		return ProxyInfo{}, url, nil
-	}
-
-	proxyInfo := ProxyInfo{
-		Token: attachVMReturn.IO.Tokens[0],
-	}
-
-	return proxyInfo, url, nil
-}
-
-// disconnect is the proxy disconnect implementation for ccProxy.
-func (p *ccProxy) disconnect() error {
-	if p.client == nil {
-		return fmt.Errorf("disconnect: Client is nil, we can't interact with cc-proxy")
-	}
-
-	p.client.Close()
-
+func (p *ccProxy) stop(pod Pod) error {
 	return nil
-}
-
-// sendCmd is the proxy sendCmd implementation for ccProxy.
-func (p *ccProxy) sendCmd(cmd interface{}) (interface{}, error) {
-	if p.client == nil {
-		return nil, fmt.Errorf("sendCmd: Client is nil, we can't interact with cc-proxy")
-	}
-
-	proxyCmd, ok := cmd.(hyperstartProxyCmd)
-	if !ok {
-		return nil, fmt.Errorf("Wrong command type, should be hyperstartProxyCmd type")
-	}
-
-	var tokens []string
-	if proxyCmd.token != "" {
-		tokens = append(tokens, proxyCmd.token)
-	}
-
-	return p.client.HyperWithTokens(proxyCmd.cmd, tokens, proxyCmd.message)
 }

--- a/cc_proxy_test.go
+++ b/cc_proxy_test.go
@@ -87,7 +87,7 @@ func TestCCProxyStart(t *testing.T) {
 	}
 
 	for _, d := range data {
-		pid, uri, err := proxy.start(d.pod)
+		pid, uri, err := proxy.start(d.pod, proxyParams{})
 		if d.expectError {
 			assert.Error(err)
 			continue

--- a/container.go
+++ b/container.go
@@ -205,11 +205,6 @@ func (c *Container) setStateHotpluggedDrive(hotplugged bool) error {
 	return nil
 }
 
-// URL returns the URL related to the pod.
-func (c *Container) URL() string {
-	return c.pod.URL()
-}
-
 // GetAnnotations returns container's annotations
 func (c *Container) GetAnnotations() map[string]string {
 	return c.config.Annotations

--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -102,18 +102,6 @@ var podConfigFlags = []cli.Flag{
 		Usage: "the hyperstart tty socket name",
 	},
 
-	cli.GenericFlag{
-		Name:  "volume",
-		Value: new(vc.Volumes),
-		Usage: "the volume to be shared with VM",
-	},
-
-	cli.GenericFlag{
-		Name:  "socket",
-		Value: new(vc.Sockets),
-		Usage: "the socket list to be shared with VM",
-	},
-
 	cli.UintFlag{
 		Name:  "cpus",
 		Value: 0,
@@ -186,16 +174,6 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 		return vc.PodConfig{}, fmt.Errorf("Could not convert shim type")
 	}
 
-	volumes, ok := context.Generic("volume").(*vc.Volumes)
-	if ok != true {
-		return vc.PodConfig{}, fmt.Errorf("Could not convert to volume list")
-	}
-
-	sockets, ok := context.Generic("socket").(*vc.Sockets)
-	if ok != true {
-		return vc.PodConfig{}, fmt.Errorf("Could not convert to socket list")
-	}
-
 	kernelPath := "/usr/share/clear-containers/vmlinuz.container"
 	if machineType == vc.QemuPCLite {
 		kernelPath = "/usr/share/clear-containers/vmlinux.container"
@@ -220,8 +198,6 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 		agConfig = vc.HyperConfig{
 			SockCtlName: hyperCtlSockName,
 			SockTtyName: hyperTtySockName,
-			Volumes:     *volumes,
-			Sockets:     *sockets,
 		}
 	default:
 		agConfig = nil

--- a/hyperstart_agent.go
+++ b/hyperstart_agent.go
@@ -91,6 +91,7 @@ func (c *HyperConfig) validate(pod Pod) bool {
 type hyper struct {
 	config HyperConfig
 	pod    *Pod
+	proxy  proxy
 	client *proxyClient.Client
 }
 
@@ -257,6 +258,11 @@ func (h *hyper) init(pod *Pod, config interface{}) (err error) {
 	// Override pod agent configuration
 	pod.config.AgentConfig = h.config
 
+	h.proxy, err = newProxy(pod.config.ProxyType)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -336,7 +342,7 @@ func (h *hyper) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
 // startPod is the agent Pod starting implementation for hyperstart.
 func (h *hyper) startPod(pod Pod) error {
 	// Start the proxy here
-	pid, uri, err := h.pod.proxy.start(pod, proxyParams{})
+	pid, uri, err := h.proxy.start(pod, proxyParams{})
 	if err != nil {
 		return err
 	}
@@ -393,7 +399,7 @@ func (h *hyper) stopPod(pod Pod) error {
 		return err
 	}
 
-	return h.pod.proxy.stop(pod)
+	return h.proxy.stop(pod)
 }
 
 func (h *hyper) startOneContainer(pod Pod, c Container) error {

--- a/hyperstart_agent.go
+++ b/hyperstart_agent.go
@@ -91,6 +91,7 @@ func (c *HyperConfig) validate(pod Pod) bool {
 type hyper struct {
 	config HyperConfig
 	pod    *Pod
+	shim   shim
 	proxy  proxy
 	client *proxyClient.Client
 }
@@ -263,6 +264,11 @@ func (h *hyper) init(pod *Pod, config interface{}) (err error) {
 		return err
 	}
 
+	h.shim, err = newShim(pod.config.ShimType)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -321,7 +327,7 @@ func (h *hyper) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
 		Process:   *hyperProcess,
 	}
 
-	process, err := prepareAndStartShim(pod, c.id, token, pod.URL(), cmd)
+	process, err := prepareAndStartShim(pod, h.shim, c.id, token, pod.URL(), cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -482,7 +488,7 @@ func (h *hyper) createContainer(pod *Pod, c *Container) (*Process, error) {
 		return nil, err
 	}
 
-	return prepareAndStartShim(pod, c.id, token, pod.URL(), c.config.Cmd)
+	return prepareAndStartShim(pod, h.shim, c.id, token, pod.URL(), c.config.Cmd)
 }
 
 // startContainer is the agent Container starting implementation for hyperstart.

--- a/hyperstart_agent.go
+++ b/hyperstart_agent.go
@@ -315,7 +315,7 @@ func (h *hyper) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
 		Process:   *hyperProcess,
 	}
 
-	process, err := c.startShim(token, h.pod.URL(), cmd, false)
+	process, err := prepareAndStartShim(pod, c.id, token, pod.URL(), cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -470,14 +470,13 @@ func (h *hyper) startOneContainer(pod Pod, c Container) error {
 }
 
 // createContainer is the agent Container creation implementation for hyperstart.
-func (h *hyper) createContainer(pod *Pod, c *Container) error {
+func (h *hyper) createContainer(pod *Pod, c *Container) (*Process, error) {
 	token, err := h.attach()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	_, err = c.startShim(token, h.pod.URL(), c.config.Cmd, true)
-	return err
+	return prepareAndStartShim(pod, c.id, token, pod.URL(), c.config.Cmd)
 }
 
 // startContainer is the agent Container starting implementation for hyperstart.

--- a/hyperstart_agent.go
+++ b/hyperstart_agent.go
@@ -260,11 +260,6 @@ func (h *hyper) init(pod *Pod, config interface{}) (err error) {
 	return nil
 }
 
-// vmURL returns VM URL from hyperstart agent implementation.
-func (h *hyper) vmURL() (string, error) {
-	return "", nil
-}
-
 func (h *hyper) createPod(pod *Pod) (err error) {
 	for _, volume := range h.config.Volumes {
 		err := pod.hypervisor.addDevice(volume, fsDev)
@@ -341,7 +336,7 @@ func (h *hyper) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
 // startPod is the agent Pod starting implementation for hyperstart.
 func (h *hyper) startPod(pod Pod) error {
 	// Start the proxy here
-	pid, uri, err := h.pod.proxy.start(pod)
+	pid, uri, err := h.pod.proxy.start(pod, proxyParams{})
 	if err != nil {
 		return err
 	}

--- a/interfaces.go
+++ b/interfaces.go
@@ -53,7 +53,6 @@ type VCPod interface {
 	GetContainer(containerID string) VCContainer
 	ID() string
 	SetAnnotations(annotations map[string]string) error
-	URL() string
 }
 
 // VCContainer is the Container interface
@@ -66,5 +65,4 @@ type VCContainer interface {
 	Pod() VCPod
 	Process() Process
 	SetPid(pid int) error
-	URL() string
 }

--- a/kata_agent.go
+++ b/kata_agent.go
@@ -145,7 +145,7 @@ func (k *kataAgent) init(pod *Pod, config interface{}) error {
 	return nil
 }
 
-func (k *kataAgent) vmURL() (string, error) {
+func (k *kataAgent) agentURL() (string, error) {
 	switch s := k.vmSocket.(type) {
 	case Socket:
 		return s.HostPath, nil
@@ -297,8 +297,18 @@ func (k *kataAgent) startPod(pod Pod) error {
 		return errorMissingProxy
 	}
 
+	// Get agent socket path to provide it to the proxy.
+	agentURL, err := k.agentURL()
+	if err != nil {
+		return err
+	}
+
+	proxyParams := proxyParams{
+		agentURL: agentURL,
+	}
+
 	// Start the proxy here
-	pid, uri, err := k.pod.proxy.start(pod)
+	pid, uri, err := k.pod.proxy.start(pod, proxyParams)
 	if err != nil {
 		return err
 	}

--- a/kata_agent_test.go
+++ b/kata_agent_test.go
@@ -46,10 +46,8 @@ func TestKataAgentConnect(t *testing.T) {
 	defer proxy.Stop()
 
 	k := &kataAgent{
-		pod: &Pod{
-			state: State{
-				URL: testKataProxyURL,
-			},
+		state: KataAgentState{
+			URL: testKataProxyURL,
 		},
 	}
 
@@ -74,10 +72,8 @@ func TestKataAgentDisconnect(t *testing.T) {
 	defer proxy.Stop()
 
 	k := &kataAgent{
-		pod: &Pod{
-			state: State{
-				URL: testKataProxyURL,
-			},
+		state: KataAgentState{
+			URL: testKataProxyURL,
 		},
 	}
 
@@ -206,10 +202,8 @@ func TestKataAgentSendReq(t *testing.T) {
 	defer proxy.Stop()
 
 	k := &kataAgent{
-		pod: &Pod{
-			state: State{
-				URL: testKataProxyURL,
-			},
+		state: KataAgentState{
+			URL: testKataProxyURL,
 		},
 	}
 

--- a/kata_proxy.go
+++ b/kata_proxy.go
@@ -17,13 +17,9 @@
 package virtcontainers
 
 import (
-	"context"
 	"fmt"
 	"os/exec"
 	"syscall"
-
-	kataclient "github.com/kata-containers/agent/protocols/client"
-	"github.com/kata-containers/agent/protocols/grpc"
 )
 
 // This is the Kata Containers implementation of the proxy interface.
@@ -31,7 +27,6 @@ import (
 // runtime and shim as if they were talking directly to the agent.
 type kataProxy struct {
 	proxyURL string
-	client   *kataclient.AgentClient
 }
 
 // start is kataProxy start implementation for proxy interface.
@@ -56,10 +51,6 @@ func (p *kataProxy) start(pod Pod) (int, string, error) {
 		return -1, "", err
 	}
 
-	if err := pod.agent.setProxyURL(proxyURL); err != nil {
-		return -1, "", err
-	}
-
 	p.proxyURL = proxyURL
 
 	args := []string{config.Path, "-listen-socket", proxyURL, "-mux-socket", vmURL}
@@ -76,103 +67,8 @@ func (p *kataProxy) start(pod Pod) (int, string, error) {
 	return cmd.Process.Pid, p.proxyURL, nil
 }
 
-// register is kataProxy register implementation for proxy interface.
-func (p *kataProxy) register(pod Pod) ([]ProxyInfo, string, error) {
-	client, err := kataclient.NewAgentClient(p.proxyURL)
-	if err != nil {
-		return []ProxyInfo{}, "", err
-	}
-	p.client = client
-
-	var proxyInfos []ProxyInfo
-
-	for i := 0; i < len(pod.containers); i++ {
-		proxyInfo := ProxyInfo{}
-
-		proxyInfos = append(proxyInfos, proxyInfo)
-	}
-
-	if p.proxyURL == "" {
-		// construct the socket path the proxy instance will use
-		proxyURL, err := defaultAgentURL(&pod, SocketTypeUNIX)
-		if err != nil {
-			return []ProxyInfo{}, "", err
-		}
-
-		p.proxyURL = proxyURL
-	}
-
-	return proxyInfos, p.proxyURL, nil
-}
-
-// unregister is kataProxy unregister implementation for proxy interface.
-func (p *kataProxy) unregister(pod Pod) error {
-	// Kill the proxy. This should ideally be dealt with from a stop method.
-	return syscall.Kill(pod.state.ProxyPid, syscall.SIGKILL)
-}
-
-// connect is kataProxy connect implementation for proxy interface.
-func (p *kataProxy) connect(pod Pod, createToken bool) (ProxyInfo, string, error) {
-	client, err := kataclient.NewAgentClient(pod.state.URL)
-	if err != nil {
-		return ProxyInfo{}, "", err
-	}
-
-	p.client = client
-
-	if p.proxyURL == "" {
-		// construct the socket path the proxy instance will use
-		proxyURL, err := defaultAgentURL(&pod, SocketTypeUNIX)
-		if err != nil {
-			return ProxyInfo{}, "", err
-		}
-
-		p.proxyURL = proxyURL
-	}
-
-	return ProxyInfo{}, p.proxyURL, nil
-}
-
-// disconnect is kataProxy disconnect implementation for proxy interface.
-func (p *kataProxy) disconnect() error {
-	if p.client == nil {
-		return fmt.Errorf("Client is nil, we can't interact with kata-proxy")
-	}
-
-	p.client.Close()
-
-	return nil
-}
-
-// sendCmd is kataProxy sendCmd implementation for proxy interface.
-func (p *kataProxy) sendCmd(cmd interface{}) (interface{}, error) {
-	if p.client == nil {
-		return nil, fmt.Errorf("Client is nil, we can't interact with kata-proxy")
-	}
-
-	switch c := cmd.(type) {
-	case *grpc.ExecProcessRequest:
-		_, err := p.client.ExecProcess(context.Background(), c)
-		return nil, err
-	case *grpc.CreateSandboxRequest:
-		_, err := p.client.CreateSandbox(context.Background(), c)
-		return nil, err
-	case *grpc.DestroySandboxRequest:
-		_, err := p.client.DestroySandbox(context.Background(), c)
-		return nil, err
-	case *grpc.CreateContainerRequest:
-		_, err := p.client.CreateContainer(context.Background(), c)
-		return nil, err
-	case *grpc.StartContainerRequest:
-		_, err := p.client.StartContainer(context.Background(), c)
-		return nil, err
-	case *grpc.RemoveContainerRequest:
-		_, err := p.client.RemoveContainer(context.Background(), c)
-		return nil, err
-	case *grpc.SignalProcessRequest:
-		_, err := p.client.SignalProcess(context.Background(), c)
-		return nil, err
-	default:
-		return nil, fmt.Errorf("Unknown gRPC type %T", c)
-	}
+// stop is kataProxy stop implementation for proxy interface.
+func (p *kataProxy) stop(pod Pod) error {
+	// Signal the proxy with SIGTERM.
+	return syscall.Kill(pod.state.ProxyPid, syscall.SIGTERM)
 }

--- a/kata_proxy.go
+++ b/kata_proxy.go
@@ -64,7 +64,7 @@ func (p *kataProxy) start(pod Pod, params proxyParams) (int, string, error) {
 }
 
 // stop is kataProxy stop implementation for proxy interface.
-func (p *kataProxy) stop(pod Pod) error {
+func (p *kataProxy) stop(pod Pod, pid int) error {
 	// Signal the proxy with SIGTERM.
-	return syscall.Kill(pod.state.ProxyPid, syscall.SIGTERM)
+	return syscall.Kill(pid, syscall.SIGTERM)
 }

--- a/no_proxy.go
+++ b/no_proxy.go
@@ -16,6 +16,10 @@
 
 package virtcontainers
 
+import (
+	"fmt"
+)
+
 // This is the no proxy implementation of the proxy interface. This
 // is a generic implementation for any case (basically any agent),
 // where no actual proxy is needed. This happens when the combination
@@ -27,19 +31,15 @@ package virtcontainers
 // is to provide both shim and runtime the correct URL to connect
 // directly to the VM.
 type noProxy struct {
-	vmURL string
 }
 
 // start is noProxy start implementation for proxy interface.
-func (p *noProxy) start(pod Pod) (int, string, error) {
-	url, err := pod.agent.vmURL()
-	if err != nil {
-		return -1, "", err
+func (p *noProxy) start(pod Pod, params proxyParams) (int, string, error) {
+	if params.agentURL == "" {
+		return -1, "", fmt.Errorf("AgentURL cannot be empty")
 	}
 
-	p.vmURL = url
-
-	return 0, p.vmURL, nil
+	return 0, params.agentURL, nil
 }
 
 // stop is noProxy stop implementation for proxy interface.

--- a/no_proxy.go
+++ b/no_proxy.go
@@ -39,42 +39,10 @@ func (p *noProxy) start(pod Pod) (int, string, error) {
 
 	p.vmURL = url
 
-	if err := pod.agent.setProxyURL(url); err != nil {
-		return -1, "", err
-	}
-
 	return 0, p.vmURL, nil
 }
 
-// register is noProxy register implementation for proxy interface.
-func (p *noProxy) register(pod Pod) ([]ProxyInfo, string, error) {
-	var proxyInfos []ProxyInfo
-
-	for i := 0; i < len(pod.containers); i++ {
-		proxyInfo := ProxyInfo{}
-
-		proxyInfos = append(proxyInfos, proxyInfo)
-	}
-
-	return proxyInfos, p.vmURL, nil
-}
-
-// unregister is noProxy unregister implementation for proxy interface.
-func (p *noProxy) unregister(pod Pod) error {
+// stop is noProxy stop implementation for proxy interface.
+func (p *noProxy) stop(pod Pod) error {
 	return nil
-}
-
-// connect is noProxy connect implementation for proxy interface.
-func (p *noProxy) connect(pod Pod, createToken bool) (ProxyInfo, string, error) {
-	return ProxyInfo{}, p.vmURL, nil
-}
-
-// disconnect is noProxy disconnect implementation for proxy interface.
-func (p *noProxy) disconnect() error {
-	return nil
-}
-
-// sendCmd is noProxy sendCmd implementation for proxy interface.
-func (p *noProxy) sendCmd(cmd interface{}) (interface{}, error) {
-	return nil, nil
 }

--- a/no_proxy.go
+++ b/no_proxy.go
@@ -43,6 +43,6 @@ func (p *noProxy) start(pod Pod, params proxyParams) (int, string, error) {
 }
 
 // stop is noProxy stop implementation for proxy interface.
-func (p *noProxy) stop(pod Pod) error {
+func (p *noProxy) stop(pod Pod, pid int) error {
 	return nil
 }

--- a/no_proxy_test.go
+++ b/no_proxy_test.go
@@ -47,7 +47,7 @@ func TestNoProxyStart(t *testing.T) {
 func TestNoProxyStop(t *testing.T) {
 	p := &noProxy{}
 
-	if err := p.stop(Pod{}); err != nil {
+	if err := p.stop(Pod{}, 0); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/no_proxy_test.go
+++ b/no_proxy_test.go
@@ -43,56 +43,10 @@ func TestNoProxyStart(t *testing.T) {
 	}
 }
 
-func TestNoProxyRegister(t *testing.T) {
-	p := &noProxy{
-		vmURL: testNoProxyVMURL,
-	}
-
-	_, vmURL, err := p.register(Pod{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if vmURL != testNoProxyVMURL {
-		t.Fatalf("Got URL %q, expecting %q", vmURL, testNoProxyVMURL)
-	}
-}
-
-func TestNoProxyUnregister(t *testing.T) {
+func TestNoProxyStop(t *testing.T) {
 	p := &noProxy{}
 
-	if err := p.unregister(Pod{}); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestNoProxyConnect(t *testing.T) {
-	p := &noProxy{
-		vmURL: testNoProxyVMURL,
-	}
-
-	_, vmURL, err := p.connect(Pod{}, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if vmURL != testNoProxyVMURL {
-		t.Fatalf("Got URL %q, expecting %q", vmURL, testNoProxyVMURL)
-	}
-}
-
-func TestNoProxyDisconnect(t *testing.T) {
-	p := &noProxy{}
-
-	if err := p.disconnect(); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestNoProxySendCmd(t *testing.T) {
-	p := &noProxy{}
-
-	if _, err := p.sendCmd(nil); err != nil {
+	if err := p.stop(Pod{}); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/no_proxy_test.go
+++ b/no_proxy_test.go
@@ -29,13 +29,14 @@ func TestNoProxyStart(t *testing.T) {
 
 	p := &noProxy{}
 
-	pid, vmURL, err := p.start(pod)
+	agentURL := "agentURL"
+	pid, vmURL, err := p.start(pod, proxyParams{agentURL: agentURL})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if vmURL != "" {
-		t.Fatalf("Got URL %q, expecting empty URL", vmURL)
+	if vmURL != agentURL {
+		t.Fatalf("Got URL %q, expecting %q", vmURL, agentURL)
 	}
 
 	if pid != 0 {

--- a/noop_agent.go
+++ b/noop_agent.go
@@ -56,8 +56,8 @@ func (n *noopAgent) stopPod(pod Pod) error {
 }
 
 // createContainer is the Noop agent Container creation implementation. It does nothing.
-func (n *noopAgent) createContainer(pod *Pod, c *Container) error {
-	return nil
+func (n *noopAgent) createContainer(pod *Pod, c *Container) (*Process, error) {
+	return &Process{}, nil
 }
 
 // startContainer is the Noop agent Container starting implementation. It does nothing.

--- a/noop_agent.go
+++ b/noop_agent.go
@@ -30,11 +30,6 @@ func (n *noopAgent) init(pod *Pod, config interface{}) error {
 	return nil
 }
 
-// vmURL returns the VM URL from the Noop agent. It does nothing.
-func (n *noopAgent) vmURL() (string, error) {
-	return "", nil
-}
-
 // createPod is the Noop agent pod creation implementation. It does nothing.
 func (n *noopAgent) createPod(pod *Pod) error {
 	return nil

--- a/noop_agent.go
+++ b/noop_agent.go
@@ -35,11 +35,6 @@ func (n *noopAgent) vmURL() (string, error) {
 	return "", nil
 }
 
-// setProxyURL sets the URL of the proxy for the Noop agent. It does nothing.
-func (n *noopAgent) setProxyURL(url string) error {
-	return nil
-}
-
 // createPod is the Noop agent pod creation implementation. It does nothing.
 func (n *noopAgent) createPod(pod *Pod) error {
 	return nil
@@ -52,7 +47,7 @@ func (n *noopAgent) capabilities() capabilities {
 
 // exec is the Noop agent command execution implementation. It does nothing.
 func (n *noopAgent) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
-	return c.startShim("", cmd, false)
+	return nil, nil
 }
 
 // startPod is the Noop agent Pod starting implementation. It does nothing.
@@ -67,8 +62,7 @@ func (n *noopAgent) stopPod(pod Pod) error {
 
 // createContainer is the Noop agent Container creation implementation. It does nothing.
 func (n *noopAgent) createContainer(pod *Pod, c *Container) error {
-	_, err := c.startShim("", c.config.Cmd, true)
-	return err
+	return nil
 }
 
 // startContainer is the Noop agent Container starting implementation. It does nothing.

--- a/noop_agent_test.go
+++ b/noop_agent_test.go
@@ -49,19 +49,6 @@ func TestNoopAgentInit(t *testing.T) {
 	}
 }
 
-func TestNoopAgentVmURL(t *testing.T) {
-	n := &noopAgent{}
-
-	url, err := n.vmURL()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if url != "" {
-		t.Fatalf("URL should be empty: %s", url)
-	}
-}
-
 func TestNoopAgentExec(t *testing.T) {
 	n := &noopAgent{}
 	cmd := Cmd{}

--- a/noop_agent_test.go
+++ b/noop_agent_test.go
@@ -89,13 +89,11 @@ func TestNoopAgentCreateContainer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = n.startPod(*pod)
-	if err != nil {
+	if err := n.startPod(*pod); err != nil {
 		t.Fatal(err)
 	}
 
-	err = n.createContainer(pod, container)
-	if err != nil {
+	if _, err := n.createContainer(pod, container); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/noop_agent_test.go
+++ b/noop_agent_test.go
@@ -62,14 +62,6 @@ func TestNoopAgentVmURL(t *testing.T) {
 	}
 }
 
-func TestNoopAgentProxyURL(t *testing.T) {
-	n := &noopAgent{}
-
-	if err := n.setProxyURL(""); err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestNoopAgentExec(t *testing.T) {
 	n := &noopAgent{}
 	cmd := Cmd{}

--- a/noop_proxy.go
+++ b/noop_proxy.go
@@ -24,7 +24,7 @@ var noopProxyURL = "noopProxyURL"
 
 // register is the proxy start implementation for testing purpose.
 // It does nothing.
-func (p *noopProxy) start(pod Pod) (int, string, error) {
+func (p *noopProxy) start(pod Pod, params proxyParams) (int, string, error) {
 	return 0, noopProxyURL, nil
 }
 

--- a/noop_proxy.go
+++ b/noop_proxy.go
@@ -30,6 +30,6 @@ func (p *noopProxy) start(pod Pod, params proxyParams) (int, string, error) {
 
 // stop is the proxy stop implementation for testing purpose.
 // It does nothing.
-func (p *noopProxy) stop(pod Pod) error {
+func (p *noopProxy) stop(pod Pod, pid int) error {
 	return nil
 }

--- a/noop_proxy.go
+++ b/noop_proxy.go
@@ -28,40 +28,8 @@ func (p *noopProxy) start(pod Pod) (int, string, error) {
 	return 0, noopProxyURL, nil
 }
 
-// register is the proxy register implementation for testing purpose.
+// stop is the proxy stop implementation for testing purpose.
 // It does nothing.
-func (p *noopProxy) register(pod Pod) ([]ProxyInfo, string, error) {
-	var proxyInfos []ProxyInfo
-
-	for i := 0; i < len(pod.containers); i++ {
-		proxyInfo := ProxyInfo{}
-
-		proxyInfos = append(proxyInfos, proxyInfo)
-	}
-
-	return proxyInfos, noopProxyURL, nil
-}
-
-// unregister is the proxy unregister implementation for testing purpose.
-// It does nothing.
-func (p *noopProxy) unregister(pod Pod) error {
+func (p *noopProxy) stop(pod Pod) error {
 	return nil
-}
-
-// connect is the proxy connect implementation for testing purpose.
-// It does nothing.
-func (p *noopProxy) connect(pod Pod, createToken bool) (ProxyInfo, string, error) {
-	return ProxyInfo{}, noopProxyURL, nil
-}
-
-// disconnect is the proxy disconnect implementation for testing purpose.
-// It does nothing.
-func (p *noopProxy) disconnect() error {
-	return nil
-}
-
-// sendCmd is the proxy sendCmd implementation for testing purpose.
-// It does nothing.
-func (p *noopProxy) sendCmd(cmd interface{}) (interface{}, error) {
-	return nil, nil
 }

--- a/pkg/mock/cc_proxy_mock.go
+++ b/pkg/mock/cc_proxy_mock.go
@@ -1,0 +1,482 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/clearcontainers/proxy/api"
+	"github.com/stretchr/testify/assert"
+)
+
+const testContainerid = "123456789"
+const testToken = "pF56IaDpuax6hihJ5PneB8JypqmOvjkqY-wKGVYqgIM="
+
+// CCProxyMock is an object mocking clearcontainers Proxy
+type CCProxyMock struct {
+	t              *testing.T
+	wg             sync.WaitGroup
+	connectionPath string
+
+	// proxy socket
+	listener net.Listener
+
+	// single client to serve
+	cl net.Conn
+
+	//token to be used for the connection
+	token string
+
+	lastStdinStream []byte
+
+	ShimConnected    chan bool
+	Signal           chan ShimSignal
+	ShimDisconnected chan bool
+	StdinReceived    chan bool
+}
+
+// NewCCProxyMock creates a hyperstart instance
+func NewCCProxyMock(t *testing.T, path string) *CCProxyMock {
+	return &CCProxyMock{
+		t:                t,
+		connectionPath:   path,
+		lastStdinStream:  nil,
+		Signal:           make(chan ShimSignal, 5),
+		ShimConnected:    make(chan bool),
+		ShimDisconnected: make(chan bool),
+		StdinReceived:    make(chan bool),
+		token:            testToken,
+	}
+}
+
+// GetProxyToken returns the token that mock proxy uses
+// to verify its client connection
+func (proxy *CCProxyMock) GetProxyToken() string {
+	return proxy.token
+}
+
+func newSignalList() []ShimSignal {
+	return make([]ShimSignal, 0, 5)
+}
+
+// GetLastStdinStream returns the last received stdin stream
+func (proxy *CCProxyMock) GetLastStdinStream() []byte {
+	return proxy.lastStdinStream
+}
+
+func (proxy *CCProxyMock) log(s string) {
+	proxy.logF("%s\n", s)
+}
+
+func (proxy *CCProxyMock) logF(format string, args ...interface{}) {
+	proxy.t.Logf("[CCProxyMock] "+format, args...)
+}
+
+type client struct {
+	proxy *CCProxyMock
+	conn  net.Conn
+}
+
+// ConnectShim payload defined here, as it has not been defined
+// in proxy api package yet
+type ConnectShim struct {
+	Token string `json:"token"`
+}
+
+// ShimSignal is the struct used to represent the signal received from the shim
+type ShimSignal struct {
+	Signal int `json:"signalNumber"`
+	Row    int `json:"rows,omitempty"`
+	Column int `json:"columns,omitempty"`
+}
+
+func connectShimHandler(data []byte, userData interface{}, response *handlerResponse) {
+	client := userData.(*client)
+	proxy := client.proxy
+
+	payload := ConnectShim{}
+	err := json.Unmarshal(data, &payload)
+	assert.Nil(proxy.t, err)
+
+	if payload.Token != proxy.token {
+		response.SetErrorMsg("Invalid Token")
+	}
+
+	proxy.logF("ConnectShim(token=%s)", payload.Token)
+
+	response.AddResult("version", api.Version)
+	proxy.ShimConnected <- true
+}
+
+func signalShimHandler(data []byte, userData interface{}, response *handlerResponse) {
+	client := userData.(*client)
+	proxy := client.proxy
+
+	signalPayload := ShimSignal{}
+	err := json.Unmarshal(data, &signalPayload)
+	assert.Nil(proxy.t, err)
+
+	proxy.logF("CCProxyMock received signal: %v", signalPayload)
+
+	proxy.Signal <- signalPayload
+}
+
+func disconnectShimHandler(data []byte, userData interface{}, response *handlerResponse) {
+	client := userData.(*client)
+	proxy := client.proxy
+
+	proxy.log("Client sent DisconnectShim Command")
+	proxy.ShimDisconnected <- true
+}
+
+func stdinShimHandler(data []byte, userData interface{}, response *handlerResponse) {
+	client := userData.(*client)
+	proxy := client.proxy
+
+	proxy.lastStdinStream = data
+	proxy.StdinReceived <- true
+}
+
+func registerVMHandler(data []byte, userData interface{}, response *handlerResponse) {
+	client := userData.(*client)
+	proxy := client.proxy
+
+	proxy.log("Register VM")
+
+	payload := api.RegisterVM{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		response.SetError(err)
+		return
+	}
+
+	// Generate fake tokens
+	var tokens []string
+	for i := 0; i < payload.NumIOStreams; i++ {
+		tokens = append(tokens, fmt.Sprintf("%d", i))
+	}
+
+	io := &api.IOResponse{
+		Tokens: tokens,
+	}
+
+	response.AddResult("io", io)
+}
+
+func unregisterVMHandler(data []byte, userData interface{}, response *handlerResponse) {
+	client := userData.(*client)
+	proxy := client.proxy
+
+	proxy.log("Unregister VM")
+}
+
+func attachVMHandler(data []byte, userData interface{}, response *handlerResponse) {
+	client := userData.(*client)
+	proxy := client.proxy
+
+	proxy.log("Attach VM")
+
+	payload := api.AttachVM{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		response.SetError(err)
+		return
+	}
+
+	// Generate fake tokens
+	var tokens []string
+	for i := 0; i < payload.NumIOStreams; i++ {
+		tokens = append(tokens, fmt.Sprintf("%d", i))
+	}
+
+	io := &api.IOResponse{
+		Tokens: tokens,
+	}
+
+	response.AddResult("io", io)
+}
+
+func hyperCmdHandler(data []byte, userData interface{}, response *handlerResponse) {
+	client := userData.(*client)
+	proxy := client.proxy
+
+	proxy.log("Hyper command")
+
+	response.SetData([]byte{})
+}
+
+// SendStdoutStream sends a Stdout Stream Frame to connected client
+func (proxy *CCProxyMock) SendStdoutStream(payload []byte) {
+	err := api.WriteStream(proxy.cl, api.StreamStdout, payload)
+	assert.Nil(proxy.t, err)
+}
+
+// SendStderrStream sends a Stderr Stream Frame to connected client
+func (proxy *CCProxyMock) SendStderrStream(payload []byte) {
+	err := api.WriteStream(proxy.cl, api.StreamStderr, payload)
+	assert.Nil(proxy.t, err)
+}
+
+// SendExitNotification sends an Exit Notification Frame to connected client
+func (proxy *CCProxyMock) SendExitNotification(payload []byte) {
+	err := api.WriteNotification(proxy.cl, api.NotificationProcessExited, payload)
+	assert.Nil(proxy.t, err)
+}
+
+func (proxy *CCProxyMock) startListening() {
+
+	l, err := net.ListenUnix("unix", &net.UnixAddr{Name: proxy.connectionPath, Net: "unix"})
+	assert.Nil(proxy.t, err)
+
+	proxy.logF("listening on %s", proxy.connectionPath)
+
+	proxy.listener = l
+}
+
+func (proxy *CCProxyMock) serveClient(proto *ccProxyProtocol, newConn net.Conn) {
+	newClient := &client{
+		proxy: proxy,
+		conn:  newConn,
+	}
+	err := proto.Serve(newConn, newClient)
+	proxy.logF("Error serving client : %v\n", err)
+
+	newConn.Close()
+	proxy.log("Client closed connection")
+
+	proxy.wg.Done()
+}
+
+func (proxy *CCProxyMock) serve() {
+	proto := newCCProxyProtocol()
+
+	// shim handlers
+	proto.Handle(FrameKey{api.TypeCommand, int(api.CmdConnectShim)}, connectShimHandler)
+	proto.Handle(FrameKey{api.TypeCommand, int(api.CmdDisconnectShim)}, disconnectShimHandler)
+	proto.Handle(FrameKey{api.TypeStream, int(api.StreamStdin)}, stdinShimHandler)
+
+	// runtime handlers
+	proto.Handle(FrameKey{api.TypeCommand, int(api.CmdRegisterVM)}, registerVMHandler)
+	proto.Handle(FrameKey{api.TypeCommand, int(api.CmdUnregisterVM)}, unregisterVMHandler)
+	proto.Handle(FrameKey{api.TypeCommand, int(api.CmdAttachVM)}, attachVMHandler)
+	proto.Handle(FrameKey{api.TypeCommand, int(api.CmdHyper)}, hyperCmdHandler)
+
+	// Shared handler between shim and runtime
+	proto.Handle(FrameKey{api.TypeCommand, int(api.CmdSignal)}, signalShimHandler)
+
+	//Wait for a single client connection
+	conn, err := proxy.listener.Accept()
+	if err != nil {
+		// Ending up into this case when the listener is closed, which
+		// is still a valid case. We don't want to throw an error in
+		// this case.
+		return
+	}
+
+	assert.NotNil(proxy.t, conn)
+	proxy.log("Client connected")
+
+	proxy.wg.Add(1)
+
+	proxy.cl = conn
+
+	proxy.serveClient(proto, conn)
+}
+
+// Start invokes mock proxy instance to start listening.
+func (proxy *CCProxyMock) Start() {
+	proxy.startListening()
+	go func() {
+		for {
+			proxy.serve()
+		}
+	}()
+}
+
+// Stop causes  mock proxy instance to stop listening,
+// close connection to client and close all channels
+func (proxy *CCProxyMock) Stop() {
+	proxy.listener.Close()
+
+	if proxy.cl != nil {
+		proxy.log("Closing client connection")
+		proxy.cl.Close()
+		proxy.cl = nil
+	} else {
+		proxy.log("Client connection already closed")
+	}
+
+	proxy.wg.Wait()
+	close(proxy.ShimConnected)
+	close(proxy.Signal)
+	close(proxy.ShimDisconnected)
+	close(proxy.StdinReceived)
+	os.Remove(proxy.connectionPath)
+	proxy.log("Stopped")
+}
+
+// XXX: could do with its own package to remove that ugly namespacing
+type ccProxyProtocolHandler func([]byte, interface{}, *handlerResponse)
+
+// Encapsulates the different parts of what a handler can return.
+type handlerResponse struct {
+	err     error
+	results map[string]interface{}
+	data    []byte
+}
+
+// SetError indicates sets error for the response.
+func (r *handlerResponse) SetError(err error) {
+	r.err = err
+}
+
+// SetErrorMsg sets an error with the passed string for the response.
+func (r *handlerResponse) SetErrorMsg(msg string) {
+	r.err = errors.New(msg)
+}
+
+// SetErrorf sets an error with the formatted string for the response.
+func (r *handlerResponse) SetErrorf(format string, a ...interface{}) {
+	r.SetError(fmt.Errorf(format, a...))
+}
+
+// AddResult adds the given key/val to the response.
+func (r *handlerResponse) AddResult(key string, value interface{}) {
+	if r.results == nil {
+		r.results = make(map[string]interface{})
+	}
+	r.results[key] = value
+}
+
+func (r *handlerResponse) SetData(data []byte) {
+	r.data = data
+}
+
+// FrameKey is a struct composed of the the frame type and opcode,
+// used as a key for retrieving the handler for handling the frame.
+type FrameKey struct {
+	ftype  api.FrameType
+	opcode int
+}
+
+func newFrameKey(frameType api.FrameType, opcode int) FrameKey {
+	return FrameKey{
+		ftype:  frameType,
+		opcode: opcode,
+	}
+}
+
+type ccProxyProtocol struct {
+	cmdHandlers map[FrameKey]ccProxyProtocolHandler
+}
+
+func newCCProxyProtocol() *ccProxyProtocol {
+	return &ccProxyProtocol{
+		cmdHandlers: make(map[FrameKey]ccProxyProtocolHandler),
+	}
+}
+
+// Handle retreives the handler for handling the frame
+func (proto *ccProxyProtocol) Handle(key FrameKey, handler ccProxyProtocolHandler) bool {
+	if _, ok := proto.cmdHandlers[key]; ok {
+		return false
+	}
+	proto.cmdHandlers[key] = handler
+	return true
+}
+
+type clientCtx struct {
+	conn     net.Conn
+	userData interface{}
+}
+
+func newErrorResponse(opcode int, errMsg string) *api.Frame {
+	frame, err := api.NewFrameJSON(api.TypeResponse, opcode, &api.ErrorResponse{
+		Message: errMsg,
+	})
+
+	if err != nil {
+		frame, err = api.NewFrameJSON(api.TypeResponse, opcode, &api.ErrorResponse{
+			Message: fmt.Sprintf("couldn't marshal response: %v", err),
+		})
+		if err != nil {
+			frame = api.NewFrame(api.TypeResponse, opcode, nil)
+		}
+	}
+
+	frame.Header.InError = true
+	return frame
+}
+
+func (proto *ccProxyProtocol) handleCommand(ctx *clientCtx, cmd *api.Frame) *api.Frame {
+	hr := handlerResponse{}
+
+	// cmd.Header.Opcode is guaranteed to be within the right bounds by
+	// ReadFrame().
+	handler := proto.cmdHandlers[FrameKey{cmd.Header.Type, int(cmd.Header.Opcode)}]
+
+	handler(cmd.Payload, ctx.userData, &hr)
+	if hr.err != nil {
+		return newErrorResponse(cmd.Header.Opcode, hr.err.Error())
+	}
+
+	var payload interface{}
+	if len(hr.results) > 0 {
+		payload = hr.results
+	}
+
+	frame, err := api.NewFrameJSON(api.TypeResponse, cmd.Header.Opcode, payload)
+	if err != nil {
+		return newErrorResponse(cmd.Header.Opcode, err.Error())
+	}
+	return frame
+}
+
+// Serve serves the client connection in a continuous loop.
+func (proto *ccProxyProtocol) Serve(conn net.Conn, userData interface{}) error {
+	ctx := &clientCtx{
+		conn:     conn,
+		userData: userData,
+	}
+
+	for {
+		frame, err := api.ReadFrame(conn)
+		if err != nil {
+			// EOF or the client isn't even sending proper JSON,
+			// just kill the connection
+			return err
+		}
+
+		if frame.Header.Type != api.TypeCommand && frame.Header.Type != api.TypeStream {
+			// EOF or the client isn't even sending proper JSON,
+			// just kill the connection
+			return fmt.Errorf("serve: expected a command got a %v", frame.Header.Type)
+		}
+
+		// Execute the corresponding handler
+		resp := proto.handleCommand(ctx, frame)
+
+		// Send the response back to the client.
+		if err = api.WriteFrame(conn, resp); err != nil {
+			// Something made us unable to write the response back
+			// to the client (could be a disconnection, ...).
+			return err
+		}
+	}
+}

--- a/pkg/vcMock/container.go
+++ b/pkg/vcMock/container.go
@@ -49,11 +49,6 @@ func (c *Container) SetPid(pid int) error {
 	return nil
 }
 
-// URL implements the VCContainer function of the same name.
-func (c *Container) URL() string {
-	return c.MockURL
-}
-
 // GetAnnotations implements the VCContainer function of the same name.
 func (c *Container) GetAnnotations() map[string]string {
 	return c.MockAnnotations

--- a/pkg/vcMock/pod.go
+++ b/pkg/vcMock/pod.go
@@ -38,11 +38,6 @@ func (p *Pod) GetAnnotations() map[string]string {
 	return p.MockAnnotations
 }
 
-// URL implements the VCPod function of the same name.
-func (p *Pod) URL() string {
-	return p.MockURL
-}
-
 // GetAllContainers implements the VCPod function of the same name.
 func (p *Pod) GetAllContainers() []vc.VCContainer {
 	var ifa = make([]vc.VCContainer, len(p.MockContainers))

--- a/pod.go
+++ b/pod.go
@@ -454,7 +454,6 @@ type Pod struct {
 
 	hypervisor hypervisor
 	agent      agent
-	shim       shim
 	storage    resourceStorage
 	network    network
 
@@ -638,18 +637,12 @@ func newPod(podConfig PodConfig) (*Pod, error) {
 		return nil, err
 	}
 
-	shim, err := newShim(podConfig.ShimType)
-	if err != nil {
-		return nil, err
-	}
-
 	network := newNetwork(podConfig.NetworkModel)
 
 	p := &Pod{
 		id:              podConfig.ID,
 		hypervisor:      hypervisor,
 		agent:           agent,
-		shim:            shim,
 		storage:         &filesystem{},
 		network:         network,
 		config:          &podConfig,

--- a/pod.go
+++ b/pod.go
@@ -62,7 +62,6 @@ const (
 // State is a pod state structure.
 type State struct {
 	State stateString `json:"state"`
-	URL   string      `json:"url,omitempty"`
 
 	// Index of the block device passed to hypervisor.
 	BlockIndex int `json:"blockIndex"`
@@ -72,9 +71,6 @@ type State struct {
 
 	// Bool to indicate if the drive for a container was hotplugged.
 	HotpluggedDrive bool `json:"hotpluggedDrive"`
-
-	// Process ID of the pods proxy instance
-	ProxyPid int
 }
 
 // valid checks that the pod state is valid.
@@ -521,13 +517,6 @@ func (p *Pod) GetAnnotations() map[string]string {
 	defer p.annotationsLock.RUnlock()
 
 	return p.config.Annotations
-}
-
-// URL returns the pod URL for any runtime to connect to the agent.
-// If the pod is configured to run with a proxy, this will be the
-// proxy endpoints URL.
-func (p *Pod) URL() string {
-	return p.state.URL
 }
 
 // GetAllContainers returns all containers.

--- a/pod.go
+++ b/pod.go
@@ -454,7 +454,6 @@ type Pod struct {
 
 	hypervisor hypervisor
 	agent      agent
-	proxy      proxy
 	shim       shim
 	storage    resourceStorage
 	network    network
@@ -639,11 +638,6 @@ func newPod(podConfig PodConfig) (*Pod, error) {
 		return nil, err
 	}
 
-	proxy, err := newProxy(podConfig.ProxyType)
-	if err != nil {
-		return nil, err
-	}
-
 	shim, err := newShim(podConfig.ShimType)
 	if err != nil {
 		return nil, err
@@ -655,7 +649,6 @@ func newPod(podConfig PodConfig) (*Pod, error) {
 		id:              podConfig.ID,
 		hypervisor:      hypervisor,
 		agent:           agent,
-		proxy:           proxy,
 		shim:            shim,
 		storage:         &filesystem{},
 		network:         network,

--- a/pod_test.go
+++ b/pod_test.go
@@ -474,16 +474,8 @@ func testCheckInitPodAndContainerStates(p *Pod, initialPodState State, c *Contai
 		return fmt.Errorf("Expected pod state %v, got %v", initialPodState.State, p.state.State)
 	}
 
-	if p.state.URL != initialPodState.URL {
-		return fmt.Errorf("Expected pod state URL %v, got %v", initialPodState.URL, p.state.URL)
-	}
-
 	if c.state.State != initialContainerState.State {
 		return fmt.Errorf("Expected container state %v, got %v", initialContainerState.State, c.state.State)
-	}
-
-	if c.state.URL != initialContainerState.URL {
-		return fmt.Errorf("Expected container state URL %v, got %v", initialContainerState.URL, c.state.URL)
 	}
 
 	return nil
@@ -500,10 +492,6 @@ func testForcePodStateChangeAndCheck(t *testing.T, p *Pod, newPodState State) er
 		return fmt.Errorf("Expected state %v, got %v", newPodState.State, p.state.State)
 	}
 
-	if p.state.URL != newPodState.URL {
-		return fmt.Errorf("Expected state URL %v, got %v", newPodState.URL, p.state.URL)
-	}
-
 	return nil
 }
 
@@ -518,10 +506,6 @@ func testForceContainerStateChangeAndCheck(t *testing.T, p *Pod, c *Container, n
 		return fmt.Errorf("Expected state %v, got %v", newContainerState.State, c.state.State)
 	}
 
-	if c.state.URL != newContainerState.URL {
-		return fmt.Errorf("Expected state URL %v, got %v", newContainerState.URL, c.state.URL)
-	}
-
 	return nil
 }
 
@@ -531,10 +515,6 @@ func testCheckPodOnDiskState(p *Pod, podState State) error {
 		return fmt.Errorf("Expected state %v, got %v", podState.State, p.state.State)
 	}
 
-	if p.state.URL != podState.URL {
-		return fmt.Errorf("Expected state URL %v, got %v", podState.URL, p.state.URL)
-	}
-
 	return nil
 }
 
@@ -542,10 +522,6 @@ func testCheckContainerOnDiskState(c *Container, containerState State) error {
 	// check on-disk state is correct
 	if c.state.State != containerState.State {
 		return fmt.Errorf("Expected state %v, got %v", containerState.State, c.state.State)
-	}
-
-	if c.state.URL != containerState.URL {
-		return fmt.Errorf("Expected state URL %v, got %v", containerState.URL, c.state.URL)
 	}
 
 	return nil
@@ -569,13 +545,11 @@ func TestPodSetPodAndContainerState(t *testing.T) {
 
 	initialPodState := State{
 		State: StateReady,
-		URL:   "",
 	}
 
 	// After a pod creation, a container has a READY state
 	initialContainerState := State{
 		State: StateReady,
-		URL:   "",
 	}
 
 	c, err := p.getContainer(contID)
@@ -596,7 +570,6 @@ func TestPodSetPodAndContainerState(t *testing.T) {
 
 	newPodState := State{
 		State: StateRunning,
-		URL:   "http://pod/url",
 	}
 
 	if err := testForcePodStateChangeAndCheck(t, p, newPodState); err != nil {
@@ -605,7 +578,6 @@ func TestPodSetPodAndContainerState(t *testing.T) {
 
 	newContainerState := State{
 		State: StateStopped,
-		URL:   "",
 	}
 
 	if err := testForceContainerStateChangeAndCheck(t, p, c, newContainerState); err != nil {
@@ -1019,8 +991,6 @@ func TestPodGetContainer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	p.state.URL = noopProxyURL
 
 	contID := "999"
 	contConfig := newTestContainerConfigNoop(contID)

--- a/pod_test.go
+++ b/pod_test.go
@@ -62,8 +62,7 @@ func testCreatePod(t *testing.T, id string,
 		return nil, fmt.Errorf("Could not create pod: %s", err)
 	}
 
-	err = pod.startProxy()
-	if err != nil {
+	if err := pod.agent.startPod(*pod); err != nil {
 		return nil, err
 	}
 
@@ -570,7 +569,7 @@ func TestPodSetPodAndContainerState(t *testing.T) {
 
 	initialPodState := State{
 		State: StateReady,
-		URL:   noopProxyURL,
+		URL:   "",
 	}
 
 	// After a pod creation, a container has a READY state

--- a/proxy.go
+++ b/proxy.go
@@ -161,5 +161,5 @@ type proxy interface {
 
 	// stop terminates a proxy instance after all communications with the
 	// agent inside the VM have been properly stopped.
-	stop(pod Pod) error
+	stop(pod Pod, pid int) error
 }

--- a/proxy.go
+++ b/proxy.go
@@ -18,9 +18,6 @@ package virtcontainers
 
 import (
 	"fmt"
-	"net"
-	"net/url"
-	"time"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/sirupsen/logrus"
@@ -136,122 +133,13 @@ func newProxyConfig(podConfig *PodConfig) (ProxyConfig, error) {
 	return config, nil
 }
 
-// ProxyInfo holds the token returned by the proxy.
-// Each ProxyInfo relates to a process running inside a container.
-type ProxyInfo struct {
-	Token string
-}
-
-// connectProxyRetry repeatedly tries to connect to the proxy on the specified
-// address until a timeout state is reached, when it will fail.
-func connectProxyRetry(scheme, address string) (conn net.Conn, err error) {
-	attempt := 1
-
-	timeoutSecs := time.Duration(waitForProxyTimeoutSecs * time.Second)
-
-	startTime := time.Now()
-	lastLogTime := startTime
-
-	for {
-		conn, err = net.Dial(scheme, address)
-		if err == nil {
-			// If the initial connection was unsuccessful,
-			// ensure a log message is generated when successfully
-			// connected.
-			if attempt > 1 {
-				proxyLogger().WithField("attempt", fmt.Sprintf("%d", attempt)).Info("Connected to proxy")
-			}
-
-			return conn, nil
-		}
-
-		attempt++
-
-		now := time.Now()
-
-		delta := now.Sub(startTime)
-		remaining := timeoutSecs - delta
-
-		if remaining <= 0 {
-			return nil, fmt.Errorf("failed to connect to proxy after %v: %v", timeoutSecs, err)
-		}
-
-		logDelta := now.Sub(lastLogTime)
-		logDeltaSecs := logDelta / time.Second
-
-		if logDeltaSecs >= 1 {
-			proxyLogger().WithError(err).WithFields(logrus.Fields{
-				"attempt":             fmt.Sprintf("%d", attempt),
-				"proxy-network":       scheme,
-				"proxy-address":       address,
-				"remaining-time-secs": fmt.Sprintf("%2.2f", remaining.Seconds()),
-			}).Warning("Retrying proxy connection")
-
-			lastLogTime = now
-		}
-
-		time.Sleep(time.Duration(100) * time.Millisecond)
-	}
-}
-
-func connectProxy(uri string) (net.Conn, error) {
-	if uri == "" {
-		return nil, fmt.Errorf("no proxy URI")
-	}
-
-	u, err := url.Parse(uri)
-	if err != nil {
-		return nil, err
-	}
-
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("URL scheme cannot be empty")
-	}
-
-	address := u.Host
-	if address == "" {
-		if u.Path == "" {
-			return nil, fmt.Errorf("URL host and path cannot be empty")
-		}
-
-		address = u.Path
-	}
-
-	return connectProxyRetry(u.Scheme, address)
-}
-
 // proxy is the virtcontainers proxy interface.
 type proxy interface {
 	// start launches a proxy instance for the specified pod, returning
 	// the PID of the process and the URL used to connect to it.
 	start(pod Pod) (int, string, error)
 
-	// register connects and registers the proxy to the given VM.
-	// It also returns information related to containers workloads.
-	register(pod Pod) ([]ProxyInfo, string, error)
-
-	// unregister unregisters and disconnects the proxy from the given VM.
-	unregister(pod Pod) error
-
-	// connect gets the proxy a handle to a previously registered VM.
-	// It also returns information related to containers workloads.
-	//
-	// createToken is intended to be true in case we don't want
-	// the proxy to create a new token, but instead only get a handle
-	// to be able to communicate with the agent inside the VM.
-	connect(pod Pod, createToken bool) (ProxyInfo, string, error)
-
-	// disconnect disconnects from the proxy.
-	disconnect() error
-
-	// sendCmd sends a command to the agent inside the VM through the
-	// proxy.
-	// This function will always be used from a specific agent
-	// implementation because a proxy type is always tied to an agent
-	// type. That's the reason why it takes an interface as parameter
-	// and it returns another interface.
-	// Those interfaces allows consumers (agent implementations) of this
-	// proxy interface to be able to use specific structures that can only
-	// be understood by a specific agent<=>proxy pair.
-	sendCmd(cmd interface{}) (interface{}, error)
+	// stop terminates a proxy instance after all communications with the
+	// agent inside the VM have been properly stopped.
+	stop(pod Pod) error
 }

--- a/shim.go
+++ b/shim.go
@@ -155,7 +155,7 @@ func stopShim(pid int) error {
 	return nil
 }
 
-func prepareAndStartShim(pod *Pod, cid, token, url string, cmd Cmd) (*Process, error) {
+func prepareAndStartShim(pod *Pod, shim shim, cid, token, url string, cmd Cmd) (*Process, error) {
 	process := &Process{
 		Token:     token,
 		StartTime: time.Now().UTC(),
@@ -170,7 +170,7 @@ func prepareAndStartShim(pod *Pod, cid, token, url string, cmd Cmd) (*Process, e
 		Detach:    cmd.Detach,
 	}
 
-	pid, err := pod.shim.start(*pod, shimParams)
+	pid, err := shim.start(*pod, shimParams)
 	if err != nil {
 		return nil, err
 	}

--- a/shim.go
+++ b/shim.go
@@ -155,6 +155,31 @@ func stopShim(pid int) error {
 	return nil
 }
 
+func prepareAndStartShim(pod *Pod, cid, token, url string, cmd Cmd) (*Process, error) {
+	process := &Process{
+		Token:     token,
+		StartTime: time.Now().UTC(),
+	}
+
+	shimParams := ShimParams{
+		Container: cid,
+		Token:     token,
+		URL:       url,
+		Console:   cmd.Console,
+		Terminal:  cmd.Interactive,
+		Detach:    cmd.Detach,
+	}
+
+	pid, err := pod.shim.start(*pod, shimParams)
+	if err != nil {
+		return nil, err
+	}
+
+	process.Pid = pid
+
+	return process, nil
+}
+
 func startShim(args []string, params ShimParams) (int, error) {
 	cmd := exec.Command(args[0], args[1:]...)
 


### PR DESCRIPTION
This PR mainly reworks the proxy interface of virtcontainers, pushes shim and proxy down the stack, that is hidden behind the agent.

Fixes #518 