### PR TITLE
Add support for scsi for hotplugging block devices

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -876,12 +876,13 @@ func TestStatusPodSuccessfulStateReady(t *testing.T) {
 
 	config := newTestPodConfigNoop()
 	hypervisorConfig := HypervisorConfig{
-		KernelPath:     filepath.Join(testDir, testKernel),
-		ImagePath:      filepath.Join(testDir, testImage),
-		HypervisorPath: filepath.Join(testDir, testHypervisor),
-		DefaultVCPUs:   defaultVCPUs,
-		DefaultMemSz:   defaultMemSzMiB,
-		DefaultBridges: defaultBridges,
+		KernelPath:        filepath.Join(testDir, testKernel),
+		ImagePath:         filepath.Join(testDir, testImage),
+		HypervisorPath:    filepath.Join(testDir, testHypervisor),
+		DefaultVCPUs:      defaultVCPUs,
+		DefaultMemSz:      defaultMemSzMiB,
+		DefaultBridges:    defaultBridges,
+		BlockDeviceDriver: defaultBlockDriver,
 	}
 
 	expectedStatus := PodStatus{
@@ -930,12 +931,13 @@ func TestStatusPodSuccessfulStateRunning(t *testing.T) {
 
 	config := newTestPodConfigNoop()
 	hypervisorConfig := HypervisorConfig{
-		KernelPath:     filepath.Join(testDir, testKernel),
-		ImagePath:      filepath.Join(testDir, testImage),
-		HypervisorPath: filepath.Join(testDir, testHypervisor),
-		DefaultVCPUs:   defaultVCPUs,
-		DefaultMemSz:   defaultMemSzMiB,
-		DefaultBridges: defaultBridges,
+		KernelPath:        filepath.Join(testDir, testKernel),
+		ImagePath:         filepath.Join(testDir, testImage),
+		HypervisorPath:    filepath.Join(testDir, testHypervisor),
+		DefaultVCPUs:      defaultVCPUs,
+		DefaultMemSz:      defaultMemSzMiB,
+		DefaultBridges:    defaultBridges,
+		BlockDeviceDriver: defaultBlockDriver,
 	}
 
 	expectedStatus := PodStatus{

--- a/container.go
+++ b/container.go
@@ -679,23 +679,24 @@ func (c *Container) hotplugDrive() error {
 		"fs-type":     fsType,
 	}).Info("Block device detected")
 
+	driveIndex, err := c.pod.getAndSetPodBlockIndex()
+	if err != nil {
+		return err
+	}
+
 	// Add drive with id as container id
 	devID := makeNameID("drive", c.id)
 	drive := Drive{
 		File:   devicePath,
 		Format: "raw",
 		ID:     devID,
+		Index:  driveIndex,
 	}
 
 	if err := c.pod.hypervisor.hotplugAddDevice(drive, blockDev); err != nil {
 		return err
 	}
 	c.setStateHotpluggedDrive(true)
-
-	driveIndex, err := c.pod.getAndSetPodBlockIndex()
-	if err != nil {
-		return err
-	}
 
 	if err := c.setStateBlockIndex(driveIndex); err != nil {
 		return err

--- a/device.go
+++ b/device.go
@@ -340,7 +340,11 @@ type BlockDevice struct {
 	DeviceType string
 	DeviceInfo DeviceInfo
 
-	// Path at which the device appears inside the VM, outside of the container mount namespace.
+	// SCSI Address of the block device, in case the device is attached using SCSI driver
+	// SCSI address is in the format SCSI-Id:LUN
+	SCSIAddr string
+
+	// Path at which the device appears inside the VM, outside of the container mount namespace
 	VirtPath string
 }
 
@@ -359,12 +363,6 @@ func (device *BlockDevice) attach(h hypervisor, c *Container) (err error) {
 
 	device.DeviceInfo.ID = hex.EncodeToString(randBytes)
 
-	drive := Drive{
-		File:   device.DeviceInfo.HostPath,
-		Format: "raw",
-		ID:     makeNameID("drive", device.DeviceInfo.ID),
-	}
-
 	// Increment the block index for the pod. This is used to determine the name
 	// for the block device in the case where the block device is used as container
 	// rootfs and the predicted block device name needs to be provided to the agent.
@@ -380,6 +378,13 @@ func (device *BlockDevice) attach(h hypervisor, c *Container) (err error) {
 		return err
 	}
 
+	drive := Drive{
+		File:   device.DeviceInfo.HostPath,
+		Format: "raw",
+		ID:     makeNameID("drive", device.DeviceInfo.ID),
+		Index:  index,
+	}
+
 	driveName, err := getVirtDriveName(index)
 	if err != nil {
 		return err
@@ -393,7 +398,17 @@ func (device *BlockDevice) attach(h hypervisor, c *Container) (err error) {
 
 	device.DeviceInfo.Hotplugged = true
 
-	device.VirtPath = filepath.Join("/dev", driveName)
+	if c.pod.config.HypervisorConfig.BlockDeviceDriver == VirtioBlock {
+		device.VirtPath = filepath.Join("/dev", driveName)
+	} else {
+		scsiAddr, err := getSCSIAddress(index)
+		if err != nil {
+			return err
+		}
+
+		device.SCSIAddr = scsiAddr
+	}
+
 	return nil
 }
 

--- a/device_test.go
+++ b/device_test.go
@@ -322,10 +322,19 @@ func TestAttachBlockDevice(t *testing.T) {
 	fs := &filesystem{}
 	hypervisor := &mockHypervisor{}
 
+	hConfig := HypervisorConfig{
+		BlockDeviceDriver: VirtioBlock,
+	}
+
+	config := &PodConfig{
+		HypervisorConfig: hConfig,
+	}
+
 	pod := &Pod{
 		id:         testPodID,
 		storage:    fs,
 		hypervisor: hypervisor,
+		config:     config,
 	}
 
 	contID := "100"
@@ -364,6 +373,20 @@ func TestAttachBlockDevice(t *testing.T) {
 	assert.True(t, ok)
 
 	container.state.State = ""
+	err = device.attach(hypervisor, &container)
+	assert.Nil(t, err)
+
+	err = device.detach(hypervisor)
+	assert.Nil(t, err)
+
+	container.state.State = StateReady
+	err = device.attach(hypervisor, &container)
+	assert.Nil(t, err)
+
+	err = device.detach(hypervisor)
+	assert.Nil(t, err)
+
+	container.pod.config.HypervisorConfig.BlockDeviceDriver = VirtioSCSI
 	err = device.attach(hypervisor, &container)
 	assert.Nil(t, err)
 

--- a/hyperstart_agent.go
+++ b/hyperstart_agent.go
@@ -459,6 +459,7 @@ func (h *hyper) startOneContainer(pod Pod, c *Container) error {
 				Path:         d.DeviceInfo.ContainerPath,
 				AbsolutePath: true,
 				DockerVolume: false,
+				SCSIAddr:     d.SCSIAddr,
 			}
 			fsmap = append(fsmap, fsmapDesc)
 		}

--- a/hyperstart_agent.go
+++ b/hyperstart_agent.go
@@ -414,13 +414,22 @@ func (h *hyper) startOneContainer(pod Pod, c *Container) error {
 	container.SystemMountsInfo.BindMountDev = c.systemMountsInfo.BindMountDev
 
 	if c.state.Fstype != "" {
-		driveName, err := getVirtDriveName(c.state.BlockIndex)
-		if err != nil {
-			return err
+		// Pass a drive name only in case of block driver
+		if pod.config.HypervisorConfig.BlockDeviceDriver == VirtioBlock {
+			driveName, err := getVirtDriveName(c.state.BlockIndex)
+			if err != nil {
+				return err
+			}
+			container.Image = driveName
+		} else {
+			scsiAddr, err := getSCSIAddress(c.state.BlockIndex)
+			if err != nil {
+				return err
+			}
+			container.SCSIAddr = scsiAddr
 		}
 
 		container.Fstype = c.state.Fstype
-		container.Image = driveName
 	} else {
 
 		if err := bindMountContainerRootfs(defaultSharedDir, pod.id, c.id, c.rootFs, false); err != nil {

--- a/hypervisor.go
+++ b/hypervisor.go
@@ -47,6 +47,8 @@ const (
 	defaultMemSzMiB = 2048
 
 	defaultBridges = 1
+
+	defaultBlockDriver = VirtioSCSI
 )
 
 // deviceType describes a virtualized device type.
@@ -155,6 +157,10 @@ type HypervisorConfig struct {
 	// DisableBlockDeviceUse disallows a block device from being used.
 	DisableBlockDeviceUse bool
 
+	// BlockDeviceDriver specifies the driver to be used for block device
+	// either VirtioSCSI or VirtioBlock with the default driver being defaultBlockDriver
+	BlockDeviceDriver string
+
 	// KernelParams are additional guest kernel parameters.
 	KernelParams []Param
 
@@ -225,6 +231,10 @@ func (conf *HypervisorConfig) valid() (bool, error) {
 
 	if conf.DefaultBridges == 0 {
 		conf.DefaultBridges = defaultBridges
+	}
+
+	if conf.BlockDeviceDriver == "" {
+		conf.BlockDeviceDriver = defaultBlockDriver
 	}
 
 	return true, nil

--- a/hypervisor_test.go
+++ b/hypervisor_test.go
@@ -174,12 +174,13 @@ func TestHypervisorConfigDefaults(t *testing.T) {
 	testHypervisorConfigValid(t, hypervisorConfig, true)
 
 	hypervisorConfigDefaultsExpected := &HypervisorConfig{
-		KernelPath:     fmt.Sprintf("%s/%s", testDir, testKernel),
-		ImagePath:      fmt.Sprintf("%s/%s", testDir, testImage),
-		HypervisorPath: "",
-		DefaultVCPUs:   defaultVCPUs,
-		DefaultMemSz:   defaultMemSzMiB,
-		DefaultBridges: defaultBridges,
+		KernelPath:        fmt.Sprintf("%s/%s", testDir, testKernel),
+		ImagePath:         fmt.Sprintf("%s/%s", testDir, testImage),
+		HypervisorPath:    "",
+		DefaultVCPUs:      defaultVCPUs,
+		DefaultMemSz:      defaultMemSzMiB,
+		DefaultBridges:    defaultBridges,
+		BlockDeviceDriver: defaultBlockDriver,
 	}
 	if reflect.DeepEqual(hypervisorConfig, hypervisorConfigDefaultsExpected) == false {
 		t.Fatal()

--- a/pkg/hyperstart/types.go
+++ b/pkg/hyperstart/types.go
@@ -207,7 +207,7 @@ type Container struct {
 	Rootfs           string              `json:"rootfs"`
 	Fstype           string              `json:"fstype,omitempty"`
 	Image            string              `json:"image"`
-	Addr             string              `json:"addr,omitempty"`
+	SCSIAddr         string              `json:"scsiAddr,omitempty"`
 	Volumes          []*VolumeDescriptor `json:"volumes,omitempty"`
 	Fsmap            []*FsmapDescriptor  `json:"fsmap,omitempty"`
 	Sysctl           map[string]string   `json:"sysctl,omitempty"`

--- a/pkg/hyperstart/types.go
+++ b/pkg/hyperstart/types.go
@@ -133,6 +133,7 @@ type FsmapDescriptor struct {
 	ReadOnly     bool   `json:"readOnly"`
 	DockerVolume bool   `json:"dockerVolume"`
 	AbsolutePath bool   `json:"absolutePath"`
+	SCSIAddr     string `json:"scsiAddr"`
 }
 
 // EnvironmentVar holds an environment variable and its value.

--- a/pod.go
+++ b/pod.go
@@ -245,6 +245,9 @@ type Drive struct {
 
 	// ID is used to identify this drive in the hypervisor options.
 	ID string
+
+	// Index assigned to the drive. In case of virtio-scsi, this is used as SCSI LUN index
+	Index int
 }
 
 // EnvVar is a key/value structure representing a command

--- a/qemu.go
+++ b/qemu.go
@@ -76,6 +76,10 @@ const (
 	removeDevice
 )
 
+const (
+	scsiControllerID = "scsi0"
+)
+
 type qmpLogger struct {
 	logger *logrus.Entry
 }
@@ -328,7 +332,6 @@ func (q *qemu) createPod(podConfig PodConfig) error {
 
 	devices = q.arch.append9PVolumes(devices, podConfig.Volumes)
 	devices = q.arch.appendConsole(devices, q.getPodConsole(podConfig.ID))
-	devices = q.arch.appendBridges(devices, q.state.Bridges)
 
 	imagePath, err := q.config.ImageAssetPath()
 	if err != nil {
@@ -338,6 +341,15 @@ func (q *qemu) createPod(podConfig PodConfig) error {
 	devices, err = q.arch.appendImage(devices, imagePath)
 	if err != nil {
 		return err
+	}
+
+	if q.config.BlockDeviceDriver == VirtioBlock {
+		devices = q.arch.appendBridges(devices, q.state.Bridges)
+		if err != nil {
+			return err
+		}
+	} else {
+		devices = q.arch.appendSCSIController(devices)
 	}
 
 	cpuModel := q.arch.cpuModel()
@@ -578,22 +590,30 @@ func (q *qemu) hotplugBlockDevice(drive Drive, op operation) error {
 			return err
 		}
 
-		driver := "virtio-blk-pci"
+		if q.config.BlockDeviceDriver == VirtioBlock {
+			driver := "virtio-blk-pci"
+			addr, bus, err := q.addDeviceToBridge(drive.ID)
 
-		addr, bus, err := q.addDeviceToBridge(drive.ID)
-		if err != nil {
-			return err
+			if err = q.qmpMonitorCh.qmp.ExecutePCIDeviceAdd(q.qmpMonitorCh.ctx, drive.ID, devID, driver, addr, bus); err != nil {
+				return err
+			}
+		} else {
+			driver := "scsi-hd"
+
+			// Bus exposed by the SCSI Controller
+			bus := scsiControllerID + ".0"
+
+			// Get SCSI-id and LUN based on the order of attaching drives.
+			scsiID, lun, err := getSCSIIdLun(drive.Index)
+			if err != nil {
+				return err
+			}
+
+			if err = q.qmpMonitorCh.qmp.ExecuteSCSIDeviceAdd(q.qmpMonitorCh.ctx, drive.ID, devID, driver, bus, scsiID, lun); err != nil {
+				return err
+			}
 		}
-
-		if err = q.qmpMonitorCh.qmp.ExecutePCIDeviceAdd(q.qmpMonitorCh.ctx, drive.ID, devID, driver, addr, bus); err != nil {
-			return err
-		}
-
 	} else {
-		if err := q.removeDeviceFromBridge(drive.ID); err != nil {
-			return err
-		}
-
 		if err := q.qmpMonitorCh.qmp.ExecuteDeviceDel(q.qmpMonitorCh.ctx, devID); err != nil {
 			return err
 		}

--- a/qemu_arch_base.go
+++ b/qemu_arch_base.go
@@ -65,6 +65,9 @@ type qemuArch interface {
 	// appendImage appends an image to devices
 	appendImage(devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error)
 
+	// appendSCSIController appens a SCSI controller to devices
+	appendSCSIController(devices []govmmQemu.Device) []govmmQemu.Device
+
 	// appendBridges appends bridges to devices
 	appendBridges(devices []govmmQemu.Device, bridges []Bridge) []govmmQemu.Device
 
@@ -105,6 +108,14 @@ const (
 	defaultCPUModel         = "host"
 	defaultBridgeBus        = "pcie.0"
 	maxDevIDSize            = 31
+)
+
+const (
+	// VirtioBlock means use virtio-blk for hotplugging drives
+	VirtioBlock = "virtio-blk"
+
+	// VirtioSCSI means use virtio-scsi for hotplugging drives
+	VirtioSCSI = "virtio-scsi"
 )
 
 const (
@@ -275,6 +286,16 @@ func (q *qemuArchBase) appendImage(devices []govmmQemu.Device, path string) ([]g
 	}
 
 	return q.appendBlockDevice(devices, drive), nil
+}
+
+func (q *qemuArchBase) appendSCSIController(devices []govmmQemu.Device) []govmmQemu.Device {
+	scsiController := govmmQemu.SCSIController{
+		ID: scsiControllerID,
+	}
+
+	devices = append(devices, scsiController)
+
+	return devices
 }
 
 // appendBridges appends to devices the given bridges

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -30,12 +30,13 @@ import (
 
 func newQemuConfig() HypervisorConfig {
 	return HypervisorConfig{
-		KernelPath:     testQemuKernelPath,
-		ImagePath:      testQemuImagePath,
-		HypervisorPath: testQemuPath,
-		DefaultVCPUs:   defaultVCPUs,
-		DefaultMemSz:   defaultMemSzMiB,
-		DefaultBridges: defaultBridges,
+		KernelPath:        testQemuKernelPath,
+		ImagePath:         testQemuImagePath,
+		HypervisorPath:    testQemuPath,
+		DefaultVCPUs:      defaultVCPUs,
+		DefaultMemSz:      defaultMemSzMiB,
+		DefaultBridges:    defaultBridges,
+		BlockDeviceDriver: defaultBlockDriver,
 	}
 }
 


### PR DESCRIPTION
With this PR, block devices are hotplugged using either virtio-scsi or virtio-block based on a configuration.