### PR TITLE
kata_agent: Unmount properly the container

### DIFF
--- a/kata_agent.go
+++ b/kata_agent.go
@@ -565,6 +565,10 @@ func (k *kataAgent) stopContainer(pod Pod, c Container) error {
 		return err
 	}
 
+	if err := bindUnmountContainerMounts(c.mounts); err != nil {
+		return err
+	}
+
 	if err := bindUnmountContainerRootfs(kataHostSharedDir, pod.id, c.id); err != nil {
 		return err
 	}


### PR DESCRIPTION
Only the unmounting of the container rootfs was performed, leaving
behind all the other mounts related to the container.

Fixes #562

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>