### PR TITLE
container: fix semantic error when container state is modified

### DIFF
--- a/container.go
+++ b/container.go
@@ -415,6 +415,13 @@ func createContainer(pod *Pod, contConfig ContainerConfig) (*Container, error) {
 	state, err := c.pod.storage.fetchContainerState(c.podID, c.id)
 	if err == nil && state.State != "" {
 		c.state.State = state.State
+		// if we return at this point, the container that is returned
+		// must match with the container in the pod (pod.containers)
+		for i := range pod.containers {
+			if c.id == pod.containers[i].id {
+				pod.containers[i] = c
+			}
+		}
 		return c, nil
 	}
 


### PR DESCRIPTION
the container returned by createContainer must be the same contained
in pod.containers, this patch is needed to avoid semantic errors
manipulating references to containers with the same container ID, but
different memory address

fixes #588

Signed-off-by: Julio Montes <julio.montes@intel.com>