### PR TITLE
qemu: change CPU topology to support until 240 CPUs

### DIFF
--- a/qemu.go
+++ b/qemu.go
@@ -107,7 +107,7 @@ var supportedQemuMachines = []govmmQemu.Machine{
 }
 
 const (
-	defaultSockets uint32 = 1
+	defaultCores   uint32 = 1
 	defaultThreads uint32 = 1
 )
 
@@ -581,10 +581,11 @@ func (q *qemu) setCPUResources(podConfig PodConfig) govmmQemu.SMP {
 		vcpus = uint32(podConfig.VMConfig.VCPUs)
 	}
 
+	// Network IO shows better performance with 1 CPU 1 Socket
 	smp := govmmQemu.SMP{
 		CPUs:    vcpus,
-		Cores:   vcpus,
-		Sockets: defaultSockets,
+		Sockets: vcpus,
+		Cores:   defaultCores,
 		Threads: defaultThreads,
 	}
 


### PR DESCRIPTION
The maximum number of CPUs per VM recommended by KVM is 240.
To support this amount of CPUs, the CPU topology must change
to 1 CPU 1 Socket, otherwise the VM will fail and print next
error message:
    
qemu: max_cpus is too large. APIC ID of last CPU is N
    
fixes #597

Signed-off-by: Julio Montes <julio.montes@intel.com>