### PR TITLE
container: Change block device hotplug ordering to get it effective on Kata Containers agent

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -160,7 +160,7 @@ type agent interface {
 	createContainer(pod *Pod, c *Container) (*Process, error)
 
 	// startContainer will tell the agent to start a container related to a Pod.
-	startContainer(pod Pod, c Container) error
+	startContainer(pod Pod, c *Container) error
 
 	// stopContainer will tell the agent to stop a container related to a Pod.
 	stopContainer(pod Pod, c Container) error

--- a/api.go
+++ b/api.go
@@ -568,7 +568,8 @@ func statusContainer(pod *Pod, containerID string) (ContainerStatus, error) {
 			// We have to check for the process state to make sure
 			// we update the status in case the process is supposed
 			// to be running but has been killed or terminated.
-			if (container.state.State == StateRunning ||
+			if (container.state.State == StateReady ||
+				container.state.State == StateRunning ||
 				container.state.State == StatePaused) &&
 				container.process.Pid > 0 {
 

--- a/container.go
+++ b/container.go
@@ -567,13 +567,12 @@ func (c *Container) stop() error {
 	// the container process has terminated, it might be possible that
 	// someone try to stop the container, and we don't want to issue an
 	// error in that case. This should be a no-op.
-	if state.State == StateStopped {
+	//
+	// This has to be handled before the transition validation since this
+	// is an exception.
+	if c.state.State == StateStopped {
 		c.Logger().Info("Container already stopped")
 		return nil
-	}
-
-	if state.State != StateRunning {
-		return fmt.Errorf("Container not running, impossible to stop")
 	}
 
 	if err := state.validTransition(StateRunning, StateStopped); err != nil {

--- a/device.go
+++ b/device.go
@@ -352,15 +352,6 @@ func newBlockDevice(devInfo DeviceInfo) *BlockDevice {
 }
 
 func (device *BlockDevice) attach(h hypervisor, c *Container) (err error) {
-	// If VM has not been launched yet, return immediately.
-	// This is because we always want to hotplug block devices.
-	// Eventually attachDevices will be called only after VM is launched,
-	// and this check can be taken out.
-	// See https://github.com/containers/virtcontainers/issues/444
-	if c.state.State == "" {
-		return nil
-	}
-
 	randBytes, err := generateRandomBytes(8)
 	if err != nil {
 		return err

--- a/hyperstart_agent.go
+++ b/hyperstart_agent.go
@@ -493,6 +493,11 @@ func (h *hyper) startContainer(pod Pod, c *Container) error {
 
 // stopContainer is the agent Container stopping implementation for hyperstart.
 func (h *hyper) stopContainer(pod Pod, c Container) error {
+	// Nothing to be done in case the container has not been started.
+	if c.state.State == StateReady {
+		return nil
+	}
+
 	return h.stopOneContainer(pod.id, c)
 }
 
@@ -525,6 +530,12 @@ func (h *hyper) stopOneContainer(podID string, c Container) error {
 
 // killContainer is the agent process signal implementation for hyperstart.
 func (h *hyper) killContainer(pod Pod, c Container, signal syscall.Signal, all bool) error {
+	// Send the signal to the shim directly in case the container has not
+	// been started yet.
+	if c.state.State == StateReady {
+		return signalShim(c.process.Pid, signal)
+	}
+
 	return h.killOneContainer(c.id, signal, all)
 }
 

--- a/hyperstart_agent.go
+++ b/hyperstart_agent.go
@@ -223,7 +223,7 @@ func (h *hyper) buildNetworkInterfacesAndRoutes(pod Pod) ([]hyperstart.NetworkIf
 	return ifaces, routes, nil
 }
 
-func fsMapFromMounts(mounts []*Mount) []*hyperstart.FsmapDescriptor {
+func fsMapFromMounts(mounts []Mount) []*hyperstart.FsmapDescriptor {
 	var fsmap []*hyperstart.FsmapDescriptor
 
 	for _, m := range mounts {
@@ -403,7 +403,7 @@ func (h *hyper) stopPod(pod Pod) error {
 	return h.proxy.stop(pod, h.state.ProxyPid)
 }
 
-func (h *hyper) startOneContainer(pod Pod, c Container) error {
+func (h *hyper) startOneContainer(pod Pod, c *Container) error {
 	process, err := h.buildHyperContainerProcess(c.config.Cmd)
 	if err != nil {
 		return err
@@ -437,7 +437,7 @@ func (h *hyper) startOneContainer(pod Pod, c Container) error {
 	//TODO : Enter mount namespace
 
 	// Handle container mounts
-	newMounts, err := bindMountContainerMounts(defaultSharedDir, "", pod.id, c.id, c.mounts)
+	newMounts, err := c.mountSharedDirMounts(defaultSharedDir, "")
 	if err != nil {
 		bindUnmountAllRootfs(defaultSharedDir, pod)
 		return err
@@ -487,7 +487,7 @@ func (h *hyper) createContainer(pod *Pod, c *Container) (*Process, error) {
 }
 
 // startContainer is the agent Container starting implementation for hyperstart.
-func (h *hyper) startContainer(pod Pod, c Container) error {
+func (h *hyper) startContainer(pod Pod, c *Container) error {
 	return h.startOneContainer(pod, c)
 }
 
@@ -510,7 +510,7 @@ func (h *hyper) stopOneContainer(podID string, c Container) error {
 		return err
 	}
 
-	if err := bindUnmountContainerMounts(c.mounts); err != nil {
+	if err := c.unmountHostMounts(); err != nil {
 		return err
 	}
 

--- a/noop_agent.go
+++ b/noop_agent.go
@@ -61,7 +61,7 @@ func (n *noopAgent) createContainer(pod *Pod, c *Container) (*Process, error) {
 }
 
 // startContainer is the Noop agent Container starting implementation. It does nothing.
-func (n *noopAgent) startContainer(pod Pod, c Container) error {
+func (n *noopAgent) startContainer(pod Pod, c *Container) error {
 	return nil
 }
 

--- a/noop_agent_test.go
+++ b/noop_agent_test.go
@@ -105,7 +105,7 @@ func TestNoopAgentStartContainer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = n.startContainer(*pod, *container)
+	err = n.startContainer(*pod, container)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/shim.go
+++ b/shim.go
@@ -140,11 +140,7 @@ func signalShim(pid int, sig syscall.Signal) error {
 			"shim-signal": sig,
 		}).Info("Signalling shim")
 
-	if err := syscall.Kill(pid, sig); err != nil {
-		return err
-	}
-
-	return nil
+	return syscall.Kill(pid, sig)
 }
 
 func stopShim(pid int) error {


### PR DESCRIPTION
The goal of this pull request is to enable the support for block devices for Kata Containers. It appeared that our sequence in container.go was tied to the hyperstart agent expecting things to be hotplugged only at the start stage. In case of Kata Containers, we need this to happen at the creation stage. This won't hurt the case for the hyperstart agent, and this will make it work for Kata too.
Now this pull request also solves other issues about implicit update of the mount list that has been discovered while trying to solve the initial problem. That's why it also refactor a bit the way bind mounts from each agent implementation actually updates the list of mounts held by the container structure.