### PR TITLE
Add support for dockershim pod annotations

### DIFF
--- a/pkg/annotations/dockershim/annotations.go
+++ b/pkg/annotations/dockershim/annotations.go
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package dockershim
+
+const (
+	// Copied from k8s.io/pkg/kubelet/dockershim/docker_service.go,
+	// used to identify whether a docker container is a sandbox or
+	// a regular container, will be removed after defining those as
+	// public fields in dockershim.
+
+	// ContainerTypeLabelKey is the container type (podsandbox or container) annotation
+	ContainerTypeLabelKey = "io.kubernetes.docker.type"
+
+	// ContainerTypeLabelSandbox represents a pod sandbox container
+	ContainerTypeLabelSandbox = "podsandbox"
+
+	// ContainerTypeLabelContainer represents a container running within a pod
+	ContainerTypeLabelContainer = "container"
+
+	// SandboxIDLabelKey is the sandbox ID annotation
+	SandboxIDLabelKey = "io.kubernetes.sandbox.id"
+)

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -26,6 +26,7 @@ import (
 	criContainerdAnnotations "github.com/containerd/cri-containerd/pkg/annotations"
 	vc "github.com/containers/virtcontainers"
 	vcAnnotations "github.com/containers/virtcontainers/pkg/annotations"
+	dockershimAnnotations "github.com/containers/virtcontainers/pkg/annotations/dockershim"
 	crioAnnotations "github.com/kubernetes-incubator/cri-o/pkg/annotations"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
@@ -42,19 +43,21 @@ var (
 
 	// CRIContainerTypeKeyList lists all the CRI keys that could define
 	// the container type from annotations in the config.json.
-	CRIContainerTypeKeyList = []string{criContainerdAnnotations.ContainerType, crioAnnotations.ContainerType}
+	CRIContainerTypeKeyList = []string{criContainerdAnnotations.ContainerType, crioAnnotations.ContainerType, dockershimAnnotations.ContainerTypeLabelKey}
 
 	// CRISandboxNameKeyList lists all the CRI keys that could define
 	// the sandbox ID (pod ID) from annotations in the config.json.
-	CRISandboxNameKeyList = []string{criContainerdAnnotations.SandboxID, crioAnnotations.SandboxID}
+	CRISandboxNameKeyList = []string{criContainerdAnnotations.SandboxID, crioAnnotations.SandboxID, dockershimAnnotations.SandboxIDLabelKey}
 
 	// CRIContainerTypeList lists all the maps from CRI ContainerTypes annotations
 	// to a virtcontainers ContainerType.
 	CRIContainerTypeList = []annotationContainerType{
 		{crioAnnotations.ContainerTypeSandbox, vc.PodSandbox},
+		{crioAnnotations.ContainerTypeContainer, vc.PodContainer},
 		{criContainerdAnnotations.ContainerTypeSandbox, vc.PodSandbox},
 		{criContainerdAnnotations.ContainerTypeContainer, vc.PodContainer},
-		{crioAnnotations.ContainerTypeContainer, vc.PodContainer},
+		{dockershimAnnotations.ContainerTypeLabelSandbox, vc.PodSandbox},
+		{dockershimAnnotations.ContainerTypeLabelContainer, vc.PodContainer},
 	}
 )
 


### PR DESCRIPTION
Dockershim use container labels to identify whether a docker container is a sandbox or a regular container.
I have sent a PR https://github.com/moby/moby/pull/36181 in moby project to pass the label to the annotations of OCI runtime spec.

This commit add support for dockershim pod annotations.

/cc @sameo 


Signed-off-by: Yanqiang Miao <miao.yanqiang@zte.com.cn>