### PR TITLE
qemu: Add support for ARM

### DIFF
--- a/api.go
+++ b/api.go
@@ -32,7 +32,12 @@ var virtLog = logrus.FieldLogger(logrus.New())
 
 // SetLogger sets the logger for virtcontainers package.
 func SetLogger(logger logrus.FieldLogger) {
-	virtLog = logger.WithField("source", "virtcontainers")
+	fields := logrus.Fields{
+		"source": "virtcontainers",
+		"arch":   runtime.GOARCH,
+	}
+
+	virtLog = logger.WithFields(fields)
 }
 
 // CreatePod is the virtcontainers pod creation entry point.

--- a/bridge.go
+++ b/bridge.go
@@ -39,33 +39,6 @@ type Bridge struct {
 	ID string
 }
 
-// NewBridges creates n new pci(e) bridges depending of the machine type
-func NewBridges(n uint32, machine string) []Bridge {
-	var bridges []Bridge
-	var bt bridgeType
-
-	switch machine {
-	case QemuQ35:
-		// currently only pci bridges are supported
-		// qemu-2.10 will introduce pcie bridges
-		fallthrough
-	case QemuPC:
-		bt = pciBridge
-	default:
-		return nil
-	}
-
-	for i := uint32(0); i < n; i++ {
-		bridges = append(bridges, Bridge{
-			Type:    bt,
-			ID:      fmt.Sprintf("%s-bridge-%d", bt, i),
-			Address: make(map[uint32]string),
-		})
-	}
-
-	return bridges
-}
-
 // addDevice on success adds the device ID to the bridge and return the address
 // where the device was added, otherwise an error is returned
 func (b *Bridge) addDevice(ID string) (uint32, error) {

--- a/hypervisor.go
+++ b/hypervisor.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 )
@@ -414,6 +415,11 @@ func getHostMemorySizeKb(memInfoPath string) (uint64, error) {
 
 // RunningOnVMM checks if the system is running inside a VM.
 func RunningOnVMM(cpuInfoPath string) (bool, error) {
+	if runtime.GOARCH == "arm64" {
+		virtLog.Debugf("Unable to know if the system is running inside a VM")
+		return false, nil
+	}
+
 	flagsField := "flags"
 
 	f, err := os.Open(cpuInfoPath)

--- a/hypervisor.go
+++ b/hypervisor.go
@@ -469,5 +469,4 @@ type hypervisor interface {
 	hotplugRemoveDevice(devInfo interface{}, devType deviceType) error
 	getPodConsole(podID string) string
 	capabilities() capabilities
-	getState() interface{}
 }

--- a/mock_hypervisor.go
+++ b/mock_hypervisor.go
@@ -71,7 +71,3 @@ func (m *mockHypervisor) hotplugRemoveDevice(devInfo interface{}, devType device
 func (m *mockHypervisor) getPodConsole(podID string) string {
 	return ""
 }
-
-func (m *mockHypervisor) getState() interface{} {
-	return nil
-}

--- a/qemu.go
+++ b/qemu.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/containers/virtcontainers/pkg/uuid"
@@ -33,7 +32,6 @@ import (
 type qmpChannel struct {
 	ctx  context.Context
 	path string
-	wg   sync.WaitGroup
 	qmp  *govmmQemu.QMP
 }
 
@@ -45,89 +43,31 @@ type QemuState struct {
 
 // qemu is an Hypervisor interface implementation for the Linux qemu hypervisor.
 type qemu struct {
-	path   string
 	config HypervisorConfig
-
-	hypervisorParams []string
-	kernelParams     []string
 
 	qmpMonitorCh qmpChannel
 	qmpControlCh qmpChannel
 
 	qemuConfig govmmQemu.Config
 
-	nestedRun bool
-
 	pod *Pod
 
 	state QemuState
+
+	arch qemuArch
 }
-
-const defaultQemuPath = "/usr/bin/qemu-system-x86_64"
-
-const defaultQemuMachineType = "pc-lite"
-
-const defaultQemuMachineAccelerators = "kvm,kernel_irqchip,nvdimm"
-
-const (
-	// QemuPCLite is the QEMU pc-lite machine type
-	QemuPCLite = defaultQemuMachineType
-
-	// QemuPC is the QEMU pc machine type
-	QemuPC = "pc"
-
-	// QemuQ35 is the QEMU Q35 machine type
-	QemuQ35 = "q35"
-)
 
 const qmpCapErrMsg = "Failed to negoatiate QMP capabilities"
 
 const qmpSockPathSizeLimit = 107
 
-// Mapping between machine types and QEMU binary paths.
-var qemuPaths = map[string]string{
-	QemuPCLite: "/usr/bin/qemu-lite-system-x86_64",
-	QemuPC:     defaultQemuPath,
-	QemuQ35:    "/usr/bin/qemu-35-system-x86_64",
+const defaultConsole = "console.sock"
+
+// agnostic list of kernel parameters
+var defaultKernelParameters = []Param{
+	{"panic", "1"},
+	{"initcall_debug", ""},
 }
-
-var supportedQemuMachines = []govmmQemu.Machine{
-	{
-		Type:         QemuPCLite,
-		Acceleration: defaultQemuMachineAccelerators,
-	},
-	{
-		Type:         QemuPC,
-		Acceleration: defaultQemuMachineAccelerators,
-	},
-	{
-		Type:         QemuQ35,
-		Acceleration: defaultQemuMachineAccelerators,
-	},
-}
-
-const (
-	defaultCores   uint32 = 1
-	defaultThreads uint32 = 1
-)
-
-const (
-	defaultMemSlots uint8 = 2
-)
-
-const (
-	defaultConsole = "console.sock"
-)
-
-const (
-	maxDevIDSize = 31
-)
-
-const (
-	// NVDIMM device needs memory space 1024MB
-	// See https://github.com/clearcontainers/runtime/issues/380
-	maxMemoryOffset = 1024
-)
 
 type operation int
 
@@ -166,367 +106,52 @@ func (l qmpLogger) Errorf(format string, v ...interface{}) {
 	l.logger.Errorf(format, v...)
 }
 
-var kernelDefaultParams = []Param{
-	{"root", "/dev/pmem0p1"},
-	{"rootflags", "dax,data=ordered,errors=remount-ro rw"},
-	{"rootfstype", "ext4"},
-	{"tsc", "reliable"},
-	{"no_timer_check", ""},
-	{"rcupdate.rcu_expedited", "1"},
-	{"i8042.direct", "1"},
-	{"i8042.dumbkbd", "1"},
-	{"i8042.nopnp", "1"},
-	{"i8042.noaux", "1"},
-	{"noreplace-smp", ""},
-	{"reboot", "k"},
-	{"panic", "1"},
-	{"console", "hvc0"},
-	{"console", "hvc1"},
-	{"initcall_debug", ""},
-	{"iommu", "off"},
-	{"cryptomgr.notests", ""},
-	{"net.ifnames", "0"},
-	{"pci", "lastbus=0"},
-}
-
-// kernelDefaultParamsNonDebug is a list of the default kernel
-// parameters that will be used in standard (non-debug) mode.
-var kernelDefaultParamsNonDebug = []Param{
-	{"quiet", ""},
-	{"systemd.show_status", "false"},
-}
-
-// kernelDefaultParamsDebug is a list of the default kernel
-// parameters that will be used in debug mode (as much boot output as
-// possible).
-var kernelDefaultParamsDebug = []Param{
-	{"debug", ""},
-	{"systemd.show_status", "true"},
-	{"systemd.log_level", "debug"},
-}
-
 // Logger returns a logrus logger appropriate for logging qemu messages
 func (q *qemu) Logger() *logrus.Entry {
 	return virtLog.WithField("subsystem", "qemu")
 }
 
-func (q *qemu) buildKernelParams() error {
-	// get a list of default kernel parameters
-	params := q.defaultKernelParams()
+func (q *qemu) buildKernelParams() string {
+	// get a list of arch kernel parameters
+	params := q.arch.kernelParameters(q.config.Debug)
+
+	// use default parameters
+	params = append(params, defaultKernelParameters...)
 
 	// add the params specified by the provided config. As the kernel
 	// honours the last parameter value set and since the config-provided
 	// params are added here, they will take priority over the defaults.
 	params = append(params, q.config.KernelParams...)
 
-	q.kernelParams = SerializeParams(params, "=")
+	paramsStr := SerializeParams(params, "=")
 
-	return nil
-}
-
-func (q *qemu) defaultKernelParams() []Param {
-	params := kernelDefaultParams
-
-	if q.config.Debug {
-		params = append(params, kernelDefaultParamsDebug...)
-	} else {
-		params = append(params, kernelDefaultParamsNonDebug...)
-	}
-
-	return params
+	return strings.Join(paramsStr, " ")
 }
 
 // Adds all capabilities supported by qemu implementation of hypervisor interface
 func (q *qemu) capabilities() capabilities {
-	var caps capabilities
-
-	// Only pc machine type supports hotplugging drives
-	if q.qemuConfig.Machine.Type == QemuPC {
-		caps.setBlockDeviceHotplugSupport()
-	}
-
-	return caps
-}
-
-func (q *qemu) appendVolume(devices []govmmQemu.Device, volume Volume) []govmmQemu.Device {
-	if volume.MountTag == "" || volume.HostPath == "" {
-		return devices
-	}
-
-	devID := fmt.Sprintf("extra-9p-%s", volume.MountTag)
-	if len(devID) > maxDevIDSize {
-		devID = string(devID[:maxDevIDSize])
-	}
-
-	devices = append(devices,
-		govmmQemu.FSDevice{
-			Driver:        govmmQemu.Virtio9P,
-			FSDriver:      govmmQemu.Local,
-			ID:            devID,
-			Path:          volume.HostPath,
-			MountTag:      volume.MountTag,
-			SecurityModel: govmmQemu.None,
-			DisableModern: q.nestedRun,
-		},
-	)
-
-	return devices
-}
-
-func (q *qemu) appendBlockDevice(devices []govmmQemu.Device, drive Drive) []govmmQemu.Device {
-	if drive.File == "" || drive.ID == "" || drive.Format == "" {
-		return devices
-	}
-
-	if len(drive.ID) > maxDevIDSize {
-		drive.ID = string(drive.ID[:maxDevIDSize])
-	}
-
-	devices = append(devices,
-		govmmQemu.BlockDevice{
-			Driver:        govmmQemu.VirtioBlock,
-			ID:            drive.ID,
-			File:          drive.File,
-			AIO:           govmmQemu.Threads,
-			Format:        govmmQemu.BlockDeviceFormat(drive.Format),
-			Interface:     "none",
-			DisableModern: q.nestedRun,
-		},
-	)
-
-	return devices
-}
-
-func (q *qemu) appendVhostUserDevice(devices []govmmQemu.Device, vhostUserDevice VhostUserDevice) []govmmQemu.Device {
-
-	qemuVhostUserDevice := govmmQemu.VhostUserDevice{}
-
-	switch vhostUserDevice := vhostUserDevice.(type) {
-	case *VhostUserNetDevice:
-		qemuVhostUserDevice.TypeDevID = makeNameID("net", vhostUserDevice.ID)
-		qemuVhostUserDevice.Address = vhostUserDevice.MacAddress
-	case *VhostUserSCSIDevice:
-		qemuVhostUserDevice.TypeDevID = makeNameID("scsi", vhostUserDevice.ID)
-	case *VhostUserBlkDevice:
-	}
-
-	qemuVhostUserDevice.VhostUserType = govmmQemu.VhostUserDeviceType(vhostUserDevice.Type())
-	qemuVhostUserDevice.SocketPath = vhostUserDevice.Attrs().SocketPath
-	qemuVhostUserDevice.CharDevID = makeNameID("char", vhostUserDevice.Attrs().ID)
-
-	devices = append(devices, qemuVhostUserDevice)
-
-	return devices
-}
-func (q *qemu) appendVFIODevice(devices []govmmQemu.Device, vfDevice VFIODevice) []govmmQemu.Device {
-	if vfDevice.BDF == "" {
-		return devices
-	}
-
-	devices = append(devices,
-		govmmQemu.VFIODevice{
-			BDF: vfDevice.BDF,
-		},
-	)
-
-	return devices
-}
-
-func (q *qemu) appendSocket(devices []govmmQemu.Device, socket Socket) []govmmQemu.Device {
-	devID := socket.ID
-	if len(devID) > maxDevIDSize {
-		devID = string(devID[:maxDevIDSize])
-	}
-
-	devices = append(devices,
-		govmmQemu.CharDevice{
-			Driver:   govmmQemu.VirtioSerialPort,
-			Backend:  govmmQemu.Socket,
-			DeviceID: socket.DeviceID,
-			ID:       devID,
-			Path:     socket.HostPath,
-			Name:     socket.Name,
-		},
-	)
-
-	return devices
-}
-
-func networkModelToQemuType(model NetInterworkingModel) govmmQemu.NetDeviceType {
-	switch model {
-	case NetXConnectBridgedModel:
-		return govmmQemu.MACVTAP //TODO: We should rename MACVTAP to .NET_FD
-	case NetXConnectMacVtapModel:
-		return govmmQemu.MACVTAP
-	//case ModelEnlightened:
-	// Here the Network plugin will create a VM native interface
-	// which could be MacVtap, IpVtap, SRIOV, veth-tap, vhost-user
-	// In these cases we will determine the interface type here
-	// and pass in the native interface through
-	default:
-		//TAP should work for most other cases
-		return govmmQemu.TAP
-	}
-}
-
-var networkIndex = 0
-
-func (q *qemu) appendNetwork(devices []govmmQemu.Device, endpoint Endpoint) []govmmQemu.Device {
-	switch ep := endpoint.(type) {
-	case *VirtualEndpoint:
-		devices = append(devices,
-			govmmQemu.NetDevice{
-				Type:          networkModelToQemuType(ep.NetPair.NetInterworkingModel),
-				Driver:        govmmQemu.VirtioNetPCI,
-				ID:            fmt.Sprintf("network-%d", networkIndex),
-				IFName:        ep.NetPair.TAPIface.Name,
-				MACAddress:    ep.NetPair.TAPIface.HardAddr,
-				DownScript:    "no",
-				Script:        "no",
-				VHost:         true,
-				DisableModern: q.nestedRun,
-				FDs:           ep.NetPair.VMFds,
-				VhostFDs:      ep.NetPair.VhostFds,
-			},
-		)
-		networkIndex++
-	}
-
-	return devices
-}
-
-func (q *qemu) appendFSDevices(devices []govmmQemu.Device, podConfig PodConfig) []govmmQemu.Device {
-	// Add the shared volumes
-	for _, v := range podConfig.Volumes {
-		devices = q.appendVolume(devices, v)
-	}
-
-	return devices
-}
-
-func (q *qemu) appendBridges(devices []govmmQemu.Device, podConfig PodConfig) ([]govmmQemu.Device, error) {
-	bus := "pci.0"
-	if podConfig.HypervisorConfig.HypervisorMachineType == QemuQ35 {
-		bus = "pcie.0"
-	}
-
-	for idx, b := range q.state.Bridges {
-		t := govmmQemu.PCIBridge
-		if b.Type == pcieBridge {
-			t = govmmQemu.PCIEBridge
-		}
-
-		devices = append(devices,
-			govmmQemu.BridgeDevice{
-				Type: t,
-				Bus:  bus,
-				ID:   b.ID,
-				// Each bridge is required to be assigned a unique chassis id > 0
-				Chassis: (idx + 1),
-				SHPC:    true,
-			},
-		)
-	}
-
-	return devices, nil
-}
-
-func (q *qemu) appendConsoles(devices []govmmQemu.Device, podConfig PodConfig) []govmmQemu.Device {
-	serial := govmmQemu.SerialDevice{
-		Driver:        govmmQemu.VirtioSerial,
-		ID:            "serial0",
-		DisableModern: q.nestedRun,
-	}
-
-	devices = append(devices, serial)
-
-	var console govmmQemu.CharDevice
-
-	console = govmmQemu.CharDevice{
-		Driver:   govmmQemu.Console,
-		Backend:  govmmQemu.Socket,
-		DeviceID: "console0",
-		ID:       "charconsole0",
-		Path:     q.getPodConsole(podConfig.ID),
-	}
-
-	devices = append(devices, console)
-
-	return devices
-}
-
-func (q *qemu) appendImage(devices []govmmQemu.Device, podConfig PodConfig) ([]govmmQemu.Device, error) {
-	imagePath, err := q.config.ImageAssetPath()
-	if err != nil {
-		return nil, err
-	}
-
-	imageFile, err := os.Open(imagePath)
-	if err != nil {
-		return nil, err
-	}
-	defer imageFile.Close()
-
-	imageStat, err := imageFile.Stat()
-	if err != nil {
-		return nil, err
-	}
-
-	object := govmmQemu.Object{
-		Driver:   govmmQemu.NVDIMM,
-		Type:     govmmQemu.MemoryBackendFile,
-		DeviceID: "nv0",
-		ID:       "mem0",
-		MemPath:  imagePath,
-		Size:     (uint64)(imageStat.Size()),
-	}
-
-	devices = append(devices, object)
-
-	return devices, nil
-}
-
-func (q *qemu) getMachine(name string) (govmmQemu.Machine, error) {
-	for _, m := range supportedQemuMachines {
-		if m.Type == name {
-			return m, nil
-		}
-	}
-
-	return govmmQemu.Machine{}, fmt.Errorf("unrecognised machine type: %v", name)
+	return q.arch.capabilities()
 }
 
 // Build the QEMU binary path
-func (q *qemu) buildPath() error {
+func (q *qemu) buildPath() (string, error) {
 	p, err := q.config.HypervisorAssetPath()
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	if p != "" {
-		q.path = p
-		return nil
+	if p == "" {
+		p, err = q.arch.qemuPath()
+		if err != nil {
+			return "", err
+		}
 	}
 
-	// We do not have a configured path, let's try to map one from the machine type
-	machineType := q.config.HypervisorMachineType
-	if machineType == "" {
-		machineType = defaultQemuMachineType
+	if _, err = os.Stat(p); os.IsNotExist(err) {
+		return "", fmt.Errorf("QEMU path (%s) does not exist", p)
 	}
 
-	p, ok := qemuPaths[machineType]
-	if !ok {
-		q.Logger().WithField("machine-type", machineType).Warn("Unknown machine type")
-		p = defaultQemuPath
-	}
-
-	if _, err := os.Stat(p); os.IsNotExist(err) {
-		return fmt.Errorf("QEMU path (%s) does not exist", p)
-	}
-
-	q.path = p
-
-	return nil
+	return p, nil
 }
 
 // init intializes the Qemu structure.
@@ -538,15 +163,16 @@ func (q *qemu) init(pod *Pod) error {
 
 	q.config = pod.config.HypervisorConfig
 	q.pod = pod
+	q.arch = newQemuArch(q.config.HypervisorMachineType)
 
-	if err := pod.storage.fetchHypervisorState(pod.id, &q.state); err != nil {
+	if err = pod.storage.fetchHypervisorState(pod.id, &q.state); err != nil {
 		q.Logger().Debug("Creating bridges")
-		q.state.Bridges = NewBridges(q.config.DefaultBridges, q.config.HypervisorMachineType)
+		q.state.Bridges = q.arch.bridges(q.config.DefaultBridges)
 
 		q.Logger().Debug("Creating UUID")
 		q.state.UUID = uuid.Generate().String()
 
-		if err := pod.storage.storeHypervisorState(pod.id, q.state); err != nil {
+		if err = pod.storage.storeHypervisorState(pod.id, q.state); err != nil {
 			return err
 		}
 	}
@@ -564,12 +190,11 @@ func (q *qemu) init(pod *Pod) error {
 		return err
 	}
 
-	if q.config.DisableNestingChecks {
-		//Intentionally ignore the nesting check
-		q.Logger().WithField("inside-vm", fmt.Sprintf("%t", nested)).Debug("Disable nesting environment checksx")
-		q.nestedRun = false
+	if !q.config.DisableNestingChecks && nested {
+		q.arch.enableNestingChecks()
 	} else {
-		q.nestedRun = nested
+		q.Logger().WithField("inside-vm", fmt.Sprintf("%t", nested)).Debug("Disable nesting environment checks")
+		q.arch.disableNestingChecks()
 	}
 
 	return nil
@@ -581,15 +206,7 @@ func (q *qemu) setCPUResources(podConfig PodConfig) govmmQemu.SMP {
 		vcpus = uint32(podConfig.VMConfig.VCPUs)
 	}
 
-	// Network IO shows better performance with 1 CPU 1 Socket
-	smp := govmmQemu.SMP{
-		CPUs:    vcpus,
-		Sockets: vcpus,
-		Cores:   defaultCores,
-		Threads: defaultThreads,
-	}
-
-	return smp
+	return q.arch.cpuTopology(vcpus)
 }
 
 func (q *qemu) setMemoryResources(podConfig PodConfig) (govmmQemu.Memory, error) {
@@ -601,20 +218,14 @@ func (q *qemu) setMemoryResources(podConfig PodConfig) (govmmQemu.Memory, error)
 		return govmmQemu.Memory{}, fmt.Errorf("Error host memory size 0")
 	}
 
-	// add 1G memory space for nvdimm device (vm guest image)
-	memMax := fmt.Sprintf("%dM", int(float64(hostMemKb)/1024)+maxMemoryOffset)
-	mem := fmt.Sprintf("%dM", q.config.DefaultMemSz)
+	hostMemMb := uint64(float64(hostMemKb / 1024))
+
+	memMb := uint64(q.config.DefaultMemSz)
 	if podConfig.VMConfig.Memory > 0 {
-		mem = fmt.Sprintf("%dM", podConfig.VMConfig.Memory)
+		memMb = uint64(podConfig.VMConfig.Memory)
 	}
 
-	memory := govmmQemu.Memory{
-		Size:   mem,
-		Slots:  defaultMemSlots,
-		MaxMem: memMax,
-	}
-
-	return memory, nil
+	return q.arch.memoryTopology(memMb, hostMemMb), nil
 }
 
 func (q *qemu) qmpSocketPath(socketName string) (string, error) {
@@ -638,12 +249,7 @@ func (q *qemu) qmpSocketPath(socketName string) (string, error) {
 func (q *qemu) createPod(podConfig PodConfig) error {
 	var devices []govmmQemu.Device
 
-	machineType := q.config.HypervisorMachineType
-	if machineType == "" {
-		machineType = defaultQemuMachineType
-	}
-
-	machine, err := q.getMachine(machineType)
+	machine, err := q.arch.machine()
 	if err != nil {
 		return err
 	}
@@ -653,7 +259,7 @@ func (q *qemu) createPod(podConfig PodConfig) error {
 		if !strings.HasPrefix(accelerators, ",") {
 			accelerators = fmt.Sprintf(",%s", accelerators)
 		}
-		machine.Acceleration += accelerators
+		machine.Options += accelerators
 	}
 
 	smp := q.setCPUResources(podConfig)
@@ -681,7 +287,7 @@ func (q *qemu) createPod(podConfig PodConfig) error {
 
 	kernel := govmmQemu.Kernel{
 		Path:   kernelPath,
-		Params: strings.Join(q.kernelParams, " "),
+		Params: q.buildKernelParams(),
 	}
 
 	rtc := govmmQemu.RTC{
@@ -728,24 +334,28 @@ func (q *qemu) createPod(podConfig PodConfig) error {
 		},
 	}
 
-	devices = q.appendFSDevices(devices, podConfig)
-	devices = q.appendConsoles(devices, podConfig)
-	devices, err = q.appendImage(devices, podConfig)
+	devices = q.arch.append9PVolumes(devices, podConfig.Volumes)
+	devices = q.arch.appendConsole(devices, q.getPodConsole(podConfig.ID))
+	devices = q.arch.appendBridges(devices, q.state.Bridges)
+
+	imagePath, err := q.config.ImageAssetPath()
 	if err != nil {
 		return err
 	}
 
-	devices, err = q.appendBridges(devices, podConfig)
+	devices, err = q.arch.appendImage(devices, imagePath)
 	if err != nil {
 		return err
 	}
 
-	cpuModel := "host"
-	if q.nestedRun {
-		cpuModel += ",pmu=off"
-	}
+	cpuModel := q.arch.cpuModel()
 
 	firmwarePath, err := podConfig.HypervisorConfig.FirmwareAssetPath()
+	if err != nil {
+		return err
+	}
+
+	qemuPath, err := q.buildPath()
 	if err != nil {
 		return err
 	}
@@ -753,7 +363,7 @@ func (q *qemu) createPod(podConfig PodConfig) error {
 	qemuConfig := govmmQemu.Config{
 		Name:        fmt.Sprintf("pod-%s", podConfig.ID),
 		UUID:        q.state.UUID,
-		Path:        q.path,
+		Path:        qemuPath,
 		Ctx:         q.qmpMonitorCh.ctx,
 		Machine:     machine,
 		SMP:         smp,
@@ -777,7 +387,7 @@ func (q *qemu) createPod(podConfig PodConfig) error {
 // startPod will start the Pod's VM.
 func (q *qemu) startPod() error {
 	if q.config.Debug {
-		params := q.defaultKernelParams()
+		params := q.arch.kernelParameters(q.config.Debug)
 		strParams := SerializeParams(params, "=")
 		formatted := strings.Join(strParams, " ")
 
@@ -1042,23 +652,23 @@ func (q *qemu) resumePod() error {
 func (q *qemu) addDevice(devInfo interface{}, devType deviceType) error {
 	switch v := devInfo.(type) {
 	case Volume:
-		q.qemuConfig.Devices = q.appendVolume(q.qemuConfig.Devices, v)
+		q.qemuConfig.Devices = q.arch.append9PVolume(q.qemuConfig.Devices, v)
 	case Socket:
-		q.qemuConfig.Devices = q.appendSocket(q.qemuConfig.Devices, v)
+		q.qemuConfig.Devices = q.arch.appendSocket(q.qemuConfig.Devices, v)
 	case Endpoint:
-		q.qemuConfig.Devices = q.appendNetwork(q.qemuConfig.Devices, v)
+		q.qemuConfig.Devices = q.arch.appendNetwork(q.qemuConfig.Devices, v)
 	case Drive:
-		q.qemuConfig.Devices = q.appendBlockDevice(q.qemuConfig.Devices, v)
+		q.qemuConfig.Devices = q.arch.appendBlockDevice(q.qemuConfig.Devices, v)
 
 	//vhostUserDevice is an interface, hence the pointer for Net, SCSI and Blk:
 	case VhostUserNetDevice:
-		q.qemuConfig.Devices = q.appendVhostUserDevice(q.qemuConfig.Devices, &v)
+		q.qemuConfig.Devices = q.arch.appendVhostUserDevice(q.qemuConfig.Devices, &v)
 	case VhostUserSCSIDevice:
-		q.qemuConfig.Devices = q.appendVhostUserDevice(q.qemuConfig.Devices, &v)
+		q.qemuConfig.Devices = q.arch.appendVhostUserDevice(q.qemuConfig.Devices, &v)
 	case VhostUserBlkDevice:
-		q.qemuConfig.Devices = q.appendVhostUserDevice(q.qemuConfig.Devices, &v)
+		q.qemuConfig.Devices = q.arch.appendVhostUserDevice(q.qemuConfig.Devices, &v)
 	case VFIODevice:
-		q.qemuConfig.Devices = q.appendVFIODevice(q.qemuConfig.Devices, v)
+		q.qemuConfig.Devices = q.arch.appendVFIODevice(q.qemuConfig.Devices, v)
 	default:
 		break
 	}

--- a/qemu.go
+++ b/qemu.go
@@ -177,14 +177,6 @@ func (q *qemu) init(pod *Pod) error {
 		}
 	}
 
-	if err := q.buildPath(); err != nil {
-		return err
-	}
-
-	if err := q.buildKernelParams(); err != nil {
-		return err
-	}
-
 	nested, err := RunningOnVMM(procCPUInfo)
 	if err != nil {
 		return err

--- a/qemu.go
+++ b/qemu.go
@@ -1071,7 +1071,3 @@ func (q *qemu) addDevice(devInfo interface{}, devType deviceType) error {
 func (q *qemu) getPodConsole(podID string) string {
 	return filepath.Join(runStoragePath, podID, defaultConsole)
 }
-
-func (q *qemu) getState() interface{} {
-	return q.state
-}

--- a/qemu_amd64.go
+++ b/qemu_amd64.go
@@ -1,0 +1,214 @@
+//
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"fmt"
+	"os"
+
+	govmmQemu "github.com/intel/govmm/qemu"
+)
+
+type qemuAmd64 struct {
+	// inherit from qemuArchBase, overwrite methods if needed
+	qemuArchBase
+}
+
+const defaultQemuPath = "/usr/bin/qemu-system-x86_64"
+
+const defaultQemuMachineType = QemuPC
+
+const defaultQemuMachineOptions = "accel=kvm,kernel_irqchip,nvdimm"
+
+const defaultPCBridgeBus = "pci.0"
+
+var qemuPaths = map[string]string{
+	QemuPCLite: "/usr/bin/qemu-lite-system-x86_64",
+	QemuPC:     defaultQemuPath,
+	QemuQ35:    defaultQemuPath,
+}
+
+var kernelParams = []Param{
+	{"root", "/dev/pmem0p1"},
+	{"rootflags", "dax,data=ordered,errors=remount-ro rw"},
+	{"rootfstype", "ext4"},
+	{"tsc", "reliable"},
+	{"no_timer_check", ""},
+	{"rcupdate.rcu_expedited", "1"},
+	{"i8042.direct", "1"},
+	{"i8042.dumbkbd", "1"},
+	{"i8042.nopnp", "1"},
+	{"i8042.noaux", "1"},
+	{"noreplace-smp", ""},
+	{"reboot", "k"},
+	{"console", "hvc0"},
+	{"console", "hvc1"},
+	{"iommu", "off"},
+	{"cryptomgr.notests", ""},
+	{"net.ifnames", "0"},
+	{"pci", "lastbus=0"},
+}
+
+var supportedQemuMachines = []govmmQemu.Machine{
+	{
+		Type:    QemuPCLite,
+		Options: defaultQemuMachineOptions,
+	},
+	{
+		Type:    QemuPC,
+		Options: defaultQemuMachineOptions,
+	},
+	{
+		Type:    QemuQ35,
+		Options: defaultQemuMachineOptions,
+	},
+}
+
+func newQemuArch(machineType string) qemuArch {
+	if machineType == "" {
+		machineType = defaultQemuMachineType
+	}
+
+	return &qemuAmd64{
+		qemuArchBase{
+			machineType:           machineType,
+			qemuPaths:             qemuPaths,
+			supportedQemuMachines: supportedQemuMachines,
+			kernelParamsNonDebug:  kernelParamsNonDebug,
+			kernelParamsDebug:     kernelParamsDebug,
+			kernelParams:          kernelParams,
+		},
+	}
+}
+
+func (q *qemuAmd64) capabilities() capabilities {
+	var caps capabilities
+
+	// Only pc machine type supports hotplugging drives
+	if q.machineType == QemuPC {
+		caps.setBlockDeviceHotplugSupport()
+	}
+
+	return caps
+}
+
+func (q *qemuAmd64) bridges(number uint32) []Bridge {
+	var bridges []Bridge
+	var bt bridgeType
+
+	switch q.machineType {
+	case QemuQ35:
+		// currently only pci bridges are supported
+		// qemu-2.10 will introduce pcie bridges
+		fallthrough
+	case QemuPC:
+		bt = pciBridge
+	default:
+		return nil
+	}
+
+	for i := uint32(0); i < number; i++ {
+		bridges = append(bridges, Bridge{
+			Type:    bt,
+			ID:      fmt.Sprintf("%s-bridge-%d", bt, i),
+			Address: make(map[uint32]string),
+		})
+	}
+
+	return bridges
+}
+
+func (q *qemuAmd64) cpuModel() string {
+	cpuModel := defaultCPUModel
+	if q.nestedRun {
+		cpuModel += ",pmu=off"
+	}
+	return cpuModel
+}
+
+func (q *qemuAmd64) memoryTopology(memoryMb, hostMemoryMb uint64) govmmQemu.Memory {
+	// NVDIMM device needs memory space 1024MB
+	// See https://github.com/clearcontainers/runtime/issues/380
+	memoryOffset := 1024
+
+	// add 1G memory space for nvdimm device (vm guest image)
+	memMax := fmt.Sprintf("%dM", hostMemoryMb+uint64(memoryOffset))
+
+	mem := fmt.Sprintf("%dM", memoryMb)
+
+	memory := govmmQemu.Memory{
+		Size:   mem,
+		Slots:  defaultMemSlots,
+		MaxMem: memMax,
+	}
+
+	return memory
+}
+
+func (q *qemuAmd64) appendImage(devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error) {
+	imageFile, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = imageFile.Close() }()
+
+	imageStat, err := imageFile.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	object := govmmQemu.Object{
+		Driver:   govmmQemu.NVDIMM,
+		Type:     govmmQemu.MemoryBackendFile,
+		DeviceID: "nv0",
+		ID:       "mem0",
+		MemPath:  path,
+		Size:     (uint64)(imageStat.Size()),
+	}
+
+	devices = append(devices, object)
+
+	return devices, nil
+}
+
+// appendBridges appends to devices the given bridges
+func (q *qemuAmd64) appendBridges(devices []govmmQemu.Device, bridges []Bridge) []govmmQemu.Device {
+	bus := defaultPCBridgeBus
+	if q.machineType == QemuQ35 {
+		bus = defaultBridgeBus
+	}
+
+	for idx, b := range bridges {
+		t := govmmQemu.PCIBridge
+		if b.Type == pcieBridge {
+			t = govmmQemu.PCIEBridge
+		}
+
+		devices = append(devices,
+			govmmQemu.BridgeDevice{
+				Type: t,
+				Bus:  bus,
+				ID:   b.ID,
+				// Each bridge is required to be assigned a unique chassis id > 0
+				Chassis: (idx + 1),
+				SHPC:    true,
+			},
+		)
+	}
+
+	return devices
+}

--- a/qemu_amd64_test.go
+++ b/qemu_amd64_test.go
@@ -1,0 +1,179 @@
+//
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	govmmQemu "github.com/intel/govmm/qemu"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQemuAmd64Capabilities(t *testing.T) {
+	assert := assert.New(t)
+
+	amd64 := newQemuArch(QemuPC)
+	caps := amd64.capabilities()
+	assert.True(caps.isBlockDeviceHotplugSupported())
+
+	amd64 = newQemuArch(QemuQ35)
+	caps = amd64.capabilities()
+	assert.False(caps.isBlockDeviceHotplugSupported())
+}
+
+func TestQemuAmd64Bridges(t *testing.T) {
+	assert := assert.New(t)
+	amd64 := newQemuArch(QemuPC)
+	len := 5
+
+	bridges := amd64.bridges(uint32(len))
+	assert.Len(bridges, len)
+
+	for i, b := range bridges {
+		id := fmt.Sprintf("%s-bridge-%d", pciBridge, i)
+		assert.Equal(pciBridge, b.Type)
+		assert.Equal(id, b.ID)
+		assert.NotNil(b.Address)
+	}
+
+	amd64 = newQemuArch(QemuQ35)
+	bridges = amd64.bridges(uint32(len))
+	assert.Len(bridges, len)
+
+	for i, b := range bridges {
+		id := fmt.Sprintf("%s-bridge-%d", pciBridge, i)
+		assert.Equal(pciBridge, b.Type)
+		assert.Equal(id, b.ID)
+		assert.NotNil(b.Address)
+	}
+
+	amd64 = newQemuArch(QemuQ35 + QemuPC)
+	bridges = amd64.bridges(uint32(len))
+	assert.Nil(bridges)
+}
+
+func TestQemuAmd64CPUModel(t *testing.T) {
+	assert := assert.New(t)
+	amd64 := newQemuArch(QemuPC)
+
+	expectedOut := defaultCPUModel
+	model := amd64.cpuModel()
+	assert.Equal(expectedOut, model)
+
+	amd64.enableNestingChecks()
+	expectedOut = defaultCPUModel + ",pmu=off"
+	model = amd64.cpuModel()
+	assert.Equal(expectedOut, model)
+}
+
+func TestQemuAmd64MemoryTopology(t *testing.T) {
+	assert := assert.New(t)
+	amd64 := newQemuArch(QemuPC)
+	memoryOffset := 1024
+
+	hostMem := uint64(100)
+	mem := uint64(120)
+	expectedMemory := govmmQemu.Memory{
+		Size:   fmt.Sprintf("%dM", mem),
+		Slots:  defaultMemSlots,
+		MaxMem: fmt.Sprintf("%dM", hostMem+uint64(memoryOffset)),
+	}
+
+	m := amd64.memoryTopology(mem, hostMem)
+	assert.Equal(expectedMemory, m)
+}
+
+func TestQemuAmd64AppendImage(t *testing.T) {
+	var devices []govmmQemu.Device
+	assert := assert.New(t)
+	amd64 := newQemuArch(QemuPC)
+
+	f, err := ioutil.TempFile("", "img")
+	assert.NoError(err)
+	defer func() { _ = f.Close() }()
+	defer func() { _ = os.Remove(f.Name()) }()
+
+	imageStat, err := f.Stat()
+	assert.NoError(err)
+
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.Object{
+			Driver:   govmmQemu.NVDIMM,
+			Type:     govmmQemu.MemoryBackendFile,
+			DeviceID: "nv0",
+			ID:       "mem0",
+			MemPath:  f.Name(),
+			Size:     (uint64)(imageStat.Size()),
+		},
+	}
+
+	devices, err = amd64.appendImage(devices, f.Name())
+	assert.NoError(err)
+
+	assert.Equal(expectedOut, devices)
+}
+
+func TestQemuAmd64AppendBridges(t *testing.T) {
+	var devices []govmmQemu.Device
+	assert := assert.New(t)
+
+	// check PC
+	amd64 := newQemuArch(QemuPC)
+
+	bridges := amd64.bridges(1)
+	assert.Len(bridges, 1)
+
+	devices = amd64.appendBridges(devices, bridges)
+	assert.Len(devices, 1)
+
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.BridgeDevice{
+			Type:    govmmQemu.PCIBridge,
+			Bus:     defaultPCBridgeBus,
+			ID:      bridges[0].ID,
+			Chassis: 1,
+			SHPC:    true,
+		},
+	}
+
+	assert.Equal(expectedOut, devices)
+
+	// Check Q35
+	amd64 = newQemuArch(QemuQ35)
+
+	bridges = amd64.bridges(1)
+	assert.Len(bridges, 1)
+
+	devices = []govmmQemu.Device{}
+	devices = amd64.appendBridges(devices, bridges)
+	assert.Len(devices, 1)
+
+	expectedOut = []govmmQemu.Device{
+		govmmQemu.BridgeDevice{
+			Type:    govmmQemu.PCIBridge,
+			Bus:     defaultBridgeBus,
+			ID:      bridges[0].ID,
+			Chassis: 1,
+			SHPC:    true,
+		},
+	}
+
+	assert.Equal(expectedOut, devices)
+}

--- a/qemu_arch_base.go
+++ b/qemu_arch_base.go
@@ -1,0 +1,446 @@
+//
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+
+	govmmQemu "github.com/intel/govmm/qemu"
+)
+
+type qemuArch interface {
+	// enableNestingChecks nesting checks will be honoured
+	enableNestingChecks()
+
+	// disableNestingChecks nesting checks will be ignored
+	disableNestingChecks()
+
+	// machine returns the machine type
+	machine() (govmmQemu.Machine, error)
+
+	// qemuPath returns the path to the QEMU binary
+	qemuPath() (string, error)
+
+	// kernelParameters returns the kernel parameters
+	// if debug is true then kernel debug parameters are included
+	kernelParameters(debug bool) []Param
+
+	//capabilities returns the capabilities supported by QEMU
+	capabilities() capabilities
+
+	// bridges returns the number bridges for the machine type
+	bridges(number uint32) []Bridge
+
+	// cpuTopology returns the CPU topology for the given amount of vcpus
+	cpuTopology(vcpus uint32) govmmQemu.SMP
+
+	// cpuModel returns the CPU model for the machine type
+	cpuModel() string
+
+	// memoryTopology returns the memory topology using the given amount of memoryMb and hostMemoryMb
+	memoryTopology(memoryMb, hostMemoryMb uint64) govmmQemu.Memory
+
+	// append9PVolumes appends volumes to devices
+	append9PVolumes(devices []govmmQemu.Device, volumes []Volume) []govmmQemu.Device
+
+	// appendConsole appends a console to devices
+	appendConsole(devices []govmmQemu.Device, path string) []govmmQemu.Device
+
+	// appendImage appends an image to devices
+	appendImage(devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error)
+
+	// appendBridges appends bridges to devices
+	appendBridges(devices []govmmQemu.Device, bridges []Bridge) []govmmQemu.Device
+
+	// append9PVolume appends a 9P volume to devices
+	append9PVolume(devices []govmmQemu.Device, volume Volume) []govmmQemu.Device
+
+	// appendSocket appends a socket to devices
+	appendSocket(devices []govmmQemu.Device, socket Socket) []govmmQemu.Device
+
+	// appendNetwork appends a endpoint device to devices
+	appendNetwork(devices []govmmQemu.Device, endpoint Endpoint) []govmmQemu.Device
+
+	// appendBlockDevice appends a block drive to devices
+	appendBlockDevice(devices []govmmQemu.Device, drive Drive) []govmmQemu.Device
+
+	// appendVhostUserDevice appends a vhost user device to devices
+	appendVhostUserDevice(devices []govmmQemu.Device, vhostUserDevice VhostUserDevice) []govmmQemu.Device
+
+	// appendVFIODevice appends a VFIO device to devices
+	appendVFIODevice(devices []govmmQemu.Device, vfioDevice VFIODevice) []govmmQemu.Device
+}
+
+type qemuArchBase struct {
+	machineType           string
+	nestedRun             bool
+	networkIndex          int
+	qemuPaths             map[string]string
+	supportedQemuMachines []govmmQemu.Machine
+	kernelParamsNonDebug  []Param
+	kernelParamsDebug     []Param
+	kernelParams          []Param
+}
+
+const (
+	defaultCores     uint32 = 1
+	defaultThreads   uint32 = 1
+	defaultMemSlots  uint8  = 2
+	defaultCPUModel         = "host"
+	defaultBridgeBus        = "pcie.0"
+	maxDevIDSize            = 31
+)
+
+const (
+	// QemuPCLite is the QEMU pc-lite machine type for amd64
+	QemuPCLite = "pc-lite"
+
+	// QemuPC is the QEMU pc machine type for amd64
+	QemuPC = "pc"
+
+	// QemuQ35 is the QEMU Q35 machine type for amd64
+	QemuQ35 = "q35"
+
+	// QemuVirt is the QEMU virt machine type for aarch64
+	QemuVirt = "virt"
+)
+
+// kernelParamsNonDebug is a list of the default kernel
+// parameters that will be used in standard (non-debug) mode.
+var kernelParamsNonDebug = []Param{
+	{"quiet", ""},
+	{"systemd.show_status", "false"},
+}
+
+// kernelParamsDebug is a list of the default kernel
+// parameters that will be used in debug mode (as much boot output as
+// possible).
+var kernelParamsDebug = []Param{
+	{"debug", ""},
+	{"systemd.show_status", "true"},
+	{"systemd.log_level", "debug"},
+}
+
+func (q *qemuArchBase) enableNestingChecks() {
+	q.nestedRun = true
+}
+
+func (q *qemuArchBase) disableNestingChecks() {
+	q.nestedRun = false
+}
+
+func (q *qemuArchBase) machine() (govmmQemu.Machine, error) {
+	for _, m := range q.supportedQemuMachines {
+		if m.Type == q.machineType {
+			return m, nil
+		}
+	}
+
+	return govmmQemu.Machine{}, fmt.Errorf("unrecognised machine type: %v", q.machineType)
+}
+
+func (q *qemuArchBase) qemuPath() (string, error) {
+	p, ok := q.qemuPaths[q.machineType]
+	if !ok {
+		return "", fmt.Errorf("Unknown machine type: %s", q.machineType)
+	}
+
+	return p, nil
+}
+
+func (q *qemuArchBase) kernelParameters(debug bool) []Param {
+	params := q.kernelParams
+
+	if debug {
+		params = append(params, q.kernelParamsDebug...)
+	} else {
+		params = append(params, q.kernelParamsNonDebug...)
+	}
+
+	return params
+}
+
+func (q *qemuArchBase) capabilities() capabilities {
+	var caps capabilities
+	caps.setBlockDeviceHotplugSupport()
+	return caps
+}
+
+func (q *qemuArchBase) bridges(number uint32) []Bridge {
+	var bridges []Bridge
+
+	for i := uint32(0); i < number; i++ {
+		bridges = append(bridges, Bridge{
+			Type:    pciBridge,
+			ID:      fmt.Sprintf("%s-bridge-%d", pciBridge, i),
+			Address: make(map[uint32]string),
+		})
+	}
+
+	return bridges
+}
+
+func (q *qemuArchBase) cpuTopology(vcpus uint32) govmmQemu.SMP {
+	smp := govmmQemu.SMP{
+		CPUs:    vcpus,
+		Sockets: vcpus,
+		Cores:   defaultCores,
+		Threads: defaultThreads,
+	}
+
+	return smp
+}
+
+func (q *qemuArchBase) cpuModel() string {
+	return defaultCPUModel
+}
+
+func (q *qemuArchBase) memoryTopology(memoryMb, hostMemoryMb uint64) govmmQemu.Memory {
+	memMax := fmt.Sprintf("%dM", hostMemoryMb)
+	mem := fmt.Sprintf("%dM", memoryMb)
+	memory := govmmQemu.Memory{
+		Size:   mem,
+		Slots:  defaultMemSlots,
+		MaxMem: memMax,
+	}
+
+	return memory
+}
+
+func (q *qemuArchBase) append9PVolumes(devices []govmmQemu.Device, volumes []Volume) []govmmQemu.Device {
+	// Add the shared volumes
+	for _, v := range volumes {
+		devices = q.append9PVolume(devices, v)
+	}
+
+	return devices
+}
+
+func (q *qemuArchBase) appendConsole(devices []govmmQemu.Device, path string) []govmmQemu.Device {
+	serial := govmmQemu.SerialDevice{
+		Driver:        govmmQemu.VirtioSerial,
+		ID:            "serial0",
+		DisableModern: q.nestedRun,
+	}
+
+	devices = append(devices, serial)
+
+	var console govmmQemu.CharDevice
+
+	console = govmmQemu.CharDevice{
+		Driver:   govmmQemu.Console,
+		Backend:  govmmQemu.Socket,
+		DeviceID: "console0",
+		ID:       "charconsole0",
+		Path:     path,
+	}
+
+	devices = append(devices, console)
+
+	return devices
+}
+
+func (q *qemuArchBase) appendImage(devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil, err
+	}
+
+	randBytes, err := generateRandomBytes(8)
+	if err != nil {
+		return nil, err
+	}
+
+	id := makeNameID("image", hex.EncodeToString(randBytes))
+
+	drive := Drive{
+		File:   path,
+		Format: "raw",
+		ID:     id,
+	}
+
+	return q.appendBlockDevice(devices, drive), nil
+}
+
+// appendBridges appends to devices the given bridges
+func (q *qemuArchBase) appendBridges(devices []govmmQemu.Device, bridges []Bridge) []govmmQemu.Device {
+	for idx, b := range bridges {
+		t := govmmQemu.PCIBridge
+		if b.Type == pcieBridge {
+			t = govmmQemu.PCIEBridge
+		}
+
+		devices = append(devices,
+			govmmQemu.BridgeDevice{
+				Type: t,
+				Bus:  defaultBridgeBus,
+				ID:   b.ID,
+				// Each bridge is required to be assigned a unique chassis id > 0
+				Chassis: (idx + 1),
+				SHPC:    true,
+			},
+		)
+	}
+
+	return devices
+}
+
+func (q *qemuArchBase) append9PVolume(devices []govmmQemu.Device, volume Volume) []govmmQemu.Device {
+	if volume.MountTag == "" || volume.HostPath == "" {
+		return devices
+	}
+
+	devID := fmt.Sprintf("extra-9p-%s", volume.MountTag)
+	if len(devID) > maxDevIDSize {
+		devID = devID[:maxDevIDSize]
+	}
+
+	devices = append(devices,
+		govmmQemu.FSDevice{
+			Driver:        govmmQemu.Virtio9P,
+			FSDriver:      govmmQemu.Local,
+			ID:            devID,
+			Path:          volume.HostPath,
+			MountTag:      volume.MountTag,
+			SecurityModel: govmmQemu.None,
+			DisableModern: q.nestedRun,
+		},
+	)
+
+	return devices
+}
+
+func (q *qemuArchBase) appendSocket(devices []govmmQemu.Device, socket Socket) []govmmQemu.Device {
+	devID := socket.ID
+	if len(devID) > maxDevIDSize {
+		devID = devID[:maxDevIDSize]
+	}
+
+	devices = append(devices,
+		govmmQemu.CharDevice{
+			Driver:   govmmQemu.VirtioSerialPort,
+			Backend:  govmmQemu.Socket,
+			DeviceID: socket.DeviceID,
+			ID:       devID,
+			Path:     socket.HostPath,
+			Name:     socket.Name,
+		},
+	)
+
+	return devices
+}
+
+func networkModelToQemuType(model NetInterworkingModel) govmmQemu.NetDeviceType {
+	switch model {
+	case NetXConnectBridgedModel:
+		return govmmQemu.MACVTAP //TODO: We should rename MACVTAP to .NET_FD
+	case NetXConnectMacVtapModel:
+		return govmmQemu.MACVTAP
+	//case ModelEnlightened:
+	// Here the Network plugin will create a VM native interface
+	// which could be MacVtap, IpVtap, SRIOV, veth-tap, vhost-user
+	// In these cases we will determine the interface type here
+	// and pass in the native interface through
+	default:
+		//TAP should work for most other cases
+		return govmmQemu.TAP
+	}
+}
+
+func (q *qemuArchBase) appendNetwork(devices []govmmQemu.Device, endpoint Endpoint) []govmmQemu.Device {
+	switch ep := endpoint.(type) {
+	case *VirtualEndpoint:
+		devices = append(devices,
+			govmmQemu.NetDevice{
+				Type:          networkModelToQemuType(ep.NetPair.NetInterworkingModel),
+				Driver:        govmmQemu.VirtioNetPCI,
+				ID:            fmt.Sprintf("network-%d", q.networkIndex),
+				IFName:        ep.NetPair.TAPIface.Name,
+				MACAddress:    ep.NetPair.TAPIface.HardAddr,
+				DownScript:    "no",
+				Script:        "no",
+				VHost:         true,
+				DisableModern: q.nestedRun,
+				FDs:           ep.NetPair.VMFds,
+				VhostFDs:      ep.NetPair.VhostFds,
+			},
+		)
+		q.networkIndex++
+	}
+
+	return devices
+}
+
+func (q *qemuArchBase) appendBlockDevice(devices []govmmQemu.Device, drive Drive) []govmmQemu.Device {
+	if drive.File == "" || drive.ID == "" || drive.Format == "" {
+		return devices
+	}
+
+	if len(drive.ID) > maxDevIDSize {
+		drive.ID = drive.ID[:maxDevIDSize]
+	}
+
+	devices = append(devices,
+		govmmQemu.BlockDevice{
+			Driver:        govmmQemu.VirtioBlock,
+			ID:            drive.ID,
+			File:          drive.File,
+			AIO:           govmmQemu.Threads,
+			Format:        govmmQemu.BlockDeviceFormat(drive.Format),
+			Interface:     "none",
+			DisableModern: q.nestedRun,
+		},
+	)
+
+	return devices
+}
+
+func (q *qemuArchBase) appendVhostUserDevice(devices []govmmQemu.Device, vhostUserDevice VhostUserDevice) []govmmQemu.Device {
+	qemuVhostUserDevice := govmmQemu.VhostUserDevice{}
+
+	switch vhostUserDevice := vhostUserDevice.(type) {
+	case *VhostUserNetDevice:
+		qemuVhostUserDevice.TypeDevID = makeNameID("net", vhostUserDevice.ID)
+		qemuVhostUserDevice.Address = vhostUserDevice.MacAddress
+	case *VhostUserSCSIDevice:
+		qemuVhostUserDevice.TypeDevID = makeNameID("scsi", vhostUserDevice.ID)
+	case *VhostUserBlkDevice:
+	}
+
+	qemuVhostUserDevice.VhostUserType = govmmQemu.VhostUserDeviceType(vhostUserDevice.Type())
+	qemuVhostUserDevice.SocketPath = vhostUserDevice.Attrs().SocketPath
+	qemuVhostUserDevice.CharDevID = makeNameID("char", vhostUserDevice.Attrs().ID)
+
+	devices = append(devices, qemuVhostUserDevice)
+
+	return devices
+}
+
+func (q *qemuArchBase) appendVFIODevice(devices []govmmQemu.Device, vfioDevice VFIODevice) []govmmQemu.Device {
+	if vfioDevice.BDF == "" {
+		return devices
+	}
+
+	devices = append(devices,
+		govmmQemu.VFIODevice{
+			BDF: vfioDevice.BDF,
+		},
+	)
+
+	return devices
+}

--- a/qemu_arch_base_test.go
+++ b/qemu_arch_base_test.go
@@ -1,0 +1,459 @@
+//
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	govmmQemu "github.com/intel/govmm/qemu"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	qemuArchBaseMachineType = "pc"
+	qemuArchBaseQemuPath    = "/usr/bin/qemu-lite-system-x86_64"
+)
+
+var qemuArchBaseQemuPaths = map[string]string{
+	qemuArchBaseMachineType: qemuArchBaseQemuPath,
+}
+
+var qemuArchBaseKernelParamsNonDebug = []Param{
+	{"quiet", ""},
+	{"systemd.show_status", "false"},
+}
+
+var qemuArchBaseKernelParamsDebug = []Param{
+	{"debug", ""},
+	{"systemd.show_status", "true"},
+	{"systemd.log_level", "debug"},
+}
+
+var qemuArchBaseKernelParams = []Param{
+	{"root", "/dev/vda"},
+	{"rootfstype", "ext4"},
+}
+
+var qemuArchBaseSupportedQemuMachines = []govmmQemu.Machine{
+	{
+		Type: qemuArchBaseMachineType,
+	},
+}
+
+func newQemuArchBase() *qemuArchBase {
+	return &qemuArchBase{
+		machineType:           qemuArchBaseMachineType,
+		nestedRun:             false,
+		qemuPaths:             qemuArchBaseQemuPaths,
+		supportedQemuMachines: qemuArchBaseSupportedQemuMachines,
+		kernelParamsNonDebug:  qemuArchBaseKernelParamsNonDebug,
+		kernelParamsDebug:     qemuArchBaseKernelParamsDebug,
+		kernelParams:          qemuArchBaseKernelParams,
+	}
+}
+
+func TestQemuArchBaseEnableNestingChecks(t *testing.T) {
+	assert := assert.New(t)
+	qemuArchBase := newQemuArchBase()
+
+	qemuArchBase.enableNestingChecks()
+	assert.True(qemuArchBase.nestedRun)
+}
+
+func TestQemuArchBaseDisableNestingChecks(t *testing.T) {
+	assert := assert.New(t)
+	qemuArchBase := newQemuArchBase()
+
+	qemuArchBase.disableNestingChecks()
+	assert.False(qemuArchBase.nestedRun)
+}
+
+func TestQemuArchBaseMachine(t *testing.T) {
+	assert := assert.New(t)
+	qemuArchBase := newQemuArchBase()
+
+	m, err := qemuArchBase.machine()
+	assert.NoError(err)
+	assert.Equal(m.Type, qemuArchBaseMachineType)
+
+	machines := []govmmQemu.Machine{
+		{
+			Type: "bad",
+		},
+	}
+	qemuArchBase.supportedQemuMachines = machines
+	m, err = qemuArchBase.machine()
+	assert.Error(err)
+	assert.Equal("", m.Type)
+}
+
+func TestQemuArchBaseQemuPath(t *testing.T) {
+	assert := assert.New(t)
+	qemuArchBase := newQemuArchBase()
+
+	p, err := qemuArchBase.qemuPath()
+	assert.NoError(err)
+	assert.Equal(p, qemuArchBaseQemuPath)
+
+	paths := map[string]string{
+		"bad": qemuArchBaseQemuPath,
+	}
+	qemuArchBase.qemuPaths = paths
+	p, err = qemuArchBase.qemuPath()
+	assert.Error(err)
+	assert.Equal("", p)
+}
+
+func TestQemuArchBaseKernelParameters(t *testing.T) {
+	assert := assert.New(t)
+	qemuArchBase := newQemuArchBase()
+
+	// with debug params
+	expectedParams := []Param(qemuArchBaseKernelParams)
+	debugParams := []Param(qemuArchBaseKernelParamsDebug)
+	expectedParams = append(expectedParams, debugParams...)
+	p := qemuArchBase.kernelParameters(true)
+	assert.Equal(expectedParams, p)
+
+	// with non-debug params
+	expectedParams = []Param(qemuArchBaseKernelParams)
+	nonDebugParams := []Param(qemuArchBaseKernelParamsNonDebug)
+	expectedParams = append(expectedParams, nonDebugParams...)
+	p = qemuArchBase.kernelParameters(false)
+	assert.Equal(expectedParams, p)
+}
+
+func TestQemuArchBaseCapabilities(t *testing.T) {
+	assert := assert.New(t)
+	qemuArchBase := newQemuArchBase()
+
+	c := qemuArchBase.capabilities()
+	assert.True(c.isBlockDeviceHotplugSupported())
+}
+
+func TestQemuArchBaseBridges(t *testing.T) {
+	assert := assert.New(t)
+	qemuArchBase := newQemuArchBase()
+	len := 5
+
+	bridges := qemuArchBase.bridges(uint32(len))
+	assert.Len(bridges, len)
+
+	for i, b := range bridges {
+		id := fmt.Sprintf("%s-bridge-%d", pciBridge, i)
+		assert.Equal(pciBridge, b.Type)
+		assert.Equal(id, b.ID)
+		assert.NotNil(b.Address)
+	}
+}
+
+func TestQemuArchBaseCPUTopology(t *testing.T) {
+	assert := assert.New(t)
+	qemuArchBase := newQemuArchBase()
+	vcpus := uint32(2)
+
+	expectedSMP := govmmQemu.SMP{
+		CPUs:    vcpus,
+		Sockets: vcpus,
+		Cores:   defaultCores,
+		Threads: defaultThreads,
+	}
+
+	smp := qemuArchBase.cpuTopology(vcpus)
+	assert.Equal(expectedSMP, smp)
+}
+
+func TestQemuArchBaseCPUModel(t *testing.T) {
+	assert := assert.New(t)
+	qemuArchBase := newQemuArchBase()
+
+	assert.Equal(defaultCPUModel, qemuArchBase.cpuModel())
+}
+
+func TestQemuArchBaseMemoryTopology(t *testing.T) {
+	assert := assert.New(t)
+	qemuArchBase := newQemuArchBase()
+
+	hostMem := uint64(100)
+	mem := uint64(120)
+	expectedMemory := govmmQemu.Memory{
+		Size:   fmt.Sprintf("%dM", mem),
+		Slots:  defaultMemSlots,
+		MaxMem: fmt.Sprintf("%dM", hostMem),
+	}
+
+	m := qemuArchBase.memoryTopology(mem, hostMem)
+	assert.Equal(expectedMemory, m)
+}
+
+func testQemuArchBaseAppend(t *testing.T, structure interface{}, expected []govmmQemu.Device) {
+	var devices []govmmQemu.Device
+	assert := assert.New(t)
+	qemuArchBase := newQemuArchBase()
+
+	switch s := structure.(type) {
+	case Volume:
+		devices = qemuArchBase.append9PVolume(devices, s)
+	case Socket:
+		devices = qemuArchBase.appendSocket(devices, s)
+	case []Volume:
+		devices = qemuArchBase.append9PVolumes(devices, s)
+	case Drive:
+		devices = qemuArchBase.appendBlockDevice(devices, s)
+	case VFIODevice:
+		devices = qemuArchBase.appendVFIODevice(devices, s)
+	case VhostUserNetDevice:
+		devices = qemuArchBase.appendVhostUserDevice(devices, &s)
+	}
+
+	assert.Equal(devices, expected)
+}
+
+func TestQemuArchBaseAppend9PVolumes(t *testing.T) {
+	volMountTag := "testVolMountTag"
+	volHostPath := "testVolHostPath"
+
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.FSDevice{
+			Driver:        govmmQemu.Virtio9P,
+			FSDriver:      govmmQemu.Local,
+			ID:            fmt.Sprintf("extra-9p-%s", fmt.Sprintf("%s.1", volMountTag)),
+			Path:          fmt.Sprintf("%s.1", volHostPath),
+			MountTag:      fmt.Sprintf("%s.1", volMountTag),
+			SecurityModel: govmmQemu.None,
+		},
+		govmmQemu.FSDevice{
+			Driver:        govmmQemu.Virtio9P,
+			FSDriver:      govmmQemu.Local,
+			ID:            fmt.Sprintf("extra-9p-%s", fmt.Sprintf("%s.2", volMountTag)),
+			Path:          fmt.Sprintf("%s.2", volHostPath),
+			MountTag:      fmt.Sprintf("%s.2", volMountTag),
+			SecurityModel: govmmQemu.None,
+		},
+	}
+
+	volumes := []Volume{
+		{
+			MountTag: fmt.Sprintf("%s.1", volMountTag),
+			HostPath: fmt.Sprintf("%s.1", volHostPath),
+		},
+		{
+			MountTag: fmt.Sprintf("%s.2", volMountTag),
+			HostPath: fmt.Sprintf("%s.2", volHostPath),
+		},
+	}
+
+	testQemuArchBaseAppend(t, volumes, expectedOut)
+}
+
+func TestQemuArchBaseAppendConsoles(t *testing.T) {
+	var devices []govmmQemu.Device
+	assert := assert.New(t)
+	qemuArchBase := newQemuArchBase()
+
+	path := filepath.Join(runStoragePath, podID, defaultConsole)
+
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.SerialDevice{
+			Driver: govmmQemu.VirtioSerial,
+			ID:     "serial0",
+		},
+		govmmQemu.CharDevice{
+			Driver:   govmmQemu.Console,
+			Backend:  govmmQemu.Socket,
+			DeviceID: "console0",
+			ID:       "charconsole0",
+			Path:     path,
+		},
+	}
+
+	devices = qemuArchBase.appendConsole(devices, path)
+	assert.Equal(expectedOut, devices)
+}
+
+func TestQemuArchBaseAppendImage(t *testing.T) {
+	var devices []govmmQemu.Device
+	assert := assert.New(t)
+	qemuArchBase := newQemuArchBase()
+
+	image, err := ioutil.TempFile("", "img")
+	assert.NoError(err)
+	err = image.Close()
+	assert.NoError(err)
+
+	devices, err = qemuArchBase.appendImage(devices, image.Name())
+	assert.NoError(err)
+	assert.Len(devices, 1)
+
+	drive, ok := devices[0].(govmmQemu.BlockDevice)
+	assert.True(ok)
+
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.BlockDevice{
+			Driver:    govmmQemu.VirtioBlock,
+			ID:        drive.ID,
+			File:      image.Name(),
+			AIO:       govmmQemu.Threads,
+			Format:    "raw",
+			Interface: "none",
+		},
+	}
+
+	assert.Equal(expectedOut, devices)
+}
+
+func TestQemuArchBaseAppendBridges(t *testing.T) {
+	var devices []govmmQemu.Device
+	assert := assert.New(t)
+	qemuArchBase := newQemuArchBase()
+
+	bridges := qemuArchBase.bridges(1)
+	assert.Len(bridges, 1)
+
+	devices = qemuArchBase.appendBridges(devices, bridges)
+	assert.Len(devices, 1)
+
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.BridgeDevice{
+			Type:    govmmQemu.PCIBridge,
+			Bus:     defaultBridgeBus,
+			ID:      bridges[0].ID,
+			Chassis: 1,
+			SHPC:    true,
+		},
+	}
+
+	assert.Equal(expectedOut, devices)
+}
+
+func TestQemuArchBaseAppend9PVolume(t *testing.T) {
+	mountTag := "testMountTag"
+	hostPath := "testHostPath"
+
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.FSDevice{
+			Driver:        govmmQemu.Virtio9P,
+			FSDriver:      govmmQemu.Local,
+			ID:            fmt.Sprintf("extra-9p-%s", mountTag),
+			Path:          hostPath,
+			MountTag:      mountTag,
+			SecurityModel: govmmQemu.None,
+		},
+	}
+
+	volume := Volume{
+		MountTag: mountTag,
+		HostPath: hostPath,
+	}
+
+	testQemuArchBaseAppend(t, volume, expectedOut)
+}
+
+func TestQemuArchBaseAppendSocket(t *testing.T) {
+	deviceID := "channelTest"
+	id := "charchTest"
+	hostPath := "/tmp/hyper_test.sock"
+	name := "sh.hyper.channel.test"
+
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.CharDevice{
+			Driver:   govmmQemu.VirtioSerialPort,
+			Backend:  govmmQemu.Socket,
+			DeviceID: deviceID,
+			ID:       id,
+			Path:     hostPath,
+			Name:     name,
+		},
+	}
+
+	socket := Socket{
+		DeviceID: deviceID,
+		ID:       id,
+		HostPath: hostPath,
+		Name:     name,
+	}
+
+	testQemuArchBaseAppend(t, socket, expectedOut)
+}
+
+func TestQemuArchBaseAppendBlockDevice(t *testing.T) {
+	id := "blockDevTest"
+	file := "/root"
+	format := "raw"
+
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.BlockDevice{
+			Driver:    govmmQemu.VirtioBlock,
+			ID:        id,
+			File:      "/root",
+			AIO:       govmmQemu.Threads,
+			Format:    govmmQemu.BlockDeviceFormat(format),
+			Interface: "none",
+		},
+	}
+
+	drive := Drive{
+		File:   file,
+		Format: format,
+		ID:     id,
+	}
+
+	testQemuArchBaseAppend(t, drive, expectedOut)
+}
+
+func TestQemuArchBaseAppendVhostUserDevice(t *testing.T) {
+	socketPath := "nonexistentpath.sock"
+	macAddress := "00:11:22:33:44:55:66"
+	id := "deadbeef"
+
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.VhostUserDevice{
+			SocketPath:    socketPath,
+			CharDevID:     fmt.Sprintf("char-%s", id),
+			TypeDevID:     fmt.Sprintf("net-%s", id),
+			Address:       macAddress,
+			VhostUserType: VhostUserNet,
+		},
+	}
+
+	vhostUserDevice := VhostUserNetDevice{
+		MacAddress: macAddress,
+	}
+	vhostUserDevice.ID = id
+	vhostUserDevice.SocketPath = socketPath
+
+	testQemuArchBaseAppend(t, vhostUserDevice, expectedOut)
+}
+
+func TestQemuArchBaseAppendVFIODevice(t *testing.T) {
+	bdf := "02:10.1"
+
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.VFIODevice{
+			BDF: bdf,
+		},
+	}
+
+	vfDevice := VFIODevice{
+		BDF: bdf,
+	}
+
+	testQemuArchBaseAppend(t, vfDevice, expectedOut)
+}

--- a/qemu_arm64.go
+++ b/qemu_arm64.go
@@ -1,0 +1,64 @@
+//
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import govmmQemu "github.com/intel/govmm/qemu"
+
+type qemuArm64 struct {
+	// inherit from qemuArchBase, overwrite methods if needed
+	qemuArchBase
+}
+
+const defaultQemuPath = "/usr/bin/qemu-system-aarch64"
+
+const defaultQemuMachineType = QemuVirt
+
+const defaultQemuMachineOptions = "gic-version=host,usb=off,accel=kvm"
+
+var qemuPaths = map[string]string{
+	QemuVirt: defaultQemuPath,
+}
+
+var kernelParams = []Param{
+	{"root", "/dev/vda1"},
+	{"console", "ttyAMA0"},
+	{"iommu.passthrough", "0"},
+}
+
+var supportedQemuMachines = []govmmQemu.Machine{
+	{
+		Type:    QemuVirt,
+		Options: defaultQemuMachineOptions,
+	},
+}
+
+func newQemuArch(machineType string) qemuArch {
+	if machineType == "" {
+		machineType = defaultQemuMachineType
+	}
+
+	return &qemuArm64{
+		qemuArchBase{
+			machineType:           machineType,
+			qemuPaths:             qemuPaths,
+			supportedQemuMachines: supportedQemuMachines,
+			kernelParamsNonDebug:  kernelParamsNonDebug,
+			kernelParamsDebug:     kernelParamsDebug,
+			kernelParams:          kernelParams,
+		},
+	}
+}

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -18,13 +18,14 @@ package virtcontainers
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
-	"strings"
 	"testing"
 
 	govmmQemu "github.com/intel/govmm/qemu"
+	"github.com/stretchr/testify/assert"
 )
 
 func newQemuConfig() HypervisorConfig {
@@ -38,7 +39,7 @@ func newQemuConfig() HypervisorConfig {
 	}
 }
 
-func testQemuBuildKernelParams(t *testing.T, kernelParams []Param, expected string, debug bool) {
+func testQemuKernelParameters(t *testing.T, kernelParams []Param, expected string, debug bool) {
 	qemuConfig := newQemuConfig()
 	qemuConfig.KernelParams = kernelParams
 
@@ -48,26 +49,18 @@ func testQemuBuildKernelParams(t *testing.T, kernelParams []Param, expected stri
 
 	q := &qemu{
 		config: qemuConfig,
+		arch:   &qemuArchBase{},
 	}
 
-	err := q.buildKernelParams()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if strings.Join(q.kernelParams, " ") != expected {
-		t.Fatal()
+	params := q.buildKernelParams()
+	if params != expected {
+		t.Fatalf("Got: %v, Expecting: %v", params, expected)
 	}
 }
 
-var testQemuKernelParamsBase = "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug iommu=off cryptomgr.notests net.ifnames=0 pci=lastbus=0"
-var testQemuKernelParamsNonDebug = "quiet systemd.show_status=false"
-var testQemuKernelParamsDebug = "debug systemd.show_status=true systemd.log_level=debug"
-
-func TestQemuBuildKernelParamsFoo(t *testing.T) {
-	// two representations of the same kernel parameters
-	suffixStr := "foo=foo bar=bar"
-	suffixParams := []Param{
+func TestQemuKernelParameters(t *testing.T) {
+	expectedOut := "panic=1 initcall_debug foo=foo bar=bar"
+	params := []Param{
 		{
 			Key:   "foo",
 			Value: "foo",
@@ -78,309 +71,8 @@ func TestQemuBuildKernelParamsFoo(t *testing.T) {
 		},
 	}
 
-	type testData struct {
-		debugParams string
-		debugValue  bool
-	}
-
-	data := []testData{
-		{testQemuKernelParamsNonDebug, false},
-		{testQemuKernelParamsDebug, true},
-	}
-
-	for _, d := range data {
-		// kernel params consist of a default set of params,
-		// followed by a set of params that depend on whether
-		// debug mode is enabled and end with any user-supplied
-		// params.
-		expected := []string{testQemuKernelParamsBase, d.debugParams, suffixStr}
-
-		expectedOut := strings.Join(expected, " ")
-
-		testQemuBuildKernelParams(t, suffixParams, expectedOut, d.debugValue)
-	}
-}
-
-func testQemuAppend(t *testing.T, structure interface{}, expected []govmmQemu.Device, devType deviceType, nestedVM bool) {
-	var devices []govmmQemu.Device
-	q := &qemu{
-		nestedRun: nestedVM,
-	}
-
-	switch s := structure.(type) {
-	case Volume:
-		devices = q.appendVolume(devices, s)
-	case Socket:
-		devices = q.appendSocket(devices, s)
-	case PodConfig:
-		switch devType {
-		case fsDev:
-			devices = q.appendFSDevices(devices, s)
-		case consoleDev:
-			devices = q.appendConsoles(devices, s)
-		}
-	case Drive:
-		devices = q.appendBlockDevice(devices, s)
-	case VFIODevice:
-		devices = q.appendVFIODevice(devices, s)
-	case VhostUserNetDevice:
-		devices = q.appendVhostUserDevice(devices, &s)
-	}
-
-	if reflect.DeepEqual(devices, expected) == false {
-		t.Fatalf("\n\tGot %v\n\tExpecting %v", devices, expected)
-	}
-}
-
-func TestQemuAppendVolume(t *testing.T) {
-	mountTag := "testMountTag"
-	hostPath := "testHostPath"
-	nestedVM := true
-
-	expectedOut := []govmmQemu.Device{
-		govmmQemu.FSDevice{
-			Driver:        govmmQemu.Virtio9P,
-			FSDriver:      govmmQemu.Local,
-			ID:            fmt.Sprintf("extra-9p-%s", mountTag),
-			Path:          hostPath,
-			MountTag:      mountTag,
-			SecurityModel: govmmQemu.None,
-			DisableModern: nestedVM,
-		},
-	}
-
-	volume := Volume{
-		MountTag: mountTag,
-		HostPath: hostPath,
-	}
-
-	testQemuAppend(t, volume, expectedOut, -1, nestedVM)
-}
-
-func TestQemuAppendSocket(t *testing.T) {
-	deviceID := "channelTest"
-	id := "charchTest"
-	hostPath := "/tmp/hyper_test.sock"
-	name := "sh.hyper.channel.test"
-	nestedVM := true
-
-	expectedOut := []govmmQemu.Device{
-		govmmQemu.CharDevice{
-			Driver:   govmmQemu.VirtioSerialPort,
-			Backend:  govmmQemu.Socket,
-			DeviceID: deviceID,
-			ID:       id,
-			Path:     hostPath,
-			Name:     name,
-		},
-	}
-
-	socket := Socket{
-		DeviceID: deviceID,
-		ID:       id,
-		HostPath: hostPath,
-		Name:     name,
-	}
-
-	testQemuAppend(t, socket, expectedOut, -1, nestedVM)
-}
-
-func TestQemuAppendBlockDevice(t *testing.T) {
-	id := "blockDevTest"
-	file := "/root"
-	format := "raw"
-	nestedVM := true
-
-	expectedOut := []govmmQemu.Device{
-		govmmQemu.BlockDevice{
-			Driver:        govmmQemu.VirtioBlock,
-			ID:            id,
-			File:          "/root",
-			AIO:           govmmQemu.Threads,
-			Format:        govmmQemu.BlockDeviceFormat(format),
-			Interface:     "none",
-			DisableModern: nestedVM,
-		},
-	}
-
-	drive := Drive{
-		File:   file,
-		Format: format,
-		ID:     id,
-	}
-
-	testQemuAppend(t, drive, expectedOut, -1, nestedVM)
-}
-
-func TestQemuAppendVFIODevice(t *testing.T) {
-	nestedVM := true
-	bdf := "02:10.1"
-
-	expectedOut := []govmmQemu.Device{
-		govmmQemu.VFIODevice{
-			BDF: bdf,
-		},
-	}
-
-	vfDevice := VFIODevice{
-		BDF: bdf,
-	}
-
-	testQemuAppend(t, vfDevice, expectedOut, -1, nestedVM)
-}
-
-func TestQemuAppendVhostUserDevice(t *testing.T) {
-	nestedVM := true
-	socketPath := "nonexistentpath.sock"
-	macAddress := "00:11:22:33:44:55:66"
-	id := "deadbeef"
-
-	expectedOut := []govmmQemu.Device{
-		govmmQemu.VhostUserDevice{
-			SocketPath:    socketPath,
-			CharDevID:     fmt.Sprintf("char-%s", id),
-			TypeDevID:     fmt.Sprintf("net-%s", id),
-			Address:       macAddress,
-			VhostUserType: VhostUserNet,
-		},
-	}
-
-	vhostUserDevice := VhostUserNetDevice{
-		MacAddress: macAddress,
-	}
-	vhostUserDevice.ID = id
-	vhostUserDevice.SocketPath = socketPath
-
-	testQemuAppend(t, vhostUserDevice, expectedOut, -1, nestedVM)
-}
-
-func TestQemuAppendFSDevices(t *testing.T) {
-	podID := "testPodID"
-	contID := "testContID"
-	contRootFs := "testContRootFs"
-	volMountTag := "testVolMountTag"
-	volHostPath := "testVolHostPath"
-	nestedVM := true
-
-	expectedOut := []govmmQemu.Device{
-		govmmQemu.FSDevice{
-			Driver:        govmmQemu.Virtio9P,
-			FSDriver:      govmmQemu.Local,
-			ID:            fmt.Sprintf("extra-9p-%s", fmt.Sprintf("%s.1", volMountTag)),
-			Path:          fmt.Sprintf("%s.1", volHostPath),
-			MountTag:      fmt.Sprintf("%s.1", volMountTag),
-			SecurityModel: govmmQemu.None,
-			DisableModern: nestedVM,
-		},
-		govmmQemu.FSDevice{
-			Driver:        govmmQemu.Virtio9P,
-			FSDriver:      govmmQemu.Local,
-			ID:            fmt.Sprintf("extra-9p-%s", fmt.Sprintf("%s.2", volMountTag)),
-			Path:          fmt.Sprintf("%s.2", volHostPath),
-			MountTag:      fmt.Sprintf("%s.2", volMountTag),
-			SecurityModel: govmmQemu.None,
-			DisableModern: nestedVM,
-		},
-	}
-
-	volumes := []Volume{
-		{
-			MountTag: fmt.Sprintf("%s.1", volMountTag),
-			HostPath: fmt.Sprintf("%s.1", volHostPath),
-		},
-		{
-			MountTag: fmt.Sprintf("%s.2", volMountTag),
-			HostPath: fmt.Sprintf("%s.2", volHostPath),
-		},
-	}
-
-	containers := []ContainerConfig{
-		{
-			ID:     fmt.Sprintf("%s.1", contID),
-			RootFs: fmt.Sprintf("%s.1", contRootFs),
-		},
-		{
-			ID:     fmt.Sprintf("%s.2", contID),
-			RootFs: fmt.Sprintf("%s.2", contRootFs),
-		},
-	}
-
-	podConfig := PodConfig{
-		ID:         podID,
-		Volumes:    volumes,
-		Containers: containers,
-	}
-
-	testQemuAppend(t, podConfig, expectedOut, fsDev, nestedVM)
-}
-
-func TestQemuAppendConsoles(t *testing.T) {
-	podID := "testPodID"
-	nestedVM := true
-
-	expectedOut := []govmmQemu.Device{
-		govmmQemu.SerialDevice{
-			Driver:        govmmQemu.VirtioSerial,
-			ID:            "serial0",
-			DisableModern: nestedVM,
-		},
-		govmmQemu.CharDevice{
-			Driver:   govmmQemu.Console,
-			Backend:  govmmQemu.Socket,
-			DeviceID: "console0",
-			ID:       "charconsole0",
-			Path:     filepath.Join(runStoragePath, podID, defaultConsole),
-		},
-	}
-
-	podConfig := PodConfig{
-		ID:         podID,
-		Containers: []ContainerConfig{},
-	}
-
-	testQemuAppend(t, podConfig, expectedOut, consoleDev, nestedVM)
-}
-
-func TestQemuAppendImage(t *testing.T) {
-	var devices []govmmQemu.Device
-
-	qemuConfig := newQemuConfig()
-	q := &qemu{
-		config: qemuConfig,
-	}
-
-	imageFile, err := os.Open(q.config.ImagePath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer imageFile.Close()
-
-	imageStat, err := imageFile.Stat()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expectedOut := []govmmQemu.Device{
-		govmmQemu.Object{
-			Driver:   govmmQemu.NVDIMM,
-			Type:     govmmQemu.MemoryBackendFile,
-			DeviceID: "nv0",
-			ID:       "mem0",
-			MemPath:  q.config.ImagePath,
-			Size:     (uint64)(imageStat.Size()),
-		},
-	}
-
-	podConfig := PodConfig{}
-
-	devices, err = q.appendImage(devices, podConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if reflect.DeepEqual(devices, expectedOut) == false {
-		t.Fatalf("Got %v\nExpecting %v", devices, expectedOut)
-	}
+	testQemuKernelParameters(t, params, expectedOut, true)
+	testQemuKernelParameters(t, params, expectedOut, false)
 }
 
 func TestQemuInit(t *testing.T) {
@@ -412,17 +104,6 @@ func TestQemuInit(t *testing.T) {
 	if reflect.DeepEqual(qemuConfig, q.config) == false {
 		t.Fatalf("Got %v\nExpecting %v", q.config, qemuConfig)
 	}
-
-	if reflect.DeepEqual(qemuConfig.HypervisorPath, q.path) == false {
-		t.Fatalf("Got %v\nExpecting %v", q.path, qemuConfig.HypervisorPath)
-	}
-
-	// non-debug is the default
-	var testQemuKernelParamsDefault = testQemuKernelParamsBase + " " + testQemuKernelParamsNonDebug
-
-	if strings.Join(q.kernelParams, " ") != testQemuKernelParamsDefault {
-		t.Fatal()
-	}
 }
 
 func TestQemuInitMissingParentDirFail(t *testing.T) {
@@ -448,16 +129,18 @@ func TestQemuInitMissingParentDirFail(t *testing.T) {
 	}
 }
 
-func TestQemuSetCPUResources(t *testing.T) {
+func TestQemuCPUTopology(t *testing.T) {
 	vcpus := 1
 
-	q := &qemu{}
+	q := &qemu{
+		arch: &qemuArchBase{},
+	}
 
 	expectedOut := govmmQemu.SMP{
 		CPUs:    uint32(vcpus),
-		Cores:   uint32(vcpus),
-		Sockets: uint32(1),
-		Threads: uint32(1),
+		Sockets: uint32(vcpus),
+		Cores:   defaultCores,
+		Threads: defaultThreads,
 	}
 
 	vmConfig := Resources{
@@ -475,20 +158,22 @@ func TestQemuSetCPUResources(t *testing.T) {
 	}
 }
 
-func TestQemuSetMemoryResources(t *testing.T) {
+func TestQemuMemoryTopology(t *testing.T) {
 	mem := 1000
 
-	q := &qemu{}
+	q := &qemu{
+		arch: &qemuArchBase{},
+	}
 
 	hostMemKb, err := getHostMemorySizeKb(procMemInfo)
 	if err != nil {
 		t.Fatal(err)
 	}
-	memMax := fmt.Sprintf("%dM", int(float64(hostMemKb)/1024)+maxMemoryOffset)
+	memMax := fmt.Sprintf("%dM", int(float64(hostMemKb)/1024))
 
 	expectedOut := govmmQemu.Memory{
-		Size:   "1000M",
-		Slots:  uint8(2),
+		Size:   fmt.Sprintf("%dM", mem),
+		Slots:  defaultMemSlots,
 		MaxMem: memMax,
 	}
 
@@ -510,9 +195,9 @@ func TestQemuSetMemoryResources(t *testing.T) {
 	}
 }
 
-func testQemuAddDevice(t *testing.T, devInfo interface{}, devType deviceType, expected []govmmQemu.Device, nestedVM bool) {
+func testQemuAddDevice(t *testing.T, devInfo interface{}, devType deviceType, expected []govmmQemu.Device) {
 	q := &qemu{
-		nestedRun: nestedVM,
+		arch: &qemuArchBase{},
 	}
 
 	err := q.addDevice(devInfo, devType)
@@ -528,7 +213,6 @@ func testQemuAddDevice(t *testing.T, devInfo interface{}, devType deviceType, ex
 func TestQemuAddDeviceFsDev(t *testing.T) {
 	mountTag := "testMountTag"
 	hostPath := "testHostPath"
-	nestedVM := true
 
 	expectedOut := []govmmQemu.Device{
 		govmmQemu.FSDevice{
@@ -538,7 +222,6 @@ func TestQemuAddDeviceFsDev(t *testing.T) {
 			Path:          hostPath,
 			MountTag:      mountTag,
 			SecurityModel: govmmQemu.None,
-			DisableModern: nestedVM,
 		},
 	}
 
@@ -547,15 +230,14 @@ func TestQemuAddDeviceFsDev(t *testing.T) {
 		HostPath: hostPath,
 	}
 
-	testQemuAddDevice(t, volume, fsDev, expectedOut, nestedVM)
+	testQemuAddDevice(t, volume, fsDev, expectedOut)
 }
 
-func TestQemuAddDeviceSerialPordDev(t *testing.T) {
+func TestQemuAddDeviceSerialPortDev(t *testing.T) {
 	deviceID := "channelTest"
 	id := "charchTest"
 	hostPath := "/tmp/hyper_test.sock"
 	name := "sh.hyper.channel.test"
-	nestedVM := true
 
 	expectedOut := []govmmQemu.Device{
 		govmmQemu.CharDevice{
@@ -575,7 +257,7 @@ func TestQemuAddDeviceSerialPordDev(t *testing.T) {
 		Name:     name,
 	}
 
-	testQemuAddDevice(t, socket, serialPortDev, expectedOut, nestedVM)
+	testQemuAddDevice(t, socket, serialPortDev, expectedOut)
 }
 
 func TestQemuGetPodConsole(t *testing.T) {
@@ -588,81 +270,61 @@ func TestQemuGetPodConsole(t *testing.T) {
 	}
 }
 
-func TestQemuMachineTypes(t *testing.T) {
-	type testData struct {
-		machineType string
-		expectValid bool
+func TestQemuCapabilities(t *testing.T) {
+	q := &qemu{
+		arch: &qemuArchBase{},
 	}
 
-	data := []testData{
-		{"pc-lite", true},
-		{"pc", true},
-		{"q35", true},
-
-		{"PC-LITE", false},
-		{"PC", false},
-		{"Q35", false},
-		{"", false},
-		{" ", false},
-		{".", false},
-		{"0", false},
-		{"1", false},
-		{"-1", false},
-		{"bon", false},
-	}
-
-	q := &qemu{}
-
-	for _, d := range data {
-		m, err := q.getMachine(d.machineType)
-
-		if d.expectValid == true {
-			if err != nil {
-				t.Fatalf("machine type %v unexpectedly invalid: %v", d.machineType, err)
-			}
-
-			if m.Type != d.machineType {
-				t.Fatalf("expected machine type %v, got %v", d.machineType, m.Type)
-			}
-		} else {
-			if err == nil {
-				t.Fatalf("machine type %v unexpectedly valid", d.machineType)
-			}
-		}
+	caps := q.capabilities()
+	if !caps.isBlockDeviceHotplugSupported() {
+		t.Fatal("Block device hotplug should be supported")
 	}
 }
 
-func TestQemuBlockHotplugCapabilities(t *testing.T) {
-	type testData struct {
-		machineType     string
-		expectedSupport bool
+func TestQemuQemuPath(t *testing.T) {
+	assert := assert.New(t)
+
+	f, err := ioutil.TempFile("", "qemu")
+	assert.NoError(err)
+	defer func() { _ = f.Close() }()
+	defer func() { _ = os.Remove(f.Name()) }()
+
+	expectedPath := f.Name()
+	qemuConfig := newQemuConfig()
+	qemuConfig.HypervisorPath = expectedPath
+	qkvm := &qemuArchBase{
+		machineType: "pc",
+		qemuPaths: map[string]string{
+			"pc": expectedPath,
+		},
 	}
 
-	data := []testData{
-		{"pc-lite", false},
-		{"q35", false},
-		{"pc", true},
-
-		{"PC-LITE", false},
-		{"PC", false},
-		{"Q35", false},
-		{"", false},
-		{" ", false},
-		{".", false},
-		{"0", false},
-		{"1", false},
-		{"-1", false},
+	q := &qemu{
+		config: qemuConfig,
+		arch:   qkvm,
 	}
 
-	q := &qemu{}
+	// get config hypervisor path
+	path, err := q.buildPath()
+	assert.NoError(err)
+	assert.Equal(path, expectedPath)
 
-	for _, d := range data {
-		q.qemuConfig.Machine.Type = d.machineType
+	// config hypervisor path does not exist
+	q.config.HypervisorPath = "/abc/rgb/123"
+	path, err = q.buildPath()
+	assert.Error(err)
+	assert.Equal(path, "")
 
-		caps := q.capabilities()
-		isSupported := caps.isBlockDeviceHotplugSupported()
-		if isSupported != d.expectedSupport {
-			t.Fatalf("expected blockdevice hotplug support : %v, got %v", d.expectedSupport, isSupported)
-		}
-	}
+	// get arch hypervisor path
+	q.config.HypervisorPath = ""
+	path, err = q.buildPath()
+	assert.NoError(err)
+	assert.Equal(path, expectedPath)
+
+	// bad machine type, arch should fail
+	qkvm.machineType = "rgb"
+	q.arch = qkvm
+	path, err = q.buildPath()
+	assert.Error(err)
+	assert.Equal(path, "")
 }

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -52,7 +52,7 @@ func testQemuKernelParameters(t *testing.T, kernelParams []Param, expected strin
 		arch:   &qemuArchBase{},
 	}
 
-	params := q.buildKernelParams()
+	params := q.kernelParameters()
 	if params != expected {
 		t.Fatalf("Got: %v, Expecting: %v", params, expected)
 	}
@@ -151,7 +151,7 @@ func TestQemuCPUTopology(t *testing.T) {
 		VMConfig: vmConfig,
 	}
 
-	smp := q.setCPUResources(podConfig)
+	smp := q.cpuTopology(podConfig)
 
 	if reflect.DeepEqual(smp, expectedOut) == false {
 		t.Fatalf("Got %v\nExpecting %v", smp, expectedOut)
@@ -185,7 +185,7 @@ func TestQemuMemoryTopology(t *testing.T) {
 		VMConfig: vmConfig,
 	}
 
-	memory, err := q.setMemoryResources(podConfig)
+	memory, err := q.memoryTopology(podConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -305,26 +305,26 @@ func TestQemuQemuPath(t *testing.T) {
 	}
 
 	// get config hypervisor path
-	path, err := q.buildPath()
+	path, err := q.qemuPath()
 	assert.NoError(err)
 	assert.Equal(path, expectedPath)
 
 	// config hypervisor path does not exist
 	q.config.HypervisorPath = "/abc/rgb/123"
-	path, err = q.buildPath()
+	path, err = q.qemuPath()
 	assert.Error(err)
 	assert.Equal(path, "")
 
 	// get arch hypervisor path
 	q.config.HypervisorPath = ""
-	path, err = q.buildPath()
+	path, err = q.qemuPath()
 	assert.NoError(err)
 	assert.Equal(path, expectedPath)
 
 	// bad machine type, arch should fail
 	qkvm.machineType = "rgb"
 	q.arch = qkvm
-	path, err = q.buildPath()
+	path, err = q.qemuPath()
 	assert.Error(err)
 	assert.Equal(path, "")
 }


### PR DESCRIPTION
This patch introduces a new interface called qemuArch that contains
the functions needed to create qemu specific architecture implementations.
This patch also includes three qemu specific architecture
implementations: qemuArchBase, qemuAmd64 and qemuArm64, since all architectures
use similar qemu command lines, the base structure is qemuArchBase that is an
agnostic implementation to start virtual machines, qemuAmd64 and qemuArm64
inherit and override (if needed) the functions of qemuArchBase, therefore architecture
specific optimizations are in qemuAmd64 and qemuArm64.
For example the `appendImage` function defined by qemuArchBase uses a block
device to provide the image to the VM, qemuArm64 inherits and doesn't
overwrite it, but qemuAmd64 inherits and overwites it to provide the
image throught NVDIMM and DAX.
    
fixes #608
fixes #610
fixes #611
fixes #612

Signed-off-by: Julio Montes <julio.montes@intel.com>