### PR TITLE
kata_agent: Support block device passthrough

### DIFF
--- a/kata_agent.go
+++ b/kata_agent.go
@@ -48,6 +48,7 @@ var (
 	type9pFs                    = "9p"
 	devPath                     = "/dev"
 	vsockSocketScheme           = "vsock"
+	kataBlkDevDriver            = "blk"
 )
 
 // KataAgentConfig is a structure storing information needed
@@ -525,6 +526,7 @@ func (k *kataAgent) createContainer(pod *Pod, c *Container) (*Process, error) {
 		}
 
 		deviceStorage := &grpc.Storage{
+			Driver:     kataBlkDevDriver,
 			Source:     d.VirtPath,
 			MountPoint: d.DeviceInfo.ContainerPath,
 		}


### PR DESCRIPTION
This patch enables the block device passthrough for Kata Containers
agent. It gives the driver field "blk" so that the agent can actually
know what to do with the passed device.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>