### PR TITLE
container: Let some time before to force kill a container process

### DIFF
--- a/shim.go
+++ b/shim.go
@@ -41,7 +41,7 @@ const (
 	KataShimType ShimType = "kataShim"
 )
 
-var waitForShimTimeout = 5.0
+var waitForShimTimeout = 10.0
 var consoleFileMode = os.FileMode(0660)
 
 // ShimParams is the structure providing specific parameters needed


### PR DESCRIPTION
Using force kill when we want to stop a container should only be
called after we left some time to make sure nothing has been killing
the container process. Indeed, signals can sometime take a few seconds
to terminate a process. In this case, we don't want to SIGKILL this
process, otherwise it would return with the exit code 137. Instead, we
want to leave it some time (10 seconds) so that it can properly end.

After those 10 seconds, we consider the previous signal didn't get the
expected effect and we force kill the container process. Indeed, we
still want to try to kill the container.

Fixes #606

Depends-on: github.com/clearcontainers/runtime#1003

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>