### PR TITLE
Run cc-shim in the network namespace of pod

### DIFF
--- a/shim.go
+++ b/shim.go
@@ -166,7 +166,16 @@ func prepareAndStartShim(pod *Pod, shim shim, cid, token, url string, cmd Cmd) (
 		Detach:    cmd.Detach,
 	}
 
-	pid, err := shim.start(*pod, shimParams)
+	netNS, err := pod.storage.fetchPodNetwork(pod.ID())
+	if err != nil {
+		return nil, err
+	}
+
+	var pid int
+	err = pod.network.run(netNS.NetNsPath, func() (shimErr error) {
+		pid, shimErr = shim.start(*pod, shimParams)
+		return
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Now, the container pid that is get by docker inspect -f '{{.State.Pid}}' [container_id] is the pid of shim process, and the shim process is in the host netwok namespace.

In some case, we should get the netwok namespace of container via the container pid (e.g. dockershim),
This PR moves the shim process into the pod network namespace like VM procewss.

Fixes #615
Related to https://github.com/clearcontainers/runtime/issues/987#issuecomment-364452318

/cc @sboeuf @sameo @plutoinmii

Signed-off-by: Yanqiang Miao <miao.yanqiang@zte.com.cn>