### PR TITLE
kata_agent: Support CRI-O with overlay

### DIFF
--- a/kata_agent.go
+++ b/kata_agent.go
@@ -414,6 +414,10 @@ func constraintGRPCSpec(grpcSpec *grpc.Spec) {
 	// here: https://github.com/kata-containers/agent/issues/104
 	grpcSpec.Linux.Seccomp = nil
 
+	// TODO: Remove this constraint as soon as the agent properly handles
+	// resources provided through the specification.
+	grpcSpec.Linux.Resources = nil
+
 	// Disable network namespace since it is already handled on the host by
 	// virtcontainers. The network is a complex part which cannot be simply
 	// passed to the agent.

--- a/kata_agent.go
+++ b/kata_agent.go
@@ -451,7 +451,7 @@ func (k *kataAgent) createContainer(pod *Pod, c *Container) (*Process, error) {
 	rootfs := &grpc.Storage{}
 
 	// This is the guest absolute root path for that container.
-	rootPath := filepath.Join(kataGuestSharedDir, pod.id, rootfsDir)
+	rootPath := filepath.Join(kataGuestSharedDir, c.id, rootfsDir)
 
 	if c.state.Fstype != "" {
 		// This is a block based device rootfs.


### PR DESCRIPTION
This pull request enables CRI-O to work with Kata Containers in case the storage driver used is overlay, meaning we rely on 9pfs to pass the rootfs inside the VM.