### PR TITLE
pod: Fetch pod network only from createPod()

### DIFF
--- a/api.go
+++ b/api.go
@@ -63,13 +63,13 @@ func createPodFromConfig(podConfig PodConfig) (*Pod, error) {
 	}
 
 	// Add the network
-	networkNS, err := p.network.add(*p, p.config.NetworkConfig, netNsPath, netNsCreated)
+	p.networkNS, err = p.network.add(*p, p.config.NetworkConfig, netNsPath, netNsCreated)
 	if err != nil {
 		return nil, err
 	}
 
 	// Store the network
-	err = p.storage.storePodNetwork(p.id, networkNS)
+	err = p.storage.storePodNetwork(p.id, p.networkNS)
 	if err != nil {
 		return nil, err
 	}
@@ -112,12 +112,6 @@ func DeletePod(podID string) (VCPod, error) {
 		return nil, err
 	}
 
-	// Fetch the network config
-	networkNS, err := p.storage.fetchPodNetwork(podID)
-	if err != nil {
-		return nil, err
-	}
-
 	// Stop shims
 	if err := p.stopShims(); err != nil {
 		return nil, err
@@ -130,8 +124,8 @@ func DeletePod(podID string) (VCPod, error) {
 	}
 
 	// Remove the network
-	if networkNS.NetNsCreated {
-		if err := p.network.remove(*p, networkNS); err != nil {
+	if p.networkNS.NetNsCreated {
+		if err := p.network.remove(*p, p.networkNS); err != nil {
 			return nil, err
 		}
 	}

--- a/hyperstart_agent.go
+++ b/hyperstart_agent.go
@@ -171,18 +171,13 @@ func (h *hyper) processHyperRoute(route netlink.Route, deviceName string) *hyper
 }
 
 func (h *hyper) buildNetworkInterfacesAndRoutes(pod Pod) ([]hyperstart.NetworkIface, []hyperstart.Route, error) {
-	networkNS, err := pod.storage.fetchPodNetwork(pod.id)
-	if err != nil {
-		return []hyperstart.NetworkIface{}, []hyperstart.Route{}, err
-	}
-
-	if networkNS.NetNsPath == "" {
+	if pod.networkNS.NetNsPath == "" {
 		return []hyperstart.NetworkIface{}, []hyperstart.Route{}, nil
 	}
 
 	var ifaces []hyperstart.NetworkIface
 	var routes []hyperstart.Route
-	for _, endpoint := range networkNS.Endpoints {
+	for _, endpoint := range pod.networkNS.Endpoints {
 		var ipAddresses []hyperstart.IPAddress
 		for _, addr := range endpoint.Properties().Addrs {
 			// Skip IPv6 because not supported by hyperstart.

--- a/pod.go
+++ b/pod.go
@@ -464,6 +464,8 @@ type Pod struct {
 
 	state State
 
+	networkNS NetworkNamespace
+
 	lockFile *os.File
 
 	annotationsLock *sync.RWMutex
@@ -573,6 +575,12 @@ func createPod(podConfig PodConfig) (*Pod, error) {
 	p, err := newPod(podConfig)
 	if err != nil {
 		return nil, err
+	}
+
+	// Fetch pod network to be able to access it from the pod structure.
+	networkNS, err := p.storage.fetchPodNetwork(p.id)
+	if err == nil {
+		p.networkNS = networkNS
 	}
 
 	// We first try to fetch the pod state from storage.

--- a/shim.go
+++ b/shim.go
@@ -166,17 +166,11 @@ func prepareAndStartShim(pod *Pod, shim shim, cid, token, url string, cmd Cmd) (
 		Detach:    cmd.Detach,
 	}
 
-	netNS, err := pod.storage.fetchPodNetwork(pod.ID())
-	if err != nil {
-		return nil, err
-	}
-
 	var pid int
-	err = pod.network.run(netNS.NetNsPath, func() (shimErr error) {
+	if err := pod.network.run(pod.networkNS.NetNsPath, func() (shimErr error) {
 		pid, shimErr = shim.start(*pod, shimParams)
 		return
-	})
-	if err != nil {
+	}); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
We don't want to fetch the pod network from the filesystem every
time we need information about it. Instead, the network is related
to the pod, that's why the pod should hold this information in-memory
through a new field into its structure.

Fixes #628

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>