### PR TITLE
block: Fix disabling block device use

### DIFF
--- a/container.go
+++ b/container.go
@@ -420,12 +420,14 @@ func createContainer(pod *Pod, contConfig ContainerConfig) (*Container, error) {
 		return nil, err
 	}
 
-	agentCaps := c.pod.agent.capabilities()
-	hypervisorCaps := c.pod.hypervisor.capabilities()
+	if !c.pod.config.HypervisorConfig.DisableBlockDeviceUse {
+		agentCaps := c.pod.agent.capabilities()
+		hypervisorCaps := c.pod.hypervisor.capabilities()
 
-	if agentCaps.isBlockDeviceSupported() && hypervisorCaps.isBlockDeviceHotplugSupported() {
-		if err := c.hotplugDrive(); err != nil {
-			return nil, err
+		if agentCaps.isBlockDeviceSupported() && hypervisorCaps.isBlockDeviceHotplugSupported() {
+			if err := c.hotplugDrive(); err != nil {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
This configuration was added to disable block devices from being
used and using 9p instead. This got dropped somewhere, add it back.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>