### PR TITLE
1.0.7 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,14 @@
+1.0.7:
+	Added ARM64 support
+	Added Kata Containers support
+	Added dockershim support
+	Added govmm support
+	Added support for the one proxy per VM model
+	Added 1.0 API documentation
+	Added hotplug support for QEMU's Q35 machine type
+	Fixed the agent, proxy and shim hierarchy
+	Fixed the state storage implementation
+
 1.0.6:
 	Added SRIOV support
 	Added Multi-OS support


### PR DESCRIPTION
Added ARM64 support
Added Kata Containers support
Added dockershim support
Added govmm support
Added support for the one proxy per VM model
Added 1.0 API documentation
Added hotplug support for QEMU's Q35 machine type
Fixed the agent, proxy and shim hierarchy
Fixed the state storage implementation

Shortlog:

10d462c block: Fix disabling block device use
5236b92 documentation: Add API usage example
77c41ca documentation: Add short container 1.0 API description
0fbae82 documentation: Add short pod 1.0 API description
5a2d207 documentation: Document the 1.0 API
1ccb3a4 pod: Fetch pod network only from createPod()
563c175 qemu: change function names
d8a6dd3 qemu: update qemu init
b877182 qemu: add support for ARM
485b51b hypervisor: remove getState function
13d23e2 vendor: Re-vendor govmm
a43389e kata_agent: Ignore resources from the specification
1479051 kata_agent: Empty namespaces paths
a28064c kata_agent: Fix 9pfs rootfs
97be8e1 vendor: Update Gopkg.toml for new prune syntax
a0ee7ef vendor: Remove constraints from packages not directly vendored
195d71f Run cc-shim in the network namespace of pod
62e5145 container: Let some time before to force kill a container process
9ab4716 container: Remove useless container fetching
1f9f41f pod: Remove useless pod fetching
b19559f pod: Don't update container states from the pod
e047779 net: remove netModel string function
ac880a1 test: network: add unit test
f19bd7a oci: Allow to get InternetworkingModel from config
573dcf0 network: Add NetInterworkingModel methods
6d19f56 network: Endpoint type dictate how the connection needs to be made
037a81a network: define internetworking model at endpoint creation
089119a network: remove unsed function createNetworkEndpoints
e6c6f84 Add support for dockershim pod annotations
e01404c container: Allow to send a signal to a created container
e5ad775 container: Allow to stop a container in state created
00a9091 qemu: change CPU topology to support until 240 CPUs
7dc7483 mount: Explicitely modify and store container mount list
9acfae9 container: Move devices and mounts creation to createContainer()
484cc19 api: Add new container pointer to pod structure
d07aeb2 container: Replace fetchContainer() with findContainer()
cc8a959 kata_agent: Unmount properly the container
a82ff68 kata_agent: Add high level unit tests
9a1f1f1 agent: Store URL and ProxyPid info from each implementation
cfa2543 agent: Cleanup agent initialization
72e4468 agent: Push shim initialization down to the agent
9e8dadb agent: Push proxy initialization down to the agent
16e3a94 agent: Return process from createContainer()
41c85b2 proxy: Add proxyParams to proxy interface
67d5423 proxy: Rework proxy interface
b654115 qemu: Log default kernel params
d460a53 qemu: Remove unecessary parameter for buildKernelParams()
80038f3 build: Only clean files if they exist
a4377a7 build: Fix clean and uninstall
5da67c9 kata_proxy: Regenerate the proxy URL when needed
5a12655 kata_agent: Parse the OCI command properly
643aeb5 agent: Increas unit testing coverage
5e78fac container: Pass the command to startShim
e747236 api: Store the pod when it's completely created
42f622b pod: Register pod against proxy
c03bd2f pod: Simplify container creation routines
17518a9 container: Rename createShimProcess
b404961 container: Let the agent implementations start the shims
c78954f pod: Wait for the VM and start the pod in startVM
f67f447 pod: Rename doFetchPod
0d794ca shim: Carry the info about terminal
03a08e1 vendor: Update kata agent vendoring
6bd535a kata_agent: Constraints the OCI spec
6b8935f vendor: Add cri-containerd annotations to vendor dir
fec607f cri: Add support for cri-contaienrd pod annotations
940a13e logging: Set source field for oci and hyperstart packages
579639b kata_proxy: Fetch guest agent logs when in debug mode
5fc2656 kata_agent: Replace OCI mounts source paths
7840481 mount: Pass guest shared dir to create the guest mounts
81c9ec3 mount: Add type and options fields
e716658 qemu: Shut the nesting env check debug
d488ca0 kata_proxy_test: Fix kata proxy unit tests
91633aa kata_proxy: Check the agent interface before dereferencing it
9aeb502 container: Create container before starting it
3fec78b kata_agent: Do not share the sandbox PID ns
8af573f kata_proxy: Kill the proxy once we unregister the VM
2ebad33 kata_agent: Unmount container rootfs when container is stopped
852f601 kata_agent: Add exec IDs for exec and create container
45c9cfd kata_agent: Fix the guest rootfs OCI path
cc469f5 kata_agent: Add logrus based logger
5a34447 kata_agent: Use the correct serial channel name
9ca6126 kata_proxy: Implement all interface ops
b8ac6b6 kata_agent: Build and store the default gRPC socket
fb1eecd mount: Fix unmount of dangling bind-mounts
d7462c7 pkg/oci: Clarify resource calculation comment
027aab8 qemu: adjust QMP naming to avoid non-unique truncation
0c4064e capabilities: Pass capabilities to hyperstart.
e20ba9d oci: Add support for capabilities
6776dd9 shim: Correct kata debug flag
b307c08 qemu: refactor/simplify addDevice function
747d364 vhost-user: rewrite to use interfaces/embedded types
cc67fb0 vhost-user: enabling for vhost-user network devices
f5587cf device: make a more generic function for hypervisor args
d6f0600 gitignore: Add new shim binary to gitignore list
bf8359f gitignore: Add new shim binary to gitignore list
c30fd9a ci: Install missing dep tool
d1bb792 kata_agent: Signal the kata shim
08c96c2 shim: Generalize stopShim
3e86f7b vendor: Force kata containers agent vendoring
34952bb shim: Factorize the shim config structure between kata and CC
a7e244a shim: Factorize shim execution code
eb8befb shim: Add a Kata shim mock implementation
6da9685 shim: Add a Kata Containers shim type
18f46de kata_shim: Initial implementation
60a446a container: Generate process token when not set
4c2c9a4 mounts: Fix bug while checking if /dev was bind-mounted
67fcb6d pkg/oci: honour CPU period and quota
1a3de59 agent: Add kata exec, stopContainer and killContainer
4f92997 annotations: Update tests to use package prefix
b3da3de mount: Fix tests for bindMountContainerRootfs function
aa75a0e kata_agent: Implement vmURL and setProxyURL
53f093d kata_agent: Initial VSOCK support
bc302d2 kata_agent: Implement the validate function
cb7fac2 kata_agent: Rename shared dir paths
0b95eda kata_agent: Create and start container implementations
c4a4be4 mount: Gather the entire bind mount API
be96f34 vendor: Update for Kata Containers
c0692ca annotations: Move OCI annotations to the annotation package
1a638c0 ci: Handle complex revendoring cases
fe726af kata_agent: Implement pod start and stop ops
3d1afe4 kata_agent: Initialize gRPC client
f6948d8 agent: Add new agent type for Kata Containers
7d35db6 kata_agent: Add Kata agent configuration
b2fe3df hyperstart: Rename to hyperstart_agent
f86cd11 kata_agent: Initial implementation
414e156 qemu: improve kernel boot time
bdde7bb pod: Add important comment for Cmd type
a217958 oci: Pass the NoNewPrivileges flag to the agent.
f683602 oci: Add support for NoNewPrivileges in oci spec
ddd89b7 cheanup: Remove vendored "golang.org/x/crypto" package.
fd6e357 cleanup: Remove sshd agent
b7c19b8 cni: update function names for consistency
847eaaa network: scan network one less time
dc4836a network: unique ID is not unique
8449f56 network: refactoring and cleanup of CNI path
d6f9690 vendor: Revendor govmm for VSOCK support
71ce0c8 proxy: Implement Kata Containers proxy
8f9a2e0 proxy: Implement no_proxy generic case
2e2d33c agent: Introduce new functions to agent interface
05cec52 hyperstart: Change the path where rootfs is bind-mounted
d0051aa agent: Pass information about  the "-v /dev:/dev"  case
bdc815d mounts: Deduce additional information about system mounts
7c88153 vendor: switch to govmm
c6b10c5 agent: Return the actual error returned by the agent
78771b2 Networking: Add support for multiqueue tap
2b38edc Revendor: Revendor qemu to add multiqueue support and vhost-user
d4a5a59 Vendoring: Revendor netlink to add multiqueue tap support
11cfdcf cni: pass pod ID to CNI plugin's add/delete calls
b956d2b gitignore: Add .swp files
d6dc515 ethtool: Remove .swp file
890a8b1 Fix network warning message
b0dd4c6 9p: Do not pass the rootfs through 9pfs
077a427 vendor: update ciao
01b012b vendor: Move the ciao vendoring to ciao-project
148b06a proxy: Launch one proxy instance per pod
619300a proxy: Use CC3 proxy path
d8f2a22 shim: Only show shim-count if there are any
c993e45 shim: Quote urls in error
aa2ba14 Remove redundant "if" check
37dc3c6 cni: Assign the netpair for virtual endpoints after scan
8f846a2 cni: Fix bug while updating endpoints after scanning net namespace
eb39def qemu: Provide unique QMP sockets names
6026603 qemu: Don't wait for the end of the VM
eeacf8b qemu: Fix disconnectCh issue and simplify it
711783f agent: hyperstart: Tear down properly the pod
b20ba87 pod: Improve pod create performances
d449ece api: Refactor RunPod()
c3663b2 pod: Run post-start hooks outside netns
42df5a6 hypervisor: add hot plugging support for Qemu Q35
7e80438 container: fix device mapper hot plug in qemu 2.9
121a37c filesystem: Fix fetchFile behaviour for devicesFileType
07593f0 block: Skip cold-plugging block devices.
4132cd6 api: Simplify drive hotplugging
74be935 network: Add interface type to our network info
5718a68 network: Cleanup and optimizations
a7935fd storage: Simplify fetches from storage
d8055a6 network: cni: Fix lack of support for SRIOV
06c73de network: Move fully to netlink structures
af12f75 network: Replace CNI Result structure with a larger one
35aafe8 vendor: Update CNI related repositories

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>