### PR TITLE
shim: Start shims inside appropriate namespaces

### DIFF
--- a/pkg/nsenter/nsenter.go
+++ b/pkg/nsenter/nsenter.go
@@ -1,0 +1,194 @@
+//
+// Copyright (c) 2018 Intel Corporation
+// Copyright 2015-2017 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package nsenter
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"sync"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// Filesystems constants.
+const (
+	// https://github.com/torvalds/linux/blob/master/include/uapi/linux/magic.h
+	nsFSMagic   = 0x6e736673
+	procFSMagic = 0x9fa0
+
+	procRootPath = "/proc"
+	nsDirPath    = "ns"
+	taskDirPath  = "task"
+)
+
+// NSType defines a namespace type.
+type NSType string
+
+// List of namespace types.
+// Notice that neither "mnt" nor "user" are listed into this list.
+// Because Golang is multithreaded, we get some errors when trying
+// to switch to those namespaces, getting "invalid argument".
+// The solution is to reexec the current code so that it will call
+// into a C constructor, making sure the namespace can be entered
+// without multithreading issues.
+const (
+	NSTypeCGroup NSType = "cgroup"
+	NSTypeIPC           = "ipc"
+	NSTypeNet           = "net"
+	NSTypePID           = "pid"
+	NSTypeUTS           = "uts"
+)
+
+// CloneFlagsTable is exported so that consumers of this package don't need
+// to define this same table again.
+var CloneFlagsTable = map[NSType]int{
+	NSTypeCGroup: unix.CLONE_NEWCGROUP,
+	NSTypeIPC:    unix.CLONE_NEWIPC,
+	NSTypeNet:    unix.CLONE_NEWNET,
+	NSTypePID:    unix.CLONE_NEWPID,
+	NSTypeUTS:    unix.CLONE_NEWUTS,
+}
+
+// Namespace describes a namespace that will be entered.
+type Namespace struct {
+	Path string
+	PID  int
+	Type NSType
+}
+
+type nsPair struct {
+	targetNS *os.File
+	threadNS *os.File
+}
+
+func getNSPathFromPID(pid int, nsType NSType) string {
+	return filepath.Join(procRootPath, strconv.Itoa(pid), nsDirPath, string(nsType))
+}
+
+func getCurrentThreadNSPath(nsType NSType) string {
+	return filepath.Join(procRootPath, strconv.Itoa(os.Getpid()),
+		taskDirPath, strconv.Itoa(unix.Gettid()), nsDirPath, string(nsType))
+}
+
+func setNS(nsFile *os.File, nsType NSType) error {
+	if nsFile == nil {
+		return fmt.Errorf("File handler cannot be nil")
+	}
+
+	nsFlag, exist := CloneFlagsTable[nsType]
+	if !exist {
+		return fmt.Errorf("Unknown namespace type %q", nsType)
+	}
+
+	if err := unix.Setns(int(nsFile.Fd()), nsFlag); err != nil {
+		return fmt.Errorf("Error switching to ns %v: %v", nsFile.Name(), err)
+	}
+
+	return nil
+}
+
+// getFileFromNS checks the provided file path actually matches a real
+// namespace filesystem, and then opens it to return a handler to this
+// file. This is needed since the system call setns() expects a file
+// descriptor to enter the given namespace.
+func getFileFromNS(nsPath string) (*os.File, error) {
+	stat := syscall.Statfs_t{}
+	if err := syscall.Statfs(nsPath, &stat); err != nil {
+		return nil, fmt.Errorf("failed to Statfs %q: %v", nsPath, err)
+	}
+
+	switch stat.Type {
+	case nsFSMagic, procFSMagic:
+		break
+	default:
+		return nil, fmt.Errorf("unknown FS magic on %q: %x", nsPath, stat.Type)
+	}
+
+	file, err := os.Open(nsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return file, nil
+}
+
+// NsEnter executes the passed closure under the given namespace,
+// restoring the original namespace afterwards.
+func NsEnter(nsList []Namespace, toRun func() error) error {
+	targetNSList := make(map[NSType]*nsPair)
+
+	// Open all targeted namespaces.
+	for _, ns := range nsList {
+		targetNSPath := ns.Path
+		if targetNSPath == "" {
+			targetNSPath = getNSPathFromPID(ns.PID, ns.Type)
+		}
+
+		targetNS, err := getFileFromNS(targetNSPath)
+		if err != nil {
+			return fmt.Errorf("failed to open target ns: %v", err)
+		}
+		defer targetNS.Close()
+
+		targetNSList[ns.Type] = &nsPair{
+			targetNS: targetNS,
+		}
+	}
+
+	containedCall := func() error {
+		for nsType := range targetNSList {
+			threadNS, err := getFileFromNS(getCurrentThreadNSPath(nsType))
+			if err != nil {
+				return fmt.Errorf("failed to open current ns: %v", err)
+			}
+			defer threadNS.Close()
+
+			targetNSList[nsType].threadNS = threadNS
+		}
+
+		// Switch to namespaces all at once.
+		for nsType, pair := range targetNSList {
+			// Switch to targeted namespace.
+			if err := setNS(pair.targetNS, nsType); err != nil {
+				return fmt.Errorf("error switching to ns %v: %v", pair.targetNS.Name(), err)
+			}
+			// Switch back to initial namespace after closure return.
+			defer setNS(pair.threadNS, nsType)
+		}
+
+		return toRun()
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	var innerError error
+	go func() {
+		defer wg.Done()
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		innerError = containedCall()
+	}()
+	wg.Wait()
+
+	return innerError
+}

--- a/pkg/nsenter/nsenter_test.go
+++ b/pkg/nsenter/nsenter_test.go
@@ -1,0 +1,256 @@
+//
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package nsenter
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	testPID    = 12345
+	testNSPath = "/foo/bar/ns"
+)
+
+func TestGetNSPathFromPID(t *testing.T) {
+	for nsType := range CloneFlagsTable {
+		expectedPath := fmt.Sprintf("/proc/%d/ns/%s", testPID, nsType)
+		path := getNSPathFromPID(testPID, nsType)
+		assert.Equal(t, path, expectedPath)
+	}
+}
+
+func TestGetCurrentThreadNSPath(t *testing.T) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	currentPID := os.Getpid()
+	currentTID := unix.Gettid()
+	for nsType := range CloneFlagsTable {
+		expectedPath := fmt.Sprintf("/proc/%d/task/%d/ns/%s", currentPID, currentTID, nsType)
+		path := getCurrentThreadNSPath(nsType)
+		assert.Equal(t, path, expectedPath)
+	}
+}
+
+func TestGetFileFromNSEmptyNSPathFailure(t *testing.T) {
+	nsFile, err := getFileFromNS("")
+	assert.NotNil(t, err, "Empty path should result as a failure")
+	assert.Nil(t, nsFile, "The file handler returned should be nil")
+}
+
+func TestGetFileFromNSNotExistingNSPathFailure(t *testing.T) {
+	nsFile, err := ioutil.TempFile("", "not-existing-ns-path")
+	if err != nil {
+		t.Fatal(err)
+	}
+	nsFilePath := nsFile.Name()
+	nsFile.Close()
+
+	if err := os.Remove(nsFilePath); err != nil {
+		t.Fatal(err)
+	}
+
+	nsFile, err = getFileFromNS(nsFilePath)
+	assert.NotNil(t, err, "Not existing path should result as a failure")
+	assert.Nil(t, nsFile, "The file handler returned should be nil")
+}
+
+func TestGetFileFromNSWrongNSPathFailure(t *testing.T) {
+	nsFile, err := ioutil.TempFile("", "wrong-ns-path")
+	if err != nil {
+		t.Fatal(err)
+	}
+	nsFilePath := nsFile.Name()
+	nsFile.Close()
+
+	defer os.Remove(nsFilePath)
+
+	nsFile, err = getFileFromNS(nsFilePath)
+	assert.NotNil(t, err, "Should fail because wrong filesystem")
+	assert.Nil(t, nsFile, "The file handler returned should be nil")
+}
+
+func TestGetFileFromNSSuccessful(t *testing.T) {
+	for nsType := range CloneFlagsTable {
+		nsFilePath := fmt.Sprintf("/proc/self/ns/%s", string(nsType))
+		nsFile, err := getFileFromNS(nsFilePath)
+		assert.Nil(t, err, "Should have succeeded: %v", err)
+		assert.NotNil(t, nsFile, "The file handler should not be nil")
+		if nsFile != nil {
+			nsFile.Close()
+		}
+	}
+}
+
+func startSleepBinary(duration int, cloneFlags int) (int, error) {
+	sleepBinName := "sleep"
+	sleepPath, err := exec.LookPath(sleepBinName)
+	if err != nil {
+		return -1, fmt.Errorf("Could not find %q: %v", sleepBinName, err)
+	}
+
+	cmd := exec.Command(sleepPath, strconv.Itoa(duration))
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Cloneflags: uintptr(cloneFlags),
+	}
+
+	if err := cmd.Start(); err != nil {
+		return -1, err
+	}
+
+	return cmd.Process.Pid, nil
+}
+
+func TestSetNSNilFileHandlerFailure(t *testing.T) {
+	err := setNS(nil, "")
+	assert.NotNil(t, err, "Should fail because file handler is nil")
+}
+
+func TestSetNSUnknownNSTypeFailure(t *testing.T) {
+	file := &os.File{}
+	err := setNS(file, "")
+	assert.NotNil(t, err, "Should fail because unknown ns type")
+}
+
+func TestSetNSWrongFileFailure(t *testing.T) {
+	nsFile, err := ioutil.TempFile("", "wrong-ns-path")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		nsFilePath := nsFile.Name()
+		nsFile.Close()
+		os.Remove(nsFilePath)
+	}()
+
+	err = setNS(nsFile, NSTypeIPC)
+	assert.NotNil(t, err, "Should fail because file is not a namespace")
+}
+
+var testNamespaceList = []Namespace{
+	{
+		Type: NSTypeCGroup,
+	},
+	{
+		Type: NSTypeIPC,
+	},
+	{
+		Type: NSTypeNet,
+	},
+	{
+		Type: NSTypePID,
+	},
+	{
+		Type: NSTypeUTS,
+	},
+}
+
+func testToRunNil() error {
+	return nil
+}
+
+func TestNsEnterEmptyPathAndPIDFromNSListFailure(t *testing.T) {
+	err := NsEnter(testNamespaceList, testToRunNil)
+	assert.NotNil(t, err, "Should fail because neither a path nor a PID"+
+		" has been provided by every namespace of the list")
+}
+
+func TestNsEnterEmptyNamespaceListSuccess(t *testing.T) {
+	err := NsEnter([]Namespace{}, testToRunNil)
+	assert.Nil(t, err, "Should not fail since closure should return nil: %v", err)
+}
+
+func TestNsEnterSuccessful(t *testing.T) {
+	nsList := testNamespaceList
+	sleepDuration := 60
+
+	cloneFlags := 0
+	for _, ns := range nsList {
+		cloneFlags |= CloneFlagsTable[ns.Type]
+	}
+
+	sleepPID, err := startSleepBinary(sleepDuration, cloneFlags)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if sleepPID > 1 {
+			unix.Kill(sleepPID, syscall.SIGKILL)
+		}
+	}()
+
+	for idx := range nsList {
+		nsList[idx].Path = getNSPathFromPID(sleepPID, nsList[idx].Type)
+		nsList[idx].PID = sleepPID
+	}
+
+	var sleepPIDFromNsEnter int
+
+	testToRun := func() error {
+		sleepPIDFromNsEnter, err = startSleepBinary(sleepDuration, 0)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	err = NsEnter(nsList, testToRun)
+	assert.Nil(t, err, "%v", err)
+
+	defer func() {
+		if sleepPIDFromNsEnter > 1 {
+			unix.Kill(sleepPIDFromNsEnter, syscall.SIGKILL)
+		}
+	}()
+
+	for _, ns := range nsList {
+		nsPathEntered := getNSPathFromPID(sleepPIDFromNsEnter, ns.Type)
+
+		// Here we are trying to resolve the path but it fails because
+		// namespaces links don't really exist. For this reason, the
+		// call to EvalSymlinks will fail when it will try to stat the
+		// resolved path found. As we only care about the path, we can
+		// retrieve it from the PathError structure.
+		evalExpectedNSPath, err := filepath.EvalSymlinks(ns.Path)
+		if err != nil {
+			evalExpectedNSPath = err.(*os.PathError).Path
+		}
+
+		// Same thing here, resolving the namespace path.
+		evalNSEnteredPath, err := filepath.EvalSymlinks(nsPathEntered)
+		if err != nil {
+			evalNSEnteredPath = err.(*os.PathError).Path
+		}
+
+		_, evalExpectedNS := filepath.Split(evalExpectedNSPath)
+		_, evalNSEntered := filepath.Split(evalNSEnteredPath)
+
+		assert.Equal(t, evalExpectedNS, evalNSEntered)
+	}
+}

--- a/shim.go
+++ b/shim.go
@@ -23,6 +23,7 @@ import (
 	"syscall"
 	"time"
 
+	ns "github.com/containers/virtcontainers/pkg/nsenter"
 	"github.com/mitchellh/mapstructure"
 	"github.com/sirupsen/logrus"
 )
@@ -54,6 +55,7 @@ type ShimParams struct {
 	Terminal  bool
 	Detach    bool
 	PID       int
+	CreateNS  []ns.NSType
 }
 
 // ShimConfig is the structure providing specific configuration
@@ -188,6 +190,15 @@ func startShim(args []string, params ShimParams) (int, error) {
 		cmd.Stderr = os.Stderr
 	}
 
+	cloneFlags := 0
+	for _, nsType := range params.CreateNS {
+		cloneFlags |= ns.CloneFlagsTable[nsType]
+	}
+
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Cloneflags: uintptr(cloneFlags),
+	}
+
 	var f *os.File
 	var err error
 	if params.Console != "" {
@@ -199,15 +210,11 @@ func startShim(args []string, params ShimParams) (int, error) {
 		cmd.Stdin = f
 		cmd.Stdout = f
 		cmd.Stderr = f
-		cmd.SysProcAttr = &syscall.SysProcAttr{
-			// Create Session
-			Setsid: true,
-
-			// Set Controlling terminal to Ctty
-			Setctty: true,
-			Ctty:    int(f.Fd()),
-		}
-
+		// Create Session
+		cmd.SysProcAttr.Setsid = true
+		// Set Controlling terminal to Ctty
+		cmd.SysProcAttr.Setctty = true
+		cmd.SysProcAttr.Ctty = int(f.Fd())
 	}
 	defer func() {
 		if f != nil {

--- a/shim.go
+++ b/shim.go
@@ -154,7 +154,8 @@ func stopShim(pid int) error {
 	return nil
 }
 
-func prepareAndStartShim(pod *Pod, shim shim, cid, token, url string, cmd Cmd) (*Process, error) {
+func prepareAndStartShim(pod *Pod, shim shim, cid, token, url string, cmd Cmd,
+	createNSList []ns.NSType, enterNSList []ns.Namespace) (*Process, error) {
 	process := &Process{
 		Token:     token,
 		StartTime: time.Now().UTC(),
@@ -167,12 +168,8 @@ func prepareAndStartShim(pod *Pod, shim shim, cid, token, url string, cmd Cmd) (
 		Console:   cmd.Console,
 		Terminal:  cmd.Interactive,
 		Detach:    cmd.Detach,
-		EnterNS:   []ns.Namespace{
-			{
-				Path: pod.networkNS.NetNsPath,
-				Type: ns.NSTypeNet,
-			},
-		},
+		CreateNS:  createNSList,
+		EnterNS:   enterNSList,
 	}
 
 	pid, err := shim.start(*pod, shimParams)


### PR DESCRIPTION
This PR first creates a new package `nsenter` so that we can spawn any code into a set of namespaces. Then, the virtcontainers code is modified to rely on this new package. At last, it starts shims from agents within the right PID namespace. In details, a shim representing a container process should enter its own PID namespace so that we can spawn other shims corresponding to exec'ed processes inside the same namespace. This is needed if we don't want some race conditions to happen, due to the exec'ed shims to never return their exit codes if the container process returned first.

Fixes #613 