### PR TITLE
filesystem: set correct access mode for pod dir tree

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -88,7 +88,7 @@ const mountsFile = "mounts.json"
 const devicesFile = "devices.json"
 
 // dirMode is the permission bits used for creating a directory
-const dirMode = os.FileMode(0750)
+const dirMode = os.FileMode(0750) | os.ModeDir
 
 // storagePathSuffix is the suffix used for all storage paths
 const storagePathSuffix = "/virtcontainers/pods"
@@ -154,7 +154,7 @@ func (fs *filesystem) Logger() *logrus.Entry {
 func (fs *filesystem) createAllResources(pod Pod) (err error) {
 	for _, resource := range []podResource{stateFileType, configFileType} {
 		_, path, _ := fs.podURI(pod.id, resource)
-		err = os.MkdirAll(path, os.ModeDir)
+		err = os.MkdirAll(path, dirMode)
 		if err != nil {
 			return err
 		}
@@ -163,7 +163,7 @@ func (fs *filesystem) createAllResources(pod Pod) (err error) {
 	for _, container := range pod.containers {
 		for _, resource := range []podResource{stateFileType, configFileType} {
 			_, path, _ := fs.containerURI(pod.id, container.id, resource)
-			err = os.MkdirAll(path, os.ModeDir)
+			err = os.MkdirAll(path, dirMode)
 			if err != nil {
 				fs.deletePodResources(pod.id, nil)
 				return err

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -80,16 +80,27 @@ func TestFilesystemCreateAllResourcesSuccessful(t *testing.T) {
 
 	for _, container := range contConfigs {
 		configPath := filepath.Join(configStoragePath, testPodID, container.ID)
-		_, err = os.Stat(configPath)
+		s, err := os.Stat(configPath)
 		if err != nil {
 			t.Fatal(err)
 		}
 
+		// Check we created the dirs with the correct mode
+		if s.Mode() != dirMode {
+			t.Fatal(fmt.Errorf("dirmode [%v] != expected [%v]", s.Mode(), dirMode))
+		}
+
 		runPath := filepath.Join(runStoragePath, testPodID, container.ID)
-		_, err = os.Stat(runPath)
+		s, err = os.Stat(runPath)
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		// Check we created the dirs with the correct mode
+		if s.Mode() != dirMode {
+			t.Fatal(fmt.Errorf("dirmode [%v] != expected [%v]", s.Mode(), dirMode))
+		}
+
 	}
 }
 


### PR DESCRIPTION
Some of the filesystem pod data tree (/var/lib/virtcontainers/*)
is currently created with the permission 01000 (d---------). This
looks like we have forgotten to or in the dirMode bits into
the MkdirAll() calls.

Or in the appropriate bits.

Fixes: #638

Signed-off-by: Graham whaley <graham.whaley@intel.com>