### PR TITLE
check: lint: ineffassign in qemu.go

### DIFF
--- a/qemu.go
+++ b/qemu.go
@@ -593,6 +593,9 @@ func (q *qemu) hotplugBlockDevice(drive Drive, op operation) error {
 		if q.config.BlockDeviceDriver == VirtioBlock {
 			driver := "virtio-blk-pci"
 			addr, bus, err := q.addDeviceToBridge(drive.ID)
+			if err != nil {
+				return err
+			}
 
 			if err = q.qmpMonitorCh.qmp.ExecutePCIDeviceAdd(q.qmpMonitorCh.ctx, drive.ID, devID, driver, addr, bus); err != nil {
 				return err


### PR DESCRIPTION
We were not checking the return err from addDeviceToBridge, which
can validly error out. lint/ineffassign picked this up.
Let's check the error return then...

Fixes: #650

Signed-off-by: Graham whaley <graham.whaley@intel.com>