### PR TITLE
docs: Developer: must develop/test in main repo

### DIFF
--- a/documentation/Developers.md
+++ b/documentation/Developers.md
@@ -3,9 +3,9 @@ Table of Contents
 =================
 
    * [Prerequisites](#prerequisites)
+   * [Cloning and Submitting](#cloning-and-submitting)
    * [Building](#building)
    * [Testing](#testing)
-   * [Submitting changes](#submitting-changes)
 
 # Prerequisites
 
@@ -19,12 +19,37 @@ Table of Contents
 A number of these can be installed using the
 [virtcontainers-setup.sh](../utils/virtcontainers-setup.sh) script.
 
+# Cloning and Submitting
+
+If you are just builiding `virtcontainers`, then you can simply clone the main repository
+from https://github.com/containers/virtcontainers.
+
+If you wish to develop `virtcontainers`, you should fork the project on github under your
+user.
+
+**Note:** As `virtcontainers` contains and references its own
+[sub packages](https://github.com/containers/virtcontainers/tree/master/pkg),
+it will **not** build or pass its tests in your user fork repo (as the
+[pkg references](https://github.com/containers/virtcontainers/blob/master/cni.go#L25)
+will still reference the main repo, and this results in golang type clashes etc.).
+
+In order to develop and submit PRs for `virtcontainers`, the easiest method is to:
+
+- Create a user fork on github.
+- Clone the main repo to your development machine (with `go get`)
+- Add your user fork as a 'remote' to the main repo on your development machine.
+- Develop and test in a branch in your main repo as per the
+[CONTRIBUTING](https://github.com/containers/virtcontainers/blob/master/CONTRIBUTING.md#pull-requests)
+guidelines.
+- Submit your PR by pushing your branch to *your user fork remote* (and **not** back
+to the main repo origin).
+
 # Building
 
 To build `virtcontainers`, at the top level directory run:
 
 ```bash
-# make
+$ make
 ```
 
 # Testing
@@ -35,22 +60,25 @@ Before testing you need to install virtcontainers. The following command will in
 `virtcontainers` into its own area (`/usr/bin/virtcontainers/bin/` by default).
 
 ```
-# sudo -E PATH=$PATH make install
+$ sudo -E PATH=$PATH make install
 ```
+
+You also need to install some extra components required for testing, by running:
+```
+$ sudo -E PATH=$PATH utils/virtcontainers-setup.sh
+```
+
+> Note: this script installs components into **/tmp**. If you reboot your machine,
+> those files will *likely be removed*, and you will need to re-run the script again
+> before you can successfully run the tests again.
 
 To test `virtcontainers`, at the top level run:
 
 ```
-# make check
+$ CI=true make check
 ```
 
 This will:
 
 - run static code checks on the code base.
 - run `go test` unit tests from the code base.
-
-# Submitting changes
-
-For details on the format and how to submit changes, refer to the
-[Contributing](CONTRIBUTING.md) document.
-


### PR DESCRIPTION
You cannot build and test in a repo fork, as the sub-pkg
references do not move with the fork, and we fail due to
type difference failures.

Add details on how to add your user fork as a remote to the
main repo so you can develop/PR.

Also update details on installing required components into
/tmp, and the inherent weakness of that.

Note you need 'CI=true' to usefully run `make check`.

Fixes: #642

Signed-off-by: Graham whaley <graham.whaley@intel.com>