### PR TITLE
[RFC] Generate enriched errors

### DIFF
--- a/api.go
+++ b/api.go
@@ -28,16 +28,16 @@ func init() {
 	runtime.LockOSThread()
 }
 
-var virtLog = logrus.FieldLogger(logrus.New())
+var logFields = logrus.Fields{
+	"source": "virtcontainers",
+	"arch":   runtime.GOARCH,
+}
+
+var virtLog = logrus.New().WithFields(logFields)
 
 // SetLogger sets the logger for virtcontainers package.
 func SetLogger(logger logrus.FieldLogger) {
-	fields := logrus.Fields{
-		"source": "virtcontainers",
-		"arch":   runtime.GOARCH,
-	}
-
-	virtLog = logger.WithFields(fields)
+	virtLog = logger.WithFields(logFields)
 }
 
 // CreatePod is the virtcontainers pod creation entry point.

--- a/container.go
+++ b/container.go
@@ -625,7 +625,7 @@ func (c *Container) kill(signal syscall.Signal, all bool) error {
 	}
 
 	if c.state.State != StateReady && c.state.State != StateRunning {
-		return fmt.Errorf("Container not ready or running, impossible to signal the container")
+		return Errorf("Container not ready or running, impossible to signal the container")
 	}
 
 	return c.pod.agent.killContainer(*(c.pod), *c, signal, all)


### PR DESCRIPTION
# Context

All components of both Clear Containers and Kata Containers now produce structured logs. This is extremely useful as the log fields provide a lot of context on key stages in the runtime flows.

# Current virtcontainers error example

However, errors currently suffer as they are wholly "free-format".

For example, here's an example of a structured log message logged by `cc-runtime`:

```
time="2018-02-28T21:18:55.292102004+01:00" level=error msg="Container not ready or running, impossible to signal the container" source=runtime pid=1234
```

Or formatted with the log-parser on https://github.com/kata-containers/tests/pull/98 for easier reading:

```
- count: 1
  timedelta: 0
  filename: /home/james/tmp/vc-old.txt
  line: 1
  time: !!timestamp 2018-02-28T21:18:55.292102004+01:00
  pid: 1234
  level: error
  msg: Container not ready or running, impossible to signal the container
  source: runtime
  name: cc-runtime
  data: {}
```

Notes:

- The `msg` is the value passed to `fmt.Errorf()`.
- The `source=runtime` is actually wrong - this error was generated by virtcontainers, but it was the *runtime* that caught the error and logged it (but how would a reader know this?)

# Error based on this PR

This PR is just an idea for how we could improve our error handling. It adds a new implementation of `Errorf()` so that rather than the above, with this PR you'd get the following:

```
time="2018-03-02T14:40:30.311729832Z" level=error arch=amd64 error="Container not ready or running, impossible to signal the container" error-time="2018-03-02T14:40:30.311705732Z" file="\"/home/james/go/src/github.com/clearcontainers/runtime/vendor/github.com/containers/virtcontainers/container.go\"" function="github.com/clearcontainers/runtime/vendor/github.com/containers/virtcontainers.(*Container).kill" hello=world line=628 name=cc-runtime pid=22469 source=virtcontainers
```

... and here's the log-parser reformatted version of that line:

```
- count: 1
  timedelta: 0
  filename: /home/james/tmp/vc.log
  line: 1
  time: !!timestamp 2018-03-02T14:40:30.311729832Z
  pid: 22469
  level: error
  msg: ""
  source: virtcontainers
  name: cc-runtime
  data:
    arch: amd64
    error: Container not ready or running, impossible to signal the container                                                                                                                 
    error-time: "2018-03-02T14:40:30.311705732Z"
    file: '"/home/james/go/src/github.com/clearcontainers/runtime/vendor/github.com/containers/virtcontainers/container.go"'
    function: github.com/clearcontainers/runtime/vendor/github.com/containers/virtcontainers.(*Container).kill
    hello: world
    line: "628"
```

Notes:

- We now get *two* timestamps - one showing the time the error was logged (`time`) and the other showing the time the error was generated (`error-time`).
- The file, line number and function *where the error was generated* are now logged.
- The `source` now correctly shows `virtcontainers`.

# Caveats

This PR is just an example. To be generally useful, we'd need this `Errorf()` function (and an equivalent to `errors.New()`) to be available to *all* components of Clear Containers and Kata Containers. That implies we'd need a new package for this functionality in a separate repo that we'd "vendor in" to all the components.

The other issue is how we handle the logger itself. Ideally, we'd find a way to register the logger with the new package and then have `Errorf()` use that logger object. But worst case, we'd need to change all the `fmt.Errorf()` and `errors.New()` calls to pass in the logger as an extra arg.

/cc @sameo, @sboeuf, @grahamwhaley.