### PR TITLE
qemu: honor DefaultVCPUs

### DIFF
--- a/example_pod_run_test.go
+++ b/example_pod_run_test.go
@@ -60,7 +60,6 @@ func Example_createAndStartPod() {
 
 	// VM resources
 	vmConfig := vc.Resources{
-		VCPUs:  4,
 		Memory: 1024,
 	}
 

--- a/hack/virtc/main.go
+++ b/hack/virtc/main.go
@@ -152,7 +152,6 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 	proxyPath := context.String("proxy-path")
 	shimPath := context.String("shim-path")
 	machineType := context.String("machine-type")
-	vmVCPUs := context.Uint("vm-vcpus")
 	vmMemory := context.Uint("vm-memory")
 	agentType, ok := context.Generic("agent").(*vc.AgentType)
 	if ok != true {
@@ -208,7 +207,6 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 	shimConfig := getShimConfig(*shimType, shimPath)
 
 	vmConfig := vc.Resources{
-		VCPUs:  vmVCPUs,
 		Memory: vmMemory,
 	}
 

--- a/hypervisor.go
+++ b/hypervisor.go
@@ -182,7 +182,6 @@ type HypervisorConfig struct {
 	Debug bool
 
 	// DefaultVCPUs specifies default number of vCPUs for the VM.
-	// Pod configuration VMConfig.VCPUs overwrites this.
 	DefaultVCPUs uint32
 
 	//DefaultMaxVCPUs specifies the maximum number of vCPUs for the VM.

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -440,23 +440,6 @@ func vmConfig(ocispec CompatOCISpec, config RuntimeConfig) (vc.Resources, error)
 		resources.Memory = uint((memBytes + (1024*1024 - 1)) / (1024 * 1024))
 	}
 
-	if ocispec.Linux.Resources.CPU != nil &&
-		ocispec.Linux.Resources.CPU.Quota != nil &&
-		ocispec.Linux.Resources.CPU.Period != nil {
-		quota := *ocispec.Linux.Resources.CPU.Quota
-		period := *ocispec.Linux.Resources.CPU.Period
-
-		if quota <= 0 {
-			return vc.Resources{}, fmt.Errorf("Invalid OCI cpu quota %d", quota)
-		}
-
-		if period == 0 {
-			return vc.Resources{}, fmt.Errorf("Invalid OCI cpu period %d", period)
-		}
-
-		resources.VCPUs = vc.ConstraintsToVCPUs(quota, period)
-	}
-
 	return resources, nil
 }
 

--- a/pkg/oci/utils_test.go
+++ b/pkg/oci/utils_test.go
@@ -213,8 +213,6 @@ func TestMinimalPodConfig(t *testing.T) {
 
 func TestVmConfig(t *testing.T) {
 	var limitBytes int64 = 128 * 1024 * 1024
-	var quota int64 = 200000
-	var period uint64 = 100000
 
 	config := RuntimeConfig{
 		VMConfig: vc.Resources{
@@ -224,7 +222,6 @@ func TestVmConfig(t *testing.T) {
 
 	expectedResources := vc.Resources{
 		Memory: 128,
-		VCPUs:  2,
 	}
 
 	ocispec := CompatOCISpec{
@@ -233,10 +230,6 @@ func TestVmConfig(t *testing.T) {
 				Resources: &specs.LinuxResources{
 					Memory: &specs.LinuxMemory{
 						Limit: &limitBytes,
-					},
-					CPU: &specs.LinuxCPU{
-						Quota:  &quota,
-						Period: &period,
 					},
 				},
 			},
@@ -260,32 +253,9 @@ func TestVmConfig(t *testing.T) {
 		t.Fatalf("Got %v\n expecting error", resources)
 	}
 
-	limitBytes = 128 * 1024 * 1024
-	quota = -1
-	ocispec.Linux.Resources.CPU.Quota = &quota
-
-	resources, err = vmConfig(ocispec, config)
-	if err == nil {
-		t.Fatalf("Got %v\n expecting error", resources)
-	}
-
-	quota = 100000
-	period = 0
-	ocispec.Linux.Resources.CPU.Quota = &quota
-
-	resources, err = vmConfig(ocispec, config)
-	if err == nil {
-		t.Fatalf("Got %v\n expecting error", resources)
-	}
-
 	// Test case when Memory is nil
 	ocispec.Spec.Linux.Resources.Memory = nil
 	expectedResources.Memory = config.VMConfig.Memory
-	quota = 50000
-	period = 20000
-	ocispec.Linux.Resources.CPU.Quota = &quota
-	ocispec.Linux.Resources.CPU.Period = &period
-	expectedResources.VCPUs = 3
 	resources, err = vmConfig(ocispec, config)
 	if err != nil {
 		t.Fatal(err)
@@ -297,7 +267,6 @@ func TestVmConfig(t *testing.T) {
 
 	// Test case when CPU is nil
 	ocispec.Spec.Linux.Resources.CPU = nil
-	expectedResources.VCPUs = config.VMConfig.VCPUs
 	limitBytes = 20
 	ocispec.Linux.Resources.Memory = &specs.LinuxMemory{Limit: &limitBytes}
 	expectedResources.Memory = 1

--- a/pod.go
+++ b/pod.go
@@ -313,9 +313,6 @@ type Cmd struct {
 
 // Resources describes VM resources configuration.
 type Resources struct {
-	// VCPUs is the number of available virtual CPUs.
-	VCPUs uint
-
 	// Memory is the amount of available memory in MiB.
 	Memory uint
 }

--- a/qemu.go
+++ b/qemu.go
@@ -204,13 +204,8 @@ func (q *qemu) init(pod *Pod) error {
 	return nil
 }
 
-func (q *qemu) cpuTopology(podConfig PodConfig) govmmQemu.SMP {
-	vcpus := q.config.DefaultVCPUs
-	if podConfig.VMConfig.VCPUs > 0 {
-		vcpus = uint32(podConfig.VMConfig.VCPUs)
-	}
-
-	return q.arch.cpuTopology(vcpus)
+func (q *qemu) cpuTopology() govmmQemu.SMP {
+	return q.arch.cpuTopology(q.config.DefaultVCPUs)
 }
 
 func (q *qemu) memoryTopology(podConfig PodConfig) (govmmQemu.Memory, error) {
@@ -266,7 +261,7 @@ func (q *qemu) createPod(podConfig PodConfig) error {
 		machine.Options += accelerators
 	}
 
-	smp := q.cpuTopology(podConfig)
+	smp := q.cpuTopology()
 
 	memory, err := q.memoryTopology(podConfig)
 	if err != nil {

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -136,6 +136,9 @@ func TestQemuCPUTopology(t *testing.T) {
 
 	q := &qemu{
 		arch: &qemuArchBase{},
+		config: HypervisorConfig{
+			DefaultVCPUs: uint32(vcpus),
+		},
 	}
 
 	expectedOut := govmmQemu.SMP{
@@ -146,15 +149,7 @@ func TestQemuCPUTopology(t *testing.T) {
 		MaxCPUs: defaultMaxQemuVCPUs,
 	}
 
-	vmConfig := Resources{
-		VCPUs: uint(vcpus),
-	}
-
-	podConfig := PodConfig{
-		VMConfig: vmConfig,
-	}
-
-	smp := q.cpuTopology(podConfig)
+	smp := q.cpuTopology()
 
 	if reflect.DeepEqual(smp, expectedOut) == false {
 		t.Fatalf("Got %v\nExpecting %v", smp, expectedOut)


### PR DESCRIPTION
Currently when a container with CPU constrains is created using docker,
the VM starts with a wrong number of vCPUs, the VM must start with the
number of vCPUs specified by `default_vcpus` allowing to the runtime hot
add/remove resources as needed.

For example if DefaultVCPUs (default_vcpus) is 1 and the container has
a constraint of 4 (docker run --cpus 4 ...), the VM must start with 1
vCPU because the runtime hot add 4 vCPUs.
Qemu command line example:
old:
`qemu-system-x86_64 ... -smp 4,cores=1,threads=1,sockets=1,maxcpus=240`

new:
`qemu-system-x86_64 ... -smp 1,cores=1,threads=1,sockets=1,maxcpus=240`

Depends-on: github.com/clearcontainers/runtime#1048

see clearcontainers/runtime#1032 and
clearcontainers/runtime#1041

fixes #661

Signed-off-by: Julio Montes <julio.montes@intel.com>