### PR TITLE
qemu: disable modern in SCSI constroller

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -68,7 +68,7 @@
 [[projects]]
   name = "github.com/intel/govmm"
   packages = ["qemu"]
-  revision = "d60256118ff05e570408e24c159171cca903e362"
+  revision = "e87160f8ea39dfe558bf6761f74717d191d82493"
 
 [[projects]]
   name = "github.com/kata-containers/agent"
@@ -221,6 +221,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e967c53b1d55018feac5c3db0e1c142cb63042311aac76206a47ce7c0cd8316c"
+  inputs-digest = "590b7d31900883c6782b596fa607426a77d71565516cfe8395379308a6285771"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -56,7 +56,7 @@
 
 [[constraint]]
   name = "github.com/intel/govmm"
-  revision = "d60256118ff05e570408e24c159171cca903e362"
+  revision = "e87160f8ea39dfe558bf6761f74717d191d82493"
 
 [[constraint]]
   name = "github.com/kata-containers/agent"

--- a/qemu_arch_base.go
+++ b/qemu_arch_base.go
@@ -291,7 +291,8 @@ func (q *qemuArchBase) appendImage(devices []govmmQemu.Device, path string) ([]g
 
 func (q *qemuArchBase) appendSCSIController(devices []govmmQemu.Device) []govmmQemu.Device {
 	scsiController := govmmQemu.SCSIController{
-		ID: scsiControllerID,
+		ID:            scsiControllerID,
+		DisableModern: q.nestedRun,
 	}
 
 	devices = append(devices, scsiController)

--- a/qemu_arch_base_test.go
+++ b/qemu_arch_base_test.go
@@ -458,3 +458,18 @@ func TestQemuArchBaseAppendVFIODevice(t *testing.T) {
 
 	testQemuArchBaseAppend(t, vfDevice, expectedOut)
 }
+
+func TestQemuArchBaseAppendSCSIController(t *testing.T) {
+	var devices []govmmQemu.Device
+	assert := assert.New(t)
+	qemuArchBase := newQemuArchBase()
+
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.SCSIController{
+			ID: scsiControllerID,
+		},
+	}
+
+	devices = qemuArchBase.appendSCSIController(devices)
+	assert.Equal(expectedOut, devices)
+}

--- a/vendor/github.com/intel/govmm/qemu/qemu.go
+++ b/vendor/github.com/intel/govmm/qemu/qemu.go
@@ -838,6 +838,9 @@ type SCSIController struct {
 
 	// Addr is the PCI address offset, this is optional
 	Addr string
+
+	// DisableModern prevents qemu from relying on fast MMIO.
+	DisableModern bool
 }
 
 // Valid returns true if the SCSIController structure is valid and complete.
@@ -860,6 +863,9 @@ func (scsiCon SCSIController) QemuParams(config *Config) []string {
 	}
 	if scsiCon.Addr != "" {
 		devParams = append(devParams, fmt.Sprintf("addr=%s", scsiCon.Addr))
+	}
+	if scsiCon.DisableModern {
+		devParams = append(devParams, fmt.Sprintf("disable-modern=true"))
 	}
 
 	qemuParams = append(qemuParams, "-device")


### PR DESCRIPTION
Disable modern to prevent qemu from relying on fast MMIO.
This change is needed to avoid boot issues when using virtio-scsi in a
nested virtual machine scenario.

fixes #663

Signed-off-by: Julio Montes <julio.montes@intel.com>