### PR TITLE
kata_agent: Add virtio-scsi support

### DIFF
--- a/kata_agent.go
+++ b/kata_agent.go
@@ -49,6 +49,7 @@ var (
 	type9pFs                    = "9p"
 	devPath                     = "/dev"
 	vsockSocketScheme           = "vsock"
+	kata9pDevType               = "9p"
 	kataBlkDevType              = "blk"
 )
 
@@ -481,6 +482,7 @@ func (k *kataAgent) startPod(pod Pod) error {
 	// (resolv.conf, etc...) and potentially all container
 	// rootfs will reside.
 	sharedVolume := &grpc.Storage{
+		Driver:     kata9pDevType,
 		Source:     mountGuest9pTag,
 		MountPoint: kataGuestSharedDir,
 		Fstype:     type9pFs,
@@ -621,14 +623,7 @@ func (k *kataAgent) createContainer(pod *Pod, c *Container) (*Process, error) {
 		// without trying to match and update it into the OCI spec list
 		// of actual devices. The device corresponding to the rootfs is
 		// a very specific case.
-		rootfsDevice := &grpc.Device{
-			Type:          kataBlkDevType,
-			VmPath:        virtPath,
-			ContainerPath: "",
-		}
-
-		ctrDevices = append(ctrDevices, rootfsDevice)
-
+		rootfs.Driver = kataBlkDevType
 		rootfs.Source = virtPath
 		rootfs.MountPoint = rootPathParent
 		rootfs.Fstype = c.state.Fstype

--- a/kata_agent.go
+++ b/kata_agent.go
@@ -589,6 +589,25 @@ func constraintGRPCSpec(grpcSpec *grpc.Spec) {
 	}
 }
 
+func (k *kataAgent) appendDevices(deviceList []*grpc.Device, devices []Device) []*grpc.Device {
+	for _, device := range devices {
+		d, ok := device.(*BlockDevice)
+		if !ok {
+			continue
+		}
+
+		kataDevice := &grpc.Device{
+			Type:          kataBlkDevType,
+			VmPath:        d.VirtPath,
+			ContainerPath: d.DeviceInfo.ContainerPath,
+		}
+
+		deviceList = append(deviceList, kataDevice)
+	}
+
+	return deviceList
+}
+
 func (k *kataAgent) createContainer(pod *Pod, c *Container) (*Process, error) {
 	ociSpecJSON, ok := c.config.Annotations[vcAnnotations.ConfigJSONKey]
 	if !ok {
@@ -683,22 +702,8 @@ func (k *kataAgent) createContainer(pod *Pod, c *Container) (*Process, error) {
 	// irrelevant information to the agent.
 	constraintGRPCSpec(grpcSpec)
 
-	// Append container mounts for block devices passed with --device.
-	for _, device := range c.devices {
-		d, ok := device.(*BlockDevice)
-
-		if !ok {
-			continue
-		}
-
-		kataDevice := &grpc.Device{
-			Type:          kataBlkDevType,
-			VmPath:        d.VirtPath,
-			ContainerPath: d.DeviceInfo.ContainerPath,
-		}
-
-		ctrDevices = append(ctrDevices, kataDevice)
-	}
+	// Append container devices for block devices passed with --device.
+	ctrDevices = k.appendDevices(ctrDevices, c.devices)
 
 	req := &grpc.CreateContainerRequest{
 		ContainerId: c.id,

--- a/kata_agent.go
+++ b/kata_agent.go
@@ -51,6 +51,7 @@ var (
 	vsockSocketScheme           = "vsock"
 	kata9pDevType               = "9p"
 	kataBlkDevType              = "blk"
+	kataSCSIDevType             = "scsi"
 	sharedDir9pOptions          = []string{"trans=virtio,version=9p2000.L", "nodev"}
 )
 
@@ -598,9 +599,15 @@ func (k *kataAgent) appendDevices(deviceList []*grpc.Device, devices []Device) [
 		}
 
 		kataDevice := &grpc.Device{
-			Type:          kataBlkDevType,
-			VmPath:        d.VirtPath,
 			ContainerPath: d.DeviceInfo.ContainerPath,
+		}
+
+		if d.SCSIAddr == "" {
+			kataDevice.Type = kataBlkDevType
+			kataDevice.VmPath = d.VirtPath
+		} else {
+			kataDevice.Type = kataSCSIDevType
+			kataDevice.Id = d.SCSIAddr
 		}
 
 		deviceList = append(deviceList, kataDevice)
@@ -631,20 +638,30 @@ func (k *kataAgent) createContainer(pod *Pod, c *Container) (*Process, error) {
 
 	if c.state.Fstype != "" {
 		// This is a block based device rootfs.
-		// driveName is the predicted virtio-block guest name (the vd* in /dev/vd*).
-		driveName, err := getVirtDriveName(c.state.BlockIndex)
-		if err != nil {
-			return nil, err
-		}
-		virtPath := filepath.Join(devPath, driveName)
 
-		// Create a new device with empty ContainerPath so that we get
-		// the device being waited for by the agent inside the VM,
-		// without trying to match and update it into the OCI spec list
-		// of actual devices. The device corresponding to the rootfs is
-		// a very specific case.
-		rootfs.Driver = kataBlkDevType
-		rootfs.Source = virtPath
+		// Pass a drive name only in case of virtio-blk driver.
+		// If virtio-scsi driver, the agent will be able to find the
+		// device based on the provided address.
+		if pod.config.HypervisorConfig.BlockDeviceDriver == VirtioBlock {
+			// driveName is the predicted virtio-block guest name (the vd* in /dev/vd*).
+			driveName, err := getVirtDriveName(c.state.BlockIndex)
+			if err != nil {
+				return nil, err
+			}
+			virtPath := filepath.Join(devPath, driveName)
+
+			rootfs.Driver = kataBlkDevType
+			rootfs.Source = virtPath
+		} else {
+			scsiAddr, err := getSCSIAddress(c.state.BlockIndex)
+			if err != nil {
+				return nil, err
+			}
+
+			rootfs.Driver = kataSCSIDevType
+			rootfs.Source = scsiAddr
+		}
+
 		rootfs.MountPoint = rootPathParent
 		rootfs.Fstype = c.state.Fstype
 

--- a/kata_agent.go
+++ b/kata_agent.go
@@ -51,6 +51,7 @@ var (
 	vsockSocketScheme           = "vsock"
 	kata9pDevType               = "9p"
 	kataBlkDevType              = "blk"
+	sharedDir9pOptions          = []string{"trans=virtio,version=9p2000.L", "nodev"}
 )
 
 // KataAgentConfig is a structure storing information needed
@@ -486,7 +487,7 @@ func (k *kataAgent) startPod(pod Pod) error {
 		Source:     mountGuest9pTag,
 		MountPoint: kataGuestSharedDir,
 		Fstype:     type9pFs,
-		Options:    []string{"trans=virtio", "nodev"},
+		Options:    sharedDir9pOptions,
 	}
 
 	req := &grpc.CreateSandboxRequest{


### PR DESCRIPTION
This patch allows to plug block devices to Kata Containers agent,
using virtio-scsi driver. Those devices can be both rootfs or
simple block device passthrough.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>