### PR TITLE
oci: apply CPU share constraint

### DIFF
--- a/container.go
+++ b/container.go
@@ -66,6 +66,9 @@ type ContainerResources struct {
 
 	// CPUPeriod specifies the CPU CFS scheduler period of time in microseconds
 	CPUPeriod uint64
+
+	// CPUShares specifies container's weight vs. other containers
+	CPUShares uint64
 }
 
 // ContainerConfig describes one container runtime configuration.

--- a/hyperstart_agent.go
+++ b/hyperstart_agent.go
@@ -431,6 +431,10 @@ func (h *hyper) startOneContainer(pod Pod, c *Container) error {
 		}
 	}
 
+	if c.config.Resources.CPUShares != 0 {
+		container.Constraints.CPUShares = c.config.Resources.CPUShares
+	}
+
 	container.SystemMountsInfo.BindMountDev = c.systemMountsInfo.BindMountDev
 
 	if c.state.Fstype != "" {

--- a/pkg/hyperstart/types.go
+++ b/pkg/hyperstart/types.go
@@ -210,6 +210,9 @@ type Constraints struct {
 
 	// CPUPeriod specifies the CPU CFS scheduler period of time in microseconds
 	CPUPeriod uint64
+
+	// CPUShares specifies container's weight vs. other containers
+	CPUShares uint64
 }
 
 // Container describes a container running on a pod.

--- a/pkg/oci/utils.go
+++ b/pkg/oci/utils.go
@@ -565,11 +565,15 @@ func ContainerConfig(ocispec CompatOCISpec, bundlePath, cid, console string, det
 	}
 
 	var resources vc.ContainerResources
-	if ocispec.Linux.Resources.CPU != nil &&
-		ocispec.Linux.Resources.CPU.Quota != nil &&
-		ocispec.Linux.Resources.CPU.Period != nil {
-		resources.CPUQuota = *ocispec.Linux.Resources.CPU.Quota
-		resources.CPUPeriod = *ocispec.Linux.Resources.CPU.Period
+	if ocispec.Linux.Resources.CPU != nil {
+		if ocispec.Linux.Resources.CPU.Quota != nil &&
+			ocispec.Linux.Resources.CPU.Period != nil {
+			resources.CPUQuota = *ocispec.Linux.Resources.CPU.Quota
+			resources.CPUPeriod = *ocispec.Linux.Resources.CPU.Period
+		}
+		if ocispec.Linux.Resources.CPU.Shares != nil {
+			resources.CPUShares = *ocispec.Linux.Resources.CPU.Shares
+		}
 	}
 
 	containerConfig := vc.ContainerConfig{


### PR DESCRIPTION
this patch is to apply CPU share constraint to new containers

fixes #669

Signed-off-by: Julio Montes <julio.montes@intel.com>