### PR TITLE
Ignore route with ipv6 gateway

### DIFF
--- a/hyperstart_agent.go
+++ b/hyperstart_agent.go
@@ -143,6 +143,12 @@ func (h *hyper) processHyperRoute(route netlink.Route, deviceName string) *hyper
 	gateway := route.Gw.String()
 	if gateway == "<nil>" {
 		gateway = ""
+	} else if route.Gw.To4() == nil { // Skip IPv6 as it is not supported by hyperstart agent
+		h.Logger().WithFields(logrus.Fields{
+			"unsupported-route-type": "ipv6",
+			"gateway":                gateway,
+		}).Warn("unsupported route")
+		return nil
 	}
 
 	var destination string

--- a/kata_agent.go
+++ b/kata_agent.go
@@ -375,7 +375,17 @@ func (k *kataAgent) generateInterfacesAndRoutes(networkNS NetworkNamespace) ([]*
 			}
 
 			if route.Gw != nil {
-				r.Gateway = route.Gw.String()
+				gateway := route.Gw.String()
+
+				if route.Gw.To4() == nil {
+					// Skip IPv6 because is is not supported
+					k.Logger().WithFields(logrus.Fields{
+						"unsupported-route-type": "ipv6",
+						"gateway":                gateway,
+					}).Warn("unsupported route")
+					continue
+				}
+				r.Gateway = gateway
 			}
 
 			if route.Src != nil {


### PR DESCRIPTION
We ignore routes that have an ipv6 destination, since we do not have support for ipv6 currently. We should do the same for default route that has an ipv6 gateway address.