### PR TITLE
1.0.8 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+1.0.8:
+	Added support for CPU hotplug
+	Added SCSI support for drives and volumes
+	Added networking support for Kata Containers
+	Added block device hotplug support for Kata Containers
+	Added support for starting shim inside their own PID namespace
+
 1.0.7:
 	Added ARM64 support
 	Added Kata Containers support


### PR DESCRIPTION
Added support for CPU hotplug
Added SCSI support for drives and volumes
Added networking support for Kata Containers
Added block device hotplug support for Kata Containers
Added support for starting shim inside their own PID namespace

Shortlog (git log --oneline --no-merges --no-decorate 1.0.7..1724b876):

3878df7 oci: apply CPU share constraint
dba0a6f vendor: update govmm
83c209d qemu: disable modern in SCSI constroller
c3ad9c2 qemu: honor DefaultVCPUs
fef9feb gitignore: Add the test support files dir
12f35ce qemu: enable CPU hotplug
925a70c pod: hot add/remove vCPUs before starting containers
4a84438 qemu: Add support for CPU hot add/remove
8ec5e61 tests: benchmark: update bundles path to local dir
6d75bc5 cni: test: move test base dir to local files
4732b03 utils: Make script install components locally
c17c48d vendor: Constraint containerd vendoring
c9996f3 filesystem: set correct access mode for pod dir tree
4f9cb18 kata_agent: Add nouuid option for xfs filesystem
085848b kata_agent: Provide hotplugged device the right rootfs path
9ef18a6 kata_agent: Update host and guest paths for Kata
2c88b8e kata_agent: Wait for rootfs if it is a hotplugged device
15a4d17 kata_agent: Support block device passthrough
fd5b27f vendor: Update Kata agent protocol
0519e89 check: lint: ineffassign in qemu.go
ae661c5 network: Fix lint errors
5c73774 shim: Start shims inside PID namespace
6d7f6e5 shim: Add ability to enter any set of namespaces
f318b77 shim: Add the ability to spawn the shim in new namespaces
fefb087 pkg: nsenter: Introduce a generic nsenter package
43c05c2 utils: setup: Add some more prereq checks to the setup script.
1a25bad docs: developers: Add some developer docs
43c9ed3 kata-agent: add initial test for kata-agent networking
082ec3f kata-agent: add network gRPC support
4b30262 setup: #!/bin/bash in the wrong place
8b7fddf vendor: re-vendor kata-containers agent
07c2c88 test: Modify block device test to test for SCSI as well
a1a569a scsi: Add SCSI support for volumes as well
3c038f1 scsi: Pass SCSI address to hyperstart agent
80bdc50 tests: Fix tests to take into account default driver for block devices
7df3f45 scsi: Add support for scsi driver for hotplugging drives

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>